### PR TITLE
changed prom metrics ipportaddr name

### DIFF
--- a/chainio/constructor/constructor.go
+++ b/chainio/constructor/constructor.go
@@ -25,7 +25,7 @@ type Config struct {
 	BlsRegistryCoordinatorAddr    string `yaml:"bls_registry_coordinator_address"`
 	BlsOperatorStateRetrieverAddr string `yaml:"bls_operator_state_retriever_address"`
 	AvsName                       string `yaml:"avs_name"`
-	IpPortAddress                 string `yaml:"ip_port_address"`
+	PromMetricsIpPortAddress      string `yaml:"prometheus_metrics_ip_port_address"`
 }
 
 type Clients struct {
@@ -44,7 +44,7 @@ func BuildClients(config Config, logger logging.Logger) (*Clients, error) {
 
 	// Create the metrics server
 	reg := prometheus.NewRegistry()
-	eigenMetrics := metrics.NewEigenMetrics(config.AvsName, config.IpPortAddress, reg, logger)
+	eigenMetrics := metrics.NewEigenMetrics(config.AvsName, config.PromMetricsIpPortAddress, reg, logger)
 
 	// creating two types of Eth clients: HTTP and WS
 	ethHttpClient, err := eth.NewClient(config.EthHttpUrl)


### PR DESCRIPTION
Small change. Just found it confusing when creating the constructor config in eigenDA repo.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->