### PR TITLE
fixed registration logic

### DIFF
--- a/chainio/elcontracts/writer.go
+++ b/chainio/elcontracts/writer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
@@ -29,7 +28,6 @@ type ELWriter interface {
 		ctx context.Context,
 		blsKeyPair *bls.KeyPair,
 		operator types.Operator,
-		blsPubkeyCompendiumAddr common.Address,
 	) (*gethtypes.Receipt, error)
 
 	// DepositERC20IntoStrategy deposits ERC20 tokens into a strategy contract.
@@ -178,7 +176,6 @@ func (w *ELChainWriter) RegisterBLSPublicKey(
 	ctx context.Context,
 	blsKeyPair *bls.KeyPair,
 	operator types.Operator,
-	blsPubkeyCompendiumAddr common.Address,
 ) (*gethtypes.Receipt, error) {
 	w.logger.Infof("Registering BLS Public key to eigenlayer for operator %s", operator.Address)
 	txOpts := w.signer.GetTxOpts()
@@ -186,7 +183,7 @@ func (w *ELChainWriter) RegisterBLSPublicKey(
 	if err != nil {
 		return nil, err
 	}
-	signedMsgHash := blsKeyPair.MakePubkeyRegistrationData(gethcommon.HexToAddress(operator.Address), blsPubkeyCompendiumAddr, chainID)
+	signedMsgHash := blsKeyPair.MakePubkeyRegistrationData(gethcommon.HexToAddress(operator.Address), w.elContractsClient.GetBLSPublicKeyCompendiumContractAddress(), chainID)
 	signedMsgHashBN254 := blspubkeycompendium.BN254G1Point(utils.ConvertToBN254G1Point(signedMsgHash))
 	G1pubkeyBN254 := blspubkeycompendium.BN254G1Point(utils.ConvertToBN254G1Point(blsKeyPair.GetPubKeyG1()))
 	G2pubkeyBN254 := blspubkeycompendium.BN254G2Point(utils.ConvertToBN254G2Point(blsKeyPair.GetPubKeyG2()))

--- a/chainio/elcontracts/writer.go
+++ b/chainio/elcontracts/writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
@@ -28,6 +29,7 @@ type ELWriter interface {
 		ctx context.Context,
 		blsKeyPair *bls.KeyPair,
 		operator types.Operator,
+		blsPubkeyCompendiumAddr common.Address,
 	) (*gethtypes.Receipt, error)
 
 	// DepositERC20IntoStrategy deposits ERC20 tokens into a strategy contract.
@@ -176,6 +178,7 @@ func (w *ELChainWriter) RegisterBLSPublicKey(
 	ctx context.Context,
 	blsKeyPair *bls.KeyPair,
 	operator types.Operator,
+	blsPubkeyCompendiumAddr common.Address,
 ) (*gethtypes.Receipt, error) {
 	w.logger.Infof("Registering BLS Public key to eigenlayer for operator %s", operator.Address)
 	txOpts := w.signer.GetTxOpts()
@@ -183,7 +186,7 @@ func (w *ELChainWriter) RegisterBLSPublicKey(
 	if err != nil {
 		return nil, err
 	}
-	signedMsgHash := blsKeyPair.MakePubkeyRegistrationData(gethcommon.HexToAddress(operator.Address), chainID)
+	signedMsgHash := blsKeyPair.MakePubkeyRegistrationData(gethcommon.HexToAddress(operator.Address), blsPubkeyCompendiumAddr, chainID)
 	signedMsgHashBN254 := blspubkeycompendium.BN254G1Point(utils.ConvertToBN254G1Point(signedMsgHash))
 	G1pubkeyBN254 := blspubkeycompendium.BN254G1Point(utils.ConvertToBN254G1Point(blsKeyPair.GetPubKeyG1()))
 	G2pubkeyBN254 := blspubkeycompendium.BN254G2Point(utils.ConvertToBN254G2Point(blsKeyPair.GetPubKeyG2()))

--- a/crypto/bls/attestation.go
+++ b/crypto/bls/attestation.go
@@ -273,6 +273,6 @@ func (k *KeyPair) GetPubKeyG1() *G1Point {
 // public key, and prevents the operator
 // from attacking the signature protocol by registering a public key that is derived from other public keys.
 // (e.g., see https://medium.com/@coolcottontail/rogue-key-attack-in-bls-signature-and-harmony-security-eac1ea2370ee)
-func (k *KeyPair) MakePubkeyRegistrationData(operatorAddress common.Address, chainId *big.Int) *G1Point {
-	return &G1Point{bn254utils.MakePubkeyRegistrationData(k.PrivKey, operatorAddress, chainId)}
+func (k *KeyPair) MakePubkeyRegistrationData(operatorAddress common.Address, blsPubkeyCompendiumAddress common.Address, chainId *big.Int) *G1Point {
+	return &G1Point{bn254utils.MakePubkeyRegistrationData(k.PrivKey, operatorAddress, blsPubkeyCompendiumAddress, chainId)}
 }

--- a/crypto/bn254/utils.go
+++ b/crypto/bn254/utils.go
@@ -146,9 +146,12 @@ func DeserializeG2(b []byte) *bn254.G2Affine {
 	return p
 }
 
-func MakePubkeyRegistrationData(privKey *fr.Element, operatorAddress common.Address, chainId *big.Int) *bn254.G1Affine {
+func MakePubkeyRegistrationData(privKey *fr.Element, operatorAddress common.Address, blsPubkeyCompendiumAddress common.Address, chainId *big.Int) *bn254.G1Affine {
 	toHash := make([]byte, 0)
 	toHash = append(toHash, operatorAddress.Bytes()...)
+	// we also sign on the bls pubkey compendium contract's address, to prevent replay attacks
+	// in different bls pubkey compendiums (in case some teams have deployed their own compendium)
+	toHash = append(toHash, blsPubkeyCompendiumAddress.Bytes()...)
 	// make sure chainId is 32 bytes
 	toHash = append(toHash, common.LeftPadBytes(chainId.Bytes(), 32)...)
 	toHash = append(toHash, []byte("EigenLayer_BN254_Pubkey_Registration")...)


### PR DESCRIPTION
bls pubkey compendium registration logic was changed to also require signing over the bls pubkey compendium's address, so updated the offchain logic to also include this.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->