### PR TITLE
update metadata to only allow png images

### DIFF
--- a/types/operator_metadata.go
+++ b/types/operator_metadata.go
@@ -111,7 +111,10 @@ func isImageURL(urlString string) bool {
 	extension := filepath.Ext(path)
 
 	// List of common image file extensions
-	imageExtensions := []string{".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp"}
+	// Only support PNG for now to reduce surface are of image validation
+	// We do NOT want to support formats like SVG since they can be used for javascript injection
+	// If we get pushback on supporting jpg, jpeg, gif, etc. we can add them later
+	imageExtensions := []string{".png"}
 
 	// Check if the extension is in the list of image extensions
 	for _, imgExt := range imageExtensions {

--- a/types/operator_metadata.go
+++ b/types/operator_metadata.go
@@ -111,9 +111,9 @@ func isImageURL(urlString string) bool {
 	extension := filepath.Ext(path)
 
 	// List of common image file extensions
-	// Only support PNG for now to reduce surface are of image validation
+	// Only support PNG for now to reduce surface area of image validation
 	// We do NOT want to support formats like SVG since they can be used for javascript injection
-	// If we get pushback on only supporting png, we can  jpg, jpeg, gif, etc. later
+	// If we get pushback on only supporting png, we can support jpg, jpeg, gif, etc. later
 	imageExtensions := []string{".png"}
 
 	// Check if the extension is in the list of image extensions

--- a/types/operator_metadata.go
+++ b/types/operator_metadata.go
@@ -113,7 +113,7 @@ func isImageURL(urlString string) bool {
 	// List of common image file extensions
 	// Only support PNG for now to reduce surface are of image validation
 	// We do NOT want to support formats like SVG since they can be used for javascript injection
-	// If we get pushback on supporting jpg, jpeg, gif, etc. we can add them later
+	// If we get pushback on only supporting png, we can  jpg, jpeg, gif, etc. later
 	imageExtensions := []string{".png"}
 
 	// Check if the extension is in the list of image extensions

--- a/types/operator_metadata_test.go
+++ b/types/operator_metadata_test.go
@@ -42,6 +42,17 @@ func TestOperatorMetadata(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Invalid metadata - wrong image format",
+			metadata: OperatorMetadata{
+				Name:        "test",
+				Description: "My operator",
+				Logo:        "https://test.com/test.svg",
+				Twitter:     "https://twitter.com/test",
+				Website:     "https://test.com",
+			},
+			wantErr: true,
+		},
+		{
 			name: "Invalid metadata - description > 500 characters",
 			metadata: OperatorMetadata{
 				Name:        "test",


### PR DESCRIPTION
Fixes # .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

We only want to allow `png` image upload to reduce surface are of image validation. IF we need other image format like jpg/jpeg, we can add that later.

### Solution
- Update validation
- Add tests

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->