### PR TITLE
Proposal: add dial constructors for all chainio structs

### DIFF
--- a/chainio/elcontracts/reader.go
+++ b/chainio/elcontracts/reader.go
@@ -80,6 +80,30 @@ func NewELChainReader(
 	}, nil
 }
 
+// Dial follows the geth constructor name convention, and is a low level contructor that
+// builds a new ELChainReader from config values as opposed to other data types
+func Dial(
+	rpcHttpUrl string,
+	rpcWsUrl string,
+	slasherAddr gethcommon.Address,
+	blsPubKeyCompendiumAddr gethcommon.Address,
+	logger logging.Logger,
+) (*ELChainReader, error) {
+	ethHttpClient, err := eth.NewClient(rpcHttpUrl)
+	if err != nil {
+		panic(err)
+	}
+	ethWsClient, err := eth.NewClient(rpcWsUrl)
+	if err != nil {
+		panic(err)
+	}
+	elContractsClient, err := clients.NewELContractsChainClient(slasherAddr, blsPubKeyCompendiumAddr, ethHttpClient, ethWsClient, logger)
+	if err != nil {
+		panic(err)
+	}
+	return NewELChainReader(elContractsClient, logger, ethHttpClient)
+}
+
 func (r *ELChainReader) IsOperatorRegistered(ctx context.Context, operator types.Operator) (bool, error) {
 	isOperator, err := r.elContractsClient.IsOperator(
 		&bind.CallOpts{},


### PR DESCRIPTION
Been integrating the metrics and nodeapi with eigenDA, and it's a real pain to use our chain readers.
Sometimes I just need a simple chainreader, and I don't want to have to use the entire huge [constructor](https://github.com/Layr-Labs/eigensdk-go/blob/master/chainio/constructor/constructor.go).

Added one example of how we could do this, just to show what I'm thinking.

Wdyt @shrimalmadhur . Should we add these everywhere? I feel like it would be helpful.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->