### PR TITLE
now fetching operatorId dynamically in economicCollector

### DIFF
--- a/chainio/avsregistry/reader.go
+++ b/chainio/avsregistry/reader.go
@@ -91,7 +91,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 		operatorId,
 		blockNumber)
 	if err != nil {
-		r.logger.Error("Failed to get operators state", "err", err)
+		r.logger.Error("Failed to get operators state", "err", err, "fn", "AvsRegistryChainReader.GetOperatorsStakeInQuorumsOfOperatorAtBlock")
 		return nil, nil, err
 	}
 

--- a/chainio/mocks/avsRegistryContractClient.go
+++ b/chainio/mocks/avsRegistryContractClient.go
@@ -9,6 +9,7 @@
 package mocks
 
 import (
+	big "math/big"
 	reflect "reflect"
 
 	contractBLSOperatorStateRetriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/BLSOperatorStateRetriever"
@@ -73,6 +74,21 @@ func (mr *MockAVSRegistryContractsClientMockRecorder) GetCheckSignaturesIndices(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckSignaturesIndices", reflect.TypeOf((*MockAVSRegistryContractsClient)(nil).GetCheckSignaturesIndices), arg0, arg1, arg2, arg3)
 }
 
+// GetCurrentOperatorStakeForQuorum mocks base method.
+func (m *MockAVSRegistryContractsClient) GetCurrentOperatorStakeForQuorum(arg0 *bind.CallOpts, arg1 [32]byte, arg2 byte) (*big.Int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentOperatorStakeForQuorum", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*big.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCurrentOperatorStakeForQuorum indicates an expected call of GetCurrentOperatorStakeForQuorum.
+func (mr *MockAVSRegistryContractsClientMockRecorder) GetCurrentOperatorStakeForQuorum(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentOperatorStakeForQuorum", reflect.TypeOf((*MockAVSRegistryContractsClient)(nil).GetCurrentOperatorStakeForQuorum), arg0, arg1, arg2)
+}
+
 // GetOperatorId mocks base method.
 func (m *MockAVSRegistryContractsClient) GetOperatorId(arg0 *bind.CallOpts, arg1 common.Address) ([32]byte, error) {
 	m.ctrl.T.Helper()
@@ -86,6 +102,21 @@ func (m *MockAVSRegistryContractsClient) GetOperatorId(arg0 *bind.CallOpts, arg1
 func (mr *MockAVSRegistryContractsClientMockRecorder) GetOperatorId(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorId", reflect.TypeOf((*MockAVSRegistryContractsClient)(nil).GetOperatorId), arg0, arg1)
+}
+
+// GetOperatorQuorumsAtCurrentBlock mocks base method.
+func (m *MockAVSRegistryContractsClient) GetOperatorQuorumsAtCurrentBlock(arg0 *bind.CallOpts, arg1 [32]byte) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperatorQuorumsAtCurrentBlock", arg0, arg1)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOperatorQuorumsAtCurrentBlock indicates an expected call of GetOperatorQuorumsAtCurrentBlock.
+func (mr *MockAVSRegistryContractsClientMockRecorder) GetOperatorQuorumsAtCurrentBlock(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorQuorumsAtCurrentBlock", reflect.TypeOf((*MockAVSRegistryContractsClient)(nil).GetOperatorQuorumsAtCurrentBlock), arg0, arg1)
 }
 
 // GetOperatorsStakeInQuorumsAtBlock mocks base method.

--- a/chainio/mocks/avsRegistryContractsReader.go
+++ b/chainio/mocks/avsRegistryContractsReader.go
@@ -10,6 +10,7 @@ package mocks
 
 import (
 	context "context"
+	big "math/big"
 	reflect "reflect"
 
 	contractBLSOperatorStateRetriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/BLSOperatorStateRetriever"
@@ -68,6 +69,21 @@ func (m *MockAvsRegistryReader) GetOperatorId(arg0 context.Context, arg1 common.
 func (mr *MockAvsRegistryReaderMockRecorder) GetOperatorId(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorId", reflect.TypeOf((*MockAvsRegistryReader)(nil).GetOperatorId), arg0, arg1)
+}
+
+// GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock mocks base method.
+func (m *MockAvsRegistryReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(arg0 context.Context, arg1 [32]byte) (map[byte]*big.Int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock", arg0, arg1)
+	ret0, _ := ret[0].(map[byte]*big.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock indicates an expected call of GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock.
+func (mr *MockAvsRegistryReaderMockRecorder) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock", reflect.TypeOf((*MockAvsRegistryReader)(nil).GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock), arg0, arg1)
 }
 
 // GetOperatorsStakeInQuorumsAtBlock mocks base method.

--- a/metrics/collectors/economic/economic.go
+++ b/metrics/collectors/economic/economic.go
@@ -108,7 +108,8 @@ func (ec *Collector) Describe(ch chan<- *prometheus.Desc) {
 	// ch <- ec.delegatedShares
 }
 
-func (ec *Collector) cacheOperatorIdIfNotCached() error {
+// initialize the operatorId if it hasn't already been initialized
+func (ec *Collector) initOperatorId() error {
 	if ec.operatorId == [32]byte{} {
 		operatorId, err := ec.avsRegistryReader.GetOperatorId(context.Background(), ec.operatorAddr)
 		if err != nil {
@@ -141,7 +142,7 @@ func (ec *Collector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	// collect registeredStake metric
-	err = ec.cacheOperatorIdIfNotCached()
+	err = ec.initOperatorId()
 	if err != nil {
 		ec.logger.Error("Failed to fetch and catch operator id. Skipping collection of registeredStake metric.", "err", err)
 	} else {

--- a/metrics/collectors/economic/economic.go
+++ b/metrics/collectors/economic/economic.go
@@ -131,9 +131,10 @@ func (ec *Collector) Collect(ch chan<- prometheus.Metric) {
 	// swap out backend for a subgraph eventually
 	operatorId, err := ec.avsRegistryReader.GetOperatorId(context.Background(), ec.operatorAddr)
 	if err != nil {
+		// we only log and don't return because we might eventually add more metrics below,
+		// and returning early would introduce a bug that we would be skipping those other metrics
 		ec.logger.Error("Failed to get operator id", "err", err)
-	}
-	if operatorId == [32]byte{} {
+	} else if operatorId == [32]byte{} {
 		ec.logger.Warn("Operator is not registered. Skipping registeredStake metric collection.", "fn", "economicCollector.Collect")
 	} else {
 		quorumNums, blsOperatorStateRetrieverOperator, err := ec.avsRegistryReader.GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(context.Background(), operatorId)

--- a/metrics/collectors/economic/economic.go
+++ b/metrics/collectors/economic/economic.go
@@ -112,9 +112,6 @@ func (ec *Collector) cacheOperatorIdIfNotCached() error {
 	if ec.operatorId == [32]byte{} {
 		operatorId, err := ec.avsRegistryReader.GetOperatorId(context.Background(), ec.operatorAddr)
 		if err != nil {
-			// we only log and don't return because we might eventually add more metrics below,
-			// and returning early would introduce a bug that we would be skipping those other metrics
-			ec.logger.Error("Failed to get operator id", "err", err)
 			return err
 		}
 		ec.operatorId = operatorId
@@ -146,6 +143,8 @@ func (ec *Collector) Collect(ch chan<- prometheus.Metric) {
 	// collect registeredStake metric
 	err = ec.cacheOperatorIdIfNotCached()
 	if err != nil {
+		ec.logger.Error("Failed to fetch and catch operator id. Skipping collection of registeredStake metric.", "err", err)
+	} else {
 		// probably should start using the avsregistry service instead of avsRegistryReader so that we can
 		// swap out backend for a subgraph eventually
 		quorumStakeMap, err := ec.avsRegistryReader.GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(context.Background(), ec.operatorId)

--- a/metrics/collectors/economic/economic_test.go
+++ b/metrics/collectors/economic/economic_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestEconomicCollector(t *testing.T) {
 	operatorAddr := common.HexToAddress("0x0")
-	operatorId := types.OperatorId{0}
+	operatorId := types.OperatorId{1}
 	quorumNames := map[types.QuorumNum]string{
 		0: "ethQuorum",
 		1: "someOtherTokenQuorum",

--- a/metrics/collectors/economic/economic_test.go
+++ b/metrics/collectors/economic/economic_test.go
@@ -29,6 +29,7 @@ func TestEconomicCollector(t *testing.T) {
 	ethReader.EXPECT().OperatorIsFrozen(gomock.Any(), operatorAddr).Return(false, nil)
 
 	avsRegistryReader := mocks.NewMockAvsRegistryReader(mockCtrl)
+	avsRegistryReader.EXPECT().GetOperatorId(gomock.Any(), operatorAddr).Return(operatorId, nil)
 	avsRegistryReader.EXPECT().GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(gomock.Any(), gomock.Any()).Return(
 		map[types.QuorumNum]*big.Int{
 			0: big.NewInt(1000),
@@ -36,7 +37,6 @@ func TestEconomicCollector(t *testing.T) {
 		},
 		nil,
 	)
-	avsRegistryReader.EXPECT().GetOperatorId(gomock.Any(), operatorAddr).Return(operatorId, nil)
 
 	logger := logging.NewNoopLogger()
 	economicCollector := NewCollector(ethReader, avsRegistryReader, "testavs", logger, operatorAddr, quorumNames)

--- a/metrics/collectors/economic/economic_test.go
+++ b/metrics/collectors/economic/economic_test.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/mocks"
-	blsoperatorstateretrievar "github.com/Layr-Labs/eigensdk-go/contracts/bindings/BLSOperatorStateRetriever"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/types"
 )
@@ -28,25 +27,12 @@ func TestEconomicCollector(t *testing.T) {
 
 	ethReader := mocks.NewMockELReader(mockCtrl)
 	ethReader.EXPECT().OperatorIsFrozen(gomock.Any(), operatorAddr).Return(false, nil)
-	// ethReader.EXPECT().GetOperatorSharesInStrategy(gomock.Any(), operatorAddr, strategyAddrs[0]).Return(big.NewInt(1000), nil)
-	// ethReader.EXPECT().GetOperatorSharesInStrategy(gomock.Any(), operatorAddr, strategyAddrs[1]).Return(big.NewInt(2000), nil)
 
 	avsRegistryReader := mocks.NewMockAvsRegistryReader(mockCtrl)
-	avsRegistryReader.EXPECT().GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(gomock.Any(), gomock.Any()).Return(
-		[]types.QuorumNum{0, 1},
-		[][]blsoperatorstateretrievar.BLSOperatorStateRetrieverOperator{
-			{
-				{
-					OperatorId: operatorId,
-					Stake:      big.NewInt(1000),
-				},
-			},
-			{
-				{
-					OperatorId: operatorId,
-					Stake:      big.NewInt(2000),
-				},
-			},
+	avsRegistryReader.EXPECT().GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(gomock.Any(), gomock.Any()).Return(
+		map[types.QuorumNum]*big.Int{
+			0: big.NewInt(1000),
+			1: big.NewInt(2000),
 		},
 		nil,
 	)

--- a/services/avsregistry/avsregistry_chaincaller.go
+++ b/services/avsregistry/avsregistry_chaincaller.go
@@ -74,7 +74,7 @@ func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context
 func (ar *AvsRegistryServiceChainCaller) GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error) {
 	operatorsAvsState, err := ar.GetOperatorsAvsStateAtBlock(ctx, quorumNumbers, blockNumber)
 	if err != nil {
-		ar.logger.Error("Failed to get operator state", "err", err, "service", "AvsRegistryServiceChainCaller")
+		ar.logger.Error("Failed to get quorum state", "err", err, "service", "AvsRegistryServiceChainCaller")
 		return nil, err
 	}
 	quorumsAvsState := make(map[types.QuorumNum]types.QuorumAvsState)


### PR DESCRIPTION
### Motivation
eigenDA team was running into errors because the economicCollector was fetching operatorId from the eigenda registry coordinator in its constructor, which is initialized before the node starts. When the operator is registered at node start, it only registers in the start() function, which happens after, so the economicCollector never gets updated with the operatorId and hence keeps erroring on the collect call.

### Solution
This PR moves fetching the operatorId into the collector. This adds 1 round trip latency to the node on every collect (every ~15sec), but at least this will fix this problem. Another solution might be to cache the operatorId after one of the collect calls gets the operatorId, but this *could* break if we later allow the operatorId to change.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->