### PR TITLE
Fix isOperatorRegistered

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -360,13 +360,14 @@ func (r *AvsRegistryChainReader) IsOperatorRegistered(
 	opts *bind.CallOpts,
 	operatorAddress gethcommon.Address,
 ) (bool, error) {
-	operatorId, err := r.registryCoordinator.GetOperatorId(opts, operatorAddress)
+	operatorStatus, err := r.registryCoordinator.GetOperatorStatus(opts, operatorAddress)
 	if err != nil {
-		r.logger.Error("Cannot get operator id", "err", err)
+		r.logger.Error("Cannot get operator status", "err", err)
 		return false, err
 	}
-	// OperatorId is set in contract during registration, so if it is not set, the operator is not registered
-	registeredWithAvs := operatorId != [32]byte{}
+
+	// 0 = NEVER_REGISTERED, 1 = REGISTERED, 2 = DEREGISTERED
+	registeredWithAvs := operatorStatus == 1
 	return registeredWithAvs, nil
 }
 


### PR DESCRIPTION
### Motivation

- `isOperatorRegistered()` was using the operator ID to determine if an operator is registered
- This was an issue because after an operator de-registers from an AVS, their operator info and ID is not removed from the registry coordinator so `isOperatorRegistered()` was still returning `true`

### Solution
- Fixes `isOperatorRegistered()` so it uses operator status instead of operator ID to determine if an operator is registered

### Testing
Tested this with the CLI in `incredible-squaring-avs` and verified that we're getting the correct value now for `registeredWithAvs`.