### PR TITLE
we were printing tx hash of half-built transactions, which was pointless

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/types"
+	sdkutils "github.com/Layr-Labs/eigensdk-go/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -255,8 +256,7 @@ func (w *AvsRegistryChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordina
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Infof("tx hash: %s", tx.Hash().String())
-	w.logger.Info("registered operator with the AVS's registry coordinator")
+	w.logger.Info("succesfully registered operator with AVS registry coordinator", "tx hash", receipt.TxHash.String())
 	return receipt, nil
 }
 
@@ -265,7 +265,7 @@ func (w *AvsRegistryChainWriter) UpdateStakesOfEntireOperatorSetForQuorums(
 	operatorsPerQuorum [][]gethcommon.Address,
 	quorumNumbers []byte,
 ) (*gethtypes.Receipt, error) {
-	w.logger.Info("updating stakes for entire operator set", "quorumNumbers", quorumNumbers)
+	w.logger.Info("updating stakes for entire operator set", "quorumNumbers", sdkutils.ConvertQuorumsBytesToInts(quorumNumbers))
 	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
 	if err != nil {
 		return nil, err
@@ -278,8 +278,7 @@ func (w *AvsRegistryChainWriter) UpdateStakesOfEntireOperatorSetForQuorums(
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Infof("tx hash: %s", tx.Hash().String())
-	w.logger.Info("updated stakes for entire operator set", "quorumNumbers", quorumNumbers)
+	w.logger.Info("succesfully updated stakes for entire operator set", "tx hash", receipt.TxHash.String(), "quorumNumbers", sdkutils.ConvertQuorumsBytesToInts(quorumNumbers))
 	return receipt, nil
 
 }
@@ -301,8 +300,7 @@ func (w *AvsRegistryChainWriter) UpdateStakesOfOperatorSubsetForAllQuorums(
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Infof("tx hash: %s", tx.Hash().String())
-	w.logger.Info("updated stakes of operator subset for all quorums", "operators", operators)
+	w.logger.Info("succesfully updated stakes of operator subset for all quorums", "tx hash", receipt.TxHash.String(), "operators", operators)
 	return receipt, nil
 
 }
@@ -325,7 +323,6 @@ func (w *AvsRegistryChainWriter) DeregisterOperator(
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Infof("tx hash: %s", tx.Hash().String())
-	w.logger.Info("deregistered operator with the AVS's registry coordinator")
+	w.logger.Info("succesfully deregistered operator with the AVS's registry coordinator", "tx hash", receipt.TxHash.String())
 	return receipt, nil
 }

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -130,7 +130,7 @@ func (w *ELChainWriter) RegisterAsOperator(ctx context.Context, operator types.O
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Infof("tx hash: %s", tx.Hash().String())
+	w.logger.Info("tx succesfully included", "tx hash", receipt.TxHash.String())
 
 	return receipt, nil
 }
@@ -156,24 +156,21 @@ func (w *ELChainWriter) UpdateOperatorDetails(
 	if err != nil {
 		return nil, err
 	}
-	_, err = w.txMgr.Send(ctx, tx)
+	receipt, err := w.txMgr.Send(ctx, tx)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Infof("tx hash: %s", tx.Hash().String())
-	w.logger.Infof("updated operator metadata URI for operator %s to EigenLayer", operator.Address)
+	w.logger.Info("succesfully updated operator metadata URI", "tx hash", receipt.TxHash.String(), "operator", operator.Address)
 
 	tx, err = w.delegationManager.UpdateOperatorMetadataURI(noSendTxOpts, operator.MetadataUrl)
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx)
+	receipt, err = w.txMgr.Send(ctx, tx)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Infof("tx hash: %s", tx.Hash().String())
-
-	w.logger.Infof("updated operator details of operator %s to EigenLayer", operator.Address)
+	w.logger.Info("succesfully updated operator details", "tx hash", receipt.TxHash.String(), "operator", operator.Address)
 	return receipt, nil
 }
 

--- a/signer/basic_signer.go
+++ b/signer/basic_signer.go
@@ -9,8 +9,8 @@ import (
 
 	sdkethclient "github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	"github.com/Layr-Labs/eigensdk-go/logging"
-	"github.com/Layr-Labs/eigensdk-go/utils"
 	"github.com/Layr-Labs/eigensdk-go/types"
+	"github.com/Layr-Labs/eigensdk-go/utils"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -165,7 +165,7 @@ func (s *BasicSigner) EnsureTransactionEvaled(tx *gethtypes.Transaction, tag str
 		return nil, fmt.Errorf("Transaction failed (tag: %v, txHash: %v, status: %v, gasUsed: %v)", tag, tx.Hash().Hex(), receipt.Status, receipt.GasUsed)
 	}
 	s.logger.Debug("successfully submitted transaction",
-		"txHash", tx.Hash().Hex(),
+		"txHash", receipt.TxHash.Hex(),
 		"tag", tag,
 		"gasUsed", receipt.GasUsed,
 	)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -76,3 +76,11 @@ func IsValidEthereumAddress(address string) bool {
 	re := regexp.MustCompile("^0x[0-9a-fA-F]{40}$")
 	return re.MatchString(address)
 }
+
+func ConvertQuorumsBytesToInts(quorums []byte) []int {
+	var quorumsInts []int
+	for _, quorum := range quorums {
+		quorumsInts = append(quorumsInts, int(quorum))
+	}
+	return quorumsInts
+}


### PR DESCRIPTION
Here's an example output from running avs-sync
![image](https://github.com/Layr-Labs/eigensdk-go/assets/9342524/c84a1aff-f005-4668-850e-0a38b7fd297b)
Funnily enough, neither of the two txHash printed is the correct one, which was extremely confusing haha.

Changed it so that everywhere we only print txHash of txs that are successfully included in the chain.