### PR TITLE
validate bls key file contents

### DIFF
--- a/crypto/bls/attestation.go
+++ b/crypto/bls/attestation.go
@@ -249,7 +249,7 @@ func ReadPrivateKeyFromFile(path string, password string) (*KeyPair, error) {
 	// This is to prevent and make sure pubkey is present.
 	// ecdsa keys doesn't have that field
 	if encryptedBLSStruct.PubKey == "" {
-		return nil, fmt.Errorf("invalid bls key file. pubkey not found")
+		return nil, fmt.Errorf("invalid bls key file. pubkey field not found")
 	}
 
 	skBytes, err := keystore.DecryptDataV3(encryptedBLSStruct.Crypto, password)

--- a/crypto/bls/attestation.go
+++ b/crypto/bls/attestation.go
@@ -243,6 +243,15 @@ func ReadPrivateKeyFromFile(path string, password string) (*KeyPair, error) {
 		return nil, err
 	}
 
+	// Check if pubkey is present, if not return error
+	// There is an issue where if you specify ecdsa key file
+	// it still works and returns a keypair since the format of storage is same.
+	// This is to prevent and make sure pubkey is present.
+	// ecdsa keys doesn't have that field
+	if encryptedBLSStruct.PubKey == "" {
+		return nil, fmt.Errorf("invalid bls key file. pubkey not found")
+	}
+
 	skBytes, err := keystore.DecryptDataV3(encryptedBLSStruct.Crypto, password)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes # .

### Motivation
Right now if you put ecdsa key file in place of bls key, it creates a new pair and carries on

### Solution
We want to put validation so that correct file is used for creating correct key. I am not sure if there's a better way to validate bls key file content which we generate.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->