### PR TITLE
[EgnKey] Generate ECDSA and BLS keys with both-key-type

### DIFF
--- a/cmd/egnkey/README.md
+++ b/cmd/egnkey/README.md
@@ -27,3 +27,8 @@ To create  in specific folder
 ```bash
    egnkey generate --key-type ecdsa --num-keys <num_key> --output-dir <path_to_folder>
 ```
+
+To create `ECDSA` and `BLS` keys in a random folder
+```bash
+   egnkey generate --key-type both --num-keys <num_key>
+```

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -222,6 +222,7 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 		key, err := crypto.GenerateKey()
 		privateKeyHex := hex.EncodeToString(key.D.Bytes())
 
+		// Low tech fix for creating valid keys, probably better is validation code
 		// Checking if the length of privateKeyHex is 32 bytes (64 characters)
 		for {
 			if len(privateKeyHex) != 64 {

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -222,8 +222,8 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 		key, err := crypto.GenerateKey()
 		privateKeyHex := hex.EncodeToString(key.D.Bytes())
 
-		// Low tech fix for creating valid keys, probably better is validation code
-		// Checking if the length of privateKeyHex is 32 bytes (64 characters)
+		// Check if the length of privateKeyHex is 32 bytes (64 characters)
+		// Validation in Library will handle this
 		lenPrivateKey := len(privateKeyHex)
 		if lenPrivateKey != 64 {
 			fmt.Printf("Private key Ignore: %s %d\n", privateKeyHex, lenPrivateKey)

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -224,13 +224,10 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 
 		// Low tech fix for creating valid keys, probably better is validation code
 		// Checking if the length of privateKeyHex is 32 bytes (64 characters)
-		for {
-			if len(privateKeyHex) != 64 {
-				key, err = crypto.GenerateKey()
-				privateKeyHex = hex.EncodeToString(key.D.Bytes())
-			} else {
-				break
-			}
+		lenPrivateKey := len(privateKeyHex)
+		if lenPrivateKey != 64 {
+			fmt.Printf("Private key Ignore: %s %d\n", privateKeyHex, lenPrivateKey)
+			continue
 		}
 
 		if err != nil {

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -65,7 +65,7 @@ It creates the following artifacts based on arguments
 
 func generate(c *cli.Context) error {
 	keyType := c.String(KeyTypeFlag.Name)
-	if keyType != "ecdsa" && keyType != "bls" {
+	if keyType != "ecdsa" && keyType != "bls" && keyType != "both" {
 		return cli.Exit("Invalid key type", 1)
 	}
 	numKeys := c.Int(NumKeysFlag.Name)
@@ -73,49 +73,116 @@ func generate(c *cli.Context) error {
 		return cli.Exit("Invalid number of keys", 1)
 	}
 
-	folder := c.String(OutputDirFlag.Name)
-	if folder == "" {
-		id, err := uuid.NewUUID()
-		if err != nil {
-			return cli.Exit("Failed to generate UUID", 1)
-		}
-		folder = id.String()
-	}
-
-	_, err := os.Stat(folder)
-	if !os.IsNotExist(err) {
-		return cli.Exit("Folder already exists, choose a different folder or delete the existing folder", 1)
-	}
-
-	err = os.MkdirAll(folder+"/"+DefaultKeyFolder, 0755)
-	if err != nil {
-		return err
-	}
-
-	passwordFile, err := os.Create(filepath.Clean(folder + "/" + PasswordFile))
-	if err != nil {
-		return err
-	}
-	privateKeyFile, err := os.Create(filepath.Clean(folder + "/" + PrivateKeyHexFile))
-	if err != nil {
-		return err
-	}
-
+	// TODO: This can be improved further with a factory pattern
 	if keyType == "ecdsa" {
-		err := generateECDSAKeys(numKeys, folder, passwordFile, privateKeyFile)
+
+		folder, err := createDir(c, "ecdsa-")
 		if err != nil {
 			return err
 		}
+
+		passwordFile, privateKeyFile, err := createPasswordAndPrivateKeyFiles(folder)
+
+		if err != nil {
+			return err
+		}
+
+		err = generateECDSAKeys(numKeys, folder, passwordFile, privateKeyFile)
+		if err != nil {
+			return err
+		}
+
 	} else if keyType == "bls" {
-		err := generateBlsKeys(numKeys, folder, passwordFile, privateKeyFile)
+
+		folder, err := createDir(c, "bls-")
 		if err != nil {
 			return err
 		}
+
+		passwordFile, privateKeyFile, err := createPasswordAndPrivateKeyFiles(folder)
+
+		if err != nil {
+			return err
+		}
+
+		err = generateBlsKeys(numKeys, folder, passwordFile, privateKeyFile)
+		if err != nil {
+			return err
+		}
+	} else if keyType == "both" {
+
+		ecdsaFolder, err := createDir(c, "ecdsa-")
+		if err != nil {
+			return err
+		}
+
+		ecdsaPasswordFile, ecdsaPrivateKeyFile, err := createPasswordAndPrivateKeyFiles(ecdsaFolder)
+
+		if err != nil {
+			return err
+		}
+
+		err = generateECDSAKeys(numKeys, ecdsaFolder, ecdsaPasswordFile, ecdsaPrivateKeyFile)
+		if err != nil {
+			return err
+		}
+
+		blsFolder, err := createDir(c, "bls-")
+		if err != nil {
+			return err
+		}
+
+		blsPasswordFile, blsPrivateKeyFile, err := createPasswordAndPrivateKeyFiles(blsFolder)
+
+		if err != nil {
+			return err
+		}
+
+		err = generateBlsKeys(numKeys, blsFolder, blsPasswordFile, blsPrivateKeyFile)
+		if err != nil {
+			return err
+		}
+
 	} else {
 		return cli.Exit("Invalid key type", 1)
 	}
 
 	return nil
+}
+
+func createDir(c *cli.Context, prefix string) (fileName string, err error) {
+	folder := c.String(OutputDirFlag.Name)
+	if folder == "" {
+		id, err := uuid.NewUUID()
+		if err != nil {
+			return "", err
+		}
+		folder = prefix + id.String()
+	}
+
+	_, err = os.Stat(folder)
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	err = os.MkdirAll(folder+"/"+DefaultKeyFolder, 0755)
+	if err != nil {
+		return "", err
+	}
+	return folder, nil
+}
+
+func createPasswordAndPrivateKeyFiles(folder string) (passwordFile, privateKeyFile *os.File, err error) {
+
+	passwordFile, err = os.Create(filepath.Clean(folder + "/" + PasswordFile))
+	if err != nil {
+		return nil, nil, err
+	}
+	privateKeyFile, err = os.Create(filepath.Clean(folder + "/" + PrivateKeyHexFile))
+	if err != nil {
+		return nil, nil, err
+	}
+	return passwordFile, privateKeyFile, nil
 }
 
 func generateBlsKeys(numKeys int, path string, passwordFile, privateKeyFile *os.File) error {
@@ -153,6 +220,18 @@ func generateBlsKeys(numKeys int, path string, passwordFile, privateKeyFile *os.
 func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *os.File) error {
 	for i := 0; i < numKeys; i++ {
 		key, err := crypto.GenerateKey()
+		privateKeyHex := hex.EncodeToString(key.D.Bytes())
+
+		// Checking if the length of privateKeyHex is 32 bytes (64 characters)
+		for {
+			if len(privateKeyHex) != 64 {
+				key, err = crypto.GenerateKey()
+				privateKeyHex = hex.EncodeToString(key.D.Bytes())
+			} else {
+				break
+			}
+		}
+
 		if err != nil {
 			return err
 		}
@@ -162,7 +241,6 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 			return err
 		}
 
-		privateKeyHex := hex.EncodeToString(key.D.Bytes())
 		fileName := fmt.Sprintf("%d.ecdsa.key.json", i+1)
 		err = ecdsa.WriteKey(filepath.Clean(path+"/"+DefaultKeyFolder+"/"+fileName), key, password)
 		if err != nil {

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -213,6 +213,10 @@ func generateBlsKeys(numKeys int, path string, passwordFile, privateKeyFile *os.
 		if err != nil {
 			return err
 		}
+
+		if (i+1)%50 == 0 {
+			fmt.Printf("Generated %d keys\n", i+1)
+		}
 	}
 	return nil
 }
@@ -227,6 +231,8 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 		lenPrivateKey := len(privateKeyHex)
 		if lenPrivateKey != 64 {
 			fmt.Printf("Private key Ignore: %s %d\n", privateKeyHex, lenPrivateKey)
+			// Reset count
+			i--
 			continue
 		}
 
@@ -253,6 +259,10 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 		_, err = privateKeyFile.WriteString("0x" + privateKeyHex + "\n")
 		if err != nil {
 			return err
+		}
+
+		if (i+1)%50 == 0 {
+			fmt.Printf("Generated %d keys\n", i+1)
 		}
 	}
 	return nil

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -165,7 +165,10 @@ func createDir(c *cli.Context, prefix string) (fileName string, err error) {
 		return "", err
 	}
 
-	err = os.MkdirAll(folder+"/"+DefaultKeyFolder, 0755)
+	// Clean the path
+	cleanFilePath := filepath.Clean(folder + "/" + DefaultKeyFolder)
+
+	err = os.MkdirAll(cleanFilePath, 0755)
 	if err != nil {
 		return "", err
 	}
@@ -227,7 +230,6 @@ func generateECDSAKeys(numKeys int, path string, passwordFile, privateKeyFile *o
 		privateKeyHex := hex.EncodeToString(key.D.Bytes())
 
 		// Check if the length of privateKeyHex is 32 bytes (64 characters)
-		// Validation in Library will handle this
 		lenPrivateKey := len(privateKeyHex)
 		if lenPrivateKey != 64 {
 			fmt.Printf("Private key Ignore: %s %d\n", privateKeyHex, lenPrivateKey)


### PR DESCRIPTION
Fixes # .

### Motivation
1. Create ECDSA and BLS keys using both key-type 
2. Prefix UUID folder name with ecdsa- and bls- to know the dir type

### Solution
1. Move some methods to common
2. Add key-type both