### PR TITLE
add validation to generates 32 bytes keys

### DIFF
--- a/chainio/elcontracts/writer.go
+++ b/chainio/elcontracts/writer.go
@@ -183,7 +183,11 @@ func (w *ELChainWriter) RegisterBLSPublicKey(
 	if err != nil {
 		return nil, err
 	}
-	signedMsgHash := blsKeyPair.MakePubkeyRegistrationData(gethcommon.HexToAddress(operator.Address), w.elContractsClient.GetBLSPublicKeyCompendiumContractAddress(), chainID)
+	signedMsgHash := blsKeyPair.MakePubkeyRegistrationData(
+		gethcommon.HexToAddress(operator.Address),
+		w.elContractsClient.GetBLSPublicKeyCompendiumContractAddress(),
+		chainID,
+	)
 	signedMsgHashBN254 := blspubkeycompendium.BN254G1Point(utils.ConvertToBN254G1Point(signedMsgHash))
 	G1pubkeyBN254 := blspubkeycompendium.BN254G1Point(utils.ConvertToBN254G1Point(blsKeyPair.GetPubKeyG1()))
 	G2pubkeyBN254 := blspubkeycompendium.BN254G2Point(utils.ConvertToBN254G2Point(blsKeyPair.GetPubKeyG2()))

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -114,6 +115,7 @@ func generate(c *cli.Context) error {
 	} else {
 		return cli.Exit("Invalid key type", 1)
 	}
+	log.Println("Generated all keys")
 
 	return nil
 }
@@ -146,6 +148,9 @@ func generateBlsKeys(numKeys int, path string, passwordFile, privateKeyFile *os.
 		if err != nil {
 			return err
 		}
+		if (i+1)%50 == 0 {
+			log.Printf("Generated %d keys\n", i+1)
+		}
 	}
 	return nil
 }
@@ -162,7 +167,14 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 			return err
 		}
 
-		privateKeyHex := hex.EncodeToString(key.D.Bytes())
+		privateKeyBytes := key.D.Bytes()
+
+		if len(privateKeyBytes) != 32 {
+			log.Println("Private key length is not 32 bytes, skipping this iteration")
+			i--
+			continue
+		}
+		privateKeyHex := hex.EncodeToString(privateKeyBytes)
 		fileName := fmt.Sprintf("%d.ecdsa.key.json", i+1)
 		err = ecdsa.WriteKey(filepath.Clean(path+"/"+DefaultKeyFolder+"/"+fileName), key, password)
 		if err != nil {
@@ -177,6 +189,9 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 		_, err = privateKeyFile.WriteString("0x" + privateKeyHex + "\n")
 		if err != nil {
 			return err
+		}
+		if (i+1)%50 == 0 {
+			log.Printf("Generated %d keys\n", i+1)
 		}
 	}
 	return nil

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -169,6 +169,7 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 
 		privateKeyBytes := key.D.Bytes()
 
+		// We don't want to save the private key if it is not 32 bytes
 		if len(privateKeyBytes) != 32 {
 			log.Println("Private key length is not 32 bytes, skipping this iteration")
 			i--

--- a/crypto/bls/attestation.go
+++ b/crypto/bls/attestation.go
@@ -273,6 +273,12 @@ func (k *KeyPair) GetPubKeyG1() *G1Point {
 // public key, and prevents the operator
 // from attacking the signature protocol by registering a public key that is derived from other public keys.
 // (e.g., see https://medium.com/@coolcottontail/rogue-key-attack-in-bls-signature-and-harmony-security-eac1ea2370ee)
-func (k *KeyPair) MakePubkeyRegistrationData(operatorAddress common.Address, blsPubkeyCompendiumAddress common.Address, chainId *big.Int) *G1Point {
-	return &G1Point{bn254utils.MakePubkeyRegistrationData(k.PrivKey, operatorAddress, blsPubkeyCompendiumAddress, chainId)}
+func (k *KeyPair) MakePubkeyRegistrationData(
+	operatorAddress common.Address,
+	blsPubkeyCompendiumAddress common.Address,
+	chainId *big.Int,
+) *G1Point {
+	return &G1Point{
+		bn254utils.MakePubkeyRegistrationData(k.PrivKey, operatorAddress, blsPubkeyCompendiumAddress, chainId),
+	}
 }

--- a/crypto/bn254/utils.go
+++ b/crypto/bn254/utils.go
@@ -146,7 +146,12 @@ func DeserializeG2(b []byte) *bn254.G2Affine {
 	return p
 }
 
-func MakePubkeyRegistrationData(privKey *fr.Element, operatorAddress common.Address, blsPubkeyCompendiumAddress common.Address, chainId *big.Int) *bn254.G1Affine {
+func MakePubkeyRegistrationData(
+	privKey *fr.Element,
+	operatorAddress common.Address,
+	blsPubkeyCompendiumAddress common.Address,
+	chainId *big.Int,
+) *bn254.G1Affine {
 	toHash := make([]byte, 0)
 	toHash = append(toHash, operatorAddress.Bytes()...)
 	// we also sign on the bls pubkey compendium contract's address, to prevent replay attacks


### PR DESCRIPTION
Fixes #58

### Motivation
`crypto.GenerateKey()` randomly generate 31 bytes private keys.  go-ethereum doesn't like that so we are adding validations for that.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->