### PR TITLE
#42: refactor types and utils

### DIFF
--- a/chainio/clients/avs_registry_contracts_client.go
+++ b/chainio/clients/avs_registry_contracts_client.go
@@ -7,6 +7,7 @@ import (
 	regcoord "github.com/Layr-Labs/eigensdk-go/contracts/bindings/BLSRegistryCoordinatorWithIndices"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/types"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -159,7 +160,7 @@ func (a *AvsRegistryContractsChainClient) GetOperatorQuorumsAtCurrentBlock(
 	if err != nil {
 		return nil, err
 	}
-	quorums := types.BitmapToQuorumIds(quorumBitmap)
+	quorums := bitmapToQuorumIds(quorumBitmap)
 	return quorums, nil
 }
 
@@ -177,7 +178,7 @@ func (a *AvsRegistryContractsChainClient) GetOperatorsStakeInQuorumsOfOperatorAt
 	if err != nil {
 		return nil, nil, err
 	}
-	quorums := types.BitmapToQuorumIds(quorumBitmap)
+	quorums := bitmapToQuorumIds(quorumBitmap)
 	return quorums, blsOperatorStateRetrieverOperator, nil
 }
 
@@ -216,4 +217,15 @@ func (a *AvsRegistryContractsChainClient) DeregisterOperator(
 		operator,
 		quorumNumbers,
 		pubkey)
+}
+
+func bitmapToQuorumIds(bitmap *big.Int) []types.QuorumNum {
+	// loop through each index in the bitmap to construct the array
+	quorumIds := make([]types.QuorumNum, 0, types.MaxNumberOfQuorums)
+	for i := 0; i < types.MaxNumberOfQuorums; i++ {
+		if bitmap.Bit(i) == 1 {
+			quorumIds = append(quorumIds, types.QuorumNum(i))
+		}
+	}
+	return quorumIds
 }

--- a/types/common.go
+++ b/types/common.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"errors"
+	"net/url"
+	"regexp"
+)
+
+func isValidEthereumAddress(address string) bool {
+	re := regexp.MustCompile("^0x[0-9a-fA-F]{40}$")
+	return re.MatchString(address)
+}
+
+func checkIfUrlIsValid(rawUrl string) error {
+	// Regular expression to validate URLs
+	urlPattern := regexp.MustCompile(`^(https?|ftp)://[^\s/$.?#].[^\s]*$`)
+
+	// Check if the URL matches the regular expression
+	if !urlPattern.MatchString(rawUrl) {
+		return errors.New("invalid url")
+	}
+
+	parsedURL, err := url.Parse(rawUrl)
+	if err != nil {
+		return err
+	}
+
+	// Check if the URL is valid
+	if parsedURL.Scheme != "" && parsedURL.Host != "" {
+		return nil
+	} else {
+		return errors.New("invalid url")
+	}
+}

--- a/types/constants.go
+++ b/types/constants.go
@@ -1,3 +1,6 @@
 package types
 
-const EigenPromNamespace = "eigen"
+const (
+	EigenPromNamespace = "eigen"
+	MaxNumberOfQuorums = 192
+)

--- a/types/operator.go
+++ b/types/operator.go
@@ -8,9 +8,9 @@ import (
 	"math/big"
 	"net/http"
 
-	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
-	"github.com/Layr-Labs/eigensdk-go/utils"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 )
 
 const (
@@ -32,15 +32,15 @@ type Operator struct {
 }
 
 func (o Operator) Validate() error {
-	if !utils.IsValidEthereumAddress(o.Address) {
+	if !isValidEthereumAddress(o.Address) {
 		return errors.New("invalid operator address")
 	}
 
-	if !utils.IsValidEthereumAddress(o.EarningsReceiverAddress) {
+	if !isValidEthereumAddress(o.EarningsReceiverAddress) {
 		return errors.New("invalid EarningsReceiverAddress address")
 	}
 
-	if o.DelegationApproverAddress != ZeroAddress && !utils.IsValidEthereumAddress(o.DelegationApproverAddress) {
+	if o.DelegationApproverAddress != ZeroAddress && !isValidEthereumAddress(o.DelegationApproverAddress) {
 		return fmt.Errorf(
 			"invalid DelegationApproverAddress address, it should be either %s or a valid non zero ethereum address",
 			ZeroAddress,
@@ -106,21 +106,6 @@ type OperatorAvsState struct {
 	// Stake of the operator for each quorum
 	StakePerQuorum map[QuorumNum]StakeAmount
 	BlockNumber    BlockNum
-}
-
-var (
-	maxNumberOfQuorums = 192
-)
-
-func BitmapToQuorumIds(bitmap *big.Int) []QuorumNum {
-	// loop through each index in the bitmap to construct the array
-	quorumIds := make([]QuorumNum, 0, maxNumberOfQuorums)
-	for i := 0; i < maxNumberOfQuorums; i++ {
-		if bitmap.Bit(i) == 1 {
-			quorumIds = append(quorumIds, QuorumNum(i))
-		}
-	}
-	return quorumIds
 }
 
 type QuorumAvsState struct {

--- a/types/operator_metadata.go
+++ b/types/operator_metadata.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
@@ -73,28 +72,6 @@ func (om *OperatorMetadata) Validate() error {
 	}
 
 	return nil
-}
-
-func checkIfUrlIsValid(rawUrl string) error {
-	// Regular expression to validate URLs
-	urlPattern := regexp.MustCompile(`^(https?|ftp)://[^\s/$.?#].[^\s]*$`)
-
-	// Check if the URL matches the regular expression
-	if !urlPattern.MatchString(rawUrl) {
-		return errors.New("invalid url")
-	}
-
-	parsedURL, err := url.Parse(rawUrl)
-	if err != nil {
-		return err
-	}
-
-	// Check if the URL is valid
-	if parsedURL.Scheme != "" && parsedURL.Host != "" {
-		return nil
-	} else {
-		return errors.New("invalid url")
-	}
 }
 
 func isImageURL(urlString string) bool {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,57 +2,11 @@ package utils
 
 import (
 	"crypto/ecdsa"
-	"encoding/json"
 	"errors"
-	"log"
-	"math/big"
-	"os"
-	"path/filepath"
-	"regexp"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"gopkg.in/yaml.v3"
+	"math/big"
 )
-
-func ReadFile(path string) ([]byte, error) {
-	b, err := os.ReadFile(filepath.Clean(path))
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
-}
-
-func ReadYamlConfig(path string, o interface{}) error {
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		log.Fatal("Path ", path, " does not exist")
-	}
-	b, err := ReadFile(path)
-	if err != nil {
-		return err
-	}
-
-	err = yaml.Unmarshal(b, o)
-	if err != nil {
-		log.Fatalf("unable to parse file with error %#v", err)
-	}
-
-	return nil
-}
-
-func ReadJsonConfig(path string, o interface{}) error {
-	b, err := ReadFile(path)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(b, o)
-	if err != nil {
-		log.Fatalf("unable to parse file with error %#v", err)
-	}
-
-	return nil
-}
 
 func EcdsaPrivateKeyToAddress(privateKey *ecdsa.PrivateKey) (gethcommon.Address, error) {
 	publicKey := privateKey.Public()
@@ -70,9 +24,4 @@ func RoundUpDivideBig(a, b *big.Int) *big.Int {
 	a.Sub(a, one)
 	res.Div(a, b)
 	return res
-}
-
-func IsValidEthereumAddress(address string) bool {
-	re := regexp.MustCompile("^0x[0-9a-fA-F]{40}$")
-	return re.MatchString(address)
 }


### PR DESCRIPTION
Fixes #42 .

### Motivation
Clean up `utils` and `types` modules.

### Solution
Moved type validations out of utils. Typecasting is moved to the service itself.

### Open questions
Right now the `types` module imports the crypto module which should not be the case. Certain types defined in crypto modules are used across other modules of the same hierarchy. Should I accommodate this in the same PR?