### PR TITLE
added error logs for avs reader/writer clients

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -120,26 +120,26 @@ func BuildAvsRegistryChainReader(
 ) (*AvsRegistryChainReader, error) {
 	contractRegistryCoordinator, err := regcoord.NewContractRegistryCoordinator(registryCoordinatorAddr, ethClient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create contractRegistryCoordinator"), err)
+		return nil, types.WrapError(errors.New("Failed to create contractRegistryCoordinator"), err)
 	}
 	blsApkRegistryAddr, err := contractRegistryCoordinator.BlsApkRegistry(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get blsApkRegistryAddr"), err)
+		return nil, types.WrapError(errors.New("Failed to get blsApkRegistryAddr"), err)
 	}
 	stakeRegistryAddr, err := contractRegistryCoordinator.StakeRegistry(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get stakeRegistryAddr"), err)
+		return nil, types.WrapError(errors.New("Failed to get stakeRegistryAddr"), err)
 	}
 	contractStakeRegistry, err := stakeregistry.NewContractStakeRegistry(stakeRegistryAddr, ethClient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create contractStakeRegistry"), err)
+		return nil, types.WrapError(errors.New("Failed to create contractStakeRegistry"), err)
 	}
 	contractOperatorStateRetriever, err := contractOperatorStateRetriever.NewContractOperatorStateRetriever(
 		operatorStateRetrieverAddr,
 		ethClient,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create contractOperatorStateRetriever"), err)
+		return nil, types.WrapError(errors.New("Failed to create contractOperatorStateRetriever"), err)
 	}
 	return NewAvsRegistryChainReader(
 		registryCoordinatorAddr,
@@ -165,10 +165,10 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtCurrentBlock(
 	}
 	curBlock, err := r.ethClient.BlockNumber(opts.Context)
 	if err != nil {
-		return nil, errors.Join(errors.New("Cannot get current block number"), err)
+		return nil, types.WrapError(errors.New("Cannot get current block number"), err)
 	}
 	if curBlock > math.MaxUint32 {
-		return nil, errors.Join(errors.New("Current block number is too large to be converted to uint32"), err)
+		return nil, types.WrapError(errors.New("Current block number is too large to be converted to uint32"), err)
 	}
 	return r.GetOperatorsStakeInQuorumsAtBlock(opts, quorumNumbers, uint32(curBlock))
 }
@@ -186,7 +186,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtBlock(
 		quorumNumbers,
 		blockNumber)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get operators state"), err)
+		return nil, types.WrapError(errors.New("Failed to get operators state"), err)
 	}
 	return operatorStakes, nil
 }
@@ -200,10 +200,10 @@ func (r *AvsRegistryChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 	}
 	curBlock, err := r.ethClient.BlockNumber(opts.Context)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get current block number"), err)
+		return nil, types.WrapError(errors.New("Failed to get current block number"), err)
 	}
 	if curBlock > math.MaxUint32 {
-		return nil, errors.Join(errors.New("Current block number is too large to be converted to uint32"), err)
+		return nil, types.WrapError(errors.New("Current block number is too large to be converted to uint32"), err)
 	}
 	operatorStakes, err := r.operatorStateRetriever.GetOperatorState(
 		opts,
@@ -212,7 +212,7 @@ func (r *AvsRegistryChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 		uint32(curBlock),
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get operators state"), err)
+		return nil, types.WrapError(errors.New("Failed to get operators state"), err)
 	}
 	var quorumOperatorAddrs [][]common.Address
 	for _, quorum := range operatorStakes {
@@ -237,7 +237,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 		operatorId,
 		blockNumber)
 	if err != nil {
-		return nil, nil, errors.Join(errors.New("Failed to get operators state"), err)
+		return nil, nil, types.WrapError(errors.New("Failed to get operators state"), err)
 	}
 	quorums := types.BitmapToQuorumIds(quorumBitmap)
 	return quorums, operatorStakes, nil
@@ -254,10 +254,10 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsOfOperatorAtCurrentBl
 	}
 	curBlock, err := r.ethClient.BlockNumber(opts.Context)
 	if err != nil {
-		return nil, nil, errors.Join(errors.New("Failed to get current block number"), err)
+		return nil, nil, types.WrapError(errors.New("Failed to get current block number"), err)
 	}
 	if curBlock > math.MaxUint32 {
-		return nil, nil, errors.Join(errors.New("Current block number is too large to be converted to uint32"), err)
+		return nil, nil, types.WrapError(errors.New("Current block number is too large to be converted to uint32"), err)
 	}
 	opts.BlockNumber = big.NewInt(int64(curBlock))
 	return r.GetOperatorsStakeInQuorumsOfOperatorAtBlock(opts, operatorId, uint32(curBlock))
@@ -272,7 +272,7 @@ func (r *AvsRegistryChainReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlo
 ) (map[types.QuorumNum]types.StakeAmount, error) {
 	quorumBitmap, err := r.registryCoordinator.GetCurrentQuorumBitmap(opts, operatorId)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get operator quorums"), err)
+		return nil, types.WrapError(errors.New("Failed to get operator quorums"), err)
 	}
 	quorums := types.BitmapToQuorumIds(quorumBitmap)
 	quorumStakes := make(map[types.QuorumNum]types.StakeAmount)
@@ -283,7 +283,7 @@ func (r *AvsRegistryChainReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlo
 			quorum,
 		)
 		if err != nil {
-			return nil, errors.Join(errors.New("Failed to get operator stake"), err)
+			return nil, types.WrapError(errors.New("Failed to get operator stake"), err)
 		}
 		quorumStakes[quorum] = stake
 	}
@@ -304,7 +304,7 @@ func (r *AvsRegistryChainReader) GetCheckSignaturesIndices(
 		nonSignerOperatorIds,
 	)
 	if err != nil {
-		return opstateretriever.OperatorStateRetrieverCheckSignaturesIndices{}, errors.Join(errors.New("Failed to get check signatures indices"), err)
+		return opstateretriever.OperatorStateRetrieverCheckSignaturesIndices{}, types.WrapError(errors.New("Failed to get check signatures indices"), err)
 	}
 	return checkSignatureIndices, nil
 }
@@ -318,7 +318,7 @@ func (r *AvsRegistryChainReader) GetOperatorId(
 		operatorAddress,
 	)
 	if err != nil {
-		return [32]byte{}, errors.Join(errors.New("Failed to get operator id"), err)
+		return [32]byte{}, types.WrapError(errors.New("Failed to get operator id"), err)
 	}
 	return operatorId, nil
 }
@@ -332,7 +332,7 @@ func (r *AvsRegistryChainReader) GetOperatorFromId(
 		operatorId,
 	)
 	if err != nil {
-		return gethcommon.Address{}, errors.Join(errors.New("Failed to get operator address"), err)
+		return gethcommon.Address{}, types.WrapError(errors.New("Failed to get operator address"), err)
 	}
 	return operatorAddress, nil
 }
@@ -343,7 +343,7 @@ func (r *AvsRegistryChainReader) IsOperatorRegistered(
 ) (bool, error) {
 	operatorStatus, err := r.registryCoordinator.GetOperatorStatus(opts, operatorAddress)
 	if err != nil {
-		return false, errors.Join(errors.New("Failed to get operator status"), err)
+		return false, types.WrapError(errors.New("Failed to get operator status"), err)
 	}
 
 	// 0 = NEVER_REGISTERED, 1 = REGISTERED, 2 = DEREGISTERED
@@ -359,7 +359,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorPubKeys(
 
 	blsApkRegistryAbi, err := abi.JSON(bytes.NewReader(eigenabi.BLSApkRegistryAbi))
 	if err != nil {
-		return nil, nil, errors.Join(errors.New("Cannot get Abi"), err)
+		return nil, nil, types.WrapError(errors.New("Cannot get Abi"), err)
 	}
 
 	query := ethereum.FilterQuery{
@@ -373,7 +373,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorPubKeys(
 
 	logs, err := r.ethClient.FilterLogs(ctx, query)
 	if err != nil {
-		return nil, nil, errors.Join(errors.New("Cannot filter logs"), err)
+		return nil, nil, types.WrapError(errors.New("Cannot filter logs"), err)
 	}
 	r.logger.Info("avsRegistryChainReader.QueryExistingRegisteredOperatorPubKeys", "transactionLogs", logs)
 
@@ -388,7 +388,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorPubKeys(
 
 		event, err := blsApkRegistryAbi.Unpack("NewPubkeyRegistration", vLog.Data)
 		if err != nil {
-			return nil, nil, errors.Join(errors.New("Cannot unpack event data"), err)
+			return nil, nil, types.WrapError(errors.New("Cannot unpack event data"), err)
 		}
 
 		G1Pubkey := event[0].(struct {

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -119,18 +119,22 @@ func BuildAvsRegistryChainReader(
 ) (*AvsRegistryChainReader, error) {
 	contractRegistryCoordinator, err := regcoord.NewContractRegistryCoordinator(registryCoordinatorAddr, ethClient)
 	if err != nil {
+		logger.Error("Failed to create contractRegistryCoordinator", "err", err)
 		return nil, err
 	}
 	blsApkRegistryAddr, err := contractRegistryCoordinator.BlsApkRegistry(&bind.CallOpts{})
 	if err != nil {
+		logger.Error("Failed to get blsApkRegistryAddr", "err", err)
 		return nil, err
 	}
 	stakeRegistryAddr, err := contractRegistryCoordinator.StakeRegistry(&bind.CallOpts{})
 	if err != nil {
+		logger.Error("Failed to get stakeRegistryAddr", "err", err)
 		return nil, err
 	}
 	contractStakeRegistry, err := stakeregistry.NewContractStakeRegistry(stakeRegistryAddr, ethClient)
 	if err != nil {
+		logger.Error("Failed to create contractStakeRegistry", "err", err)
 		return nil, err
 	}
 	contractOperatorStateRetriever, err := contractOperatorStateRetriever.NewContractOperatorStateRetriever(
@@ -138,6 +142,7 @@ func BuildAvsRegistryChainReader(
 		ethClient,
 	)
 	if err != nil {
+		logger.Error("Failed to create contractOperatorStateRetriever", "err", err)
 		return nil, err
 	}
 	return NewAvsRegistryChainReader(

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -3,6 +3,7 @@ package avsregistry
 import (
 	"bytes"
 	"context"
+	"errors"
 	"math"
 	"math/big"
 
@@ -119,31 +120,26 @@ func BuildAvsRegistryChainReader(
 ) (*AvsRegistryChainReader, error) {
 	contractRegistryCoordinator, err := regcoord.NewContractRegistryCoordinator(registryCoordinatorAddr, ethClient)
 	if err != nil {
-		logger.Error("Failed to create contractRegistryCoordinator", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create contractRegistryCoordinator"), err)
 	}
 	blsApkRegistryAddr, err := contractRegistryCoordinator.BlsApkRegistry(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to get blsApkRegistryAddr", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get blsApkRegistryAddr"), err)
 	}
 	stakeRegistryAddr, err := contractRegistryCoordinator.StakeRegistry(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to get stakeRegistryAddr", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get stakeRegistryAddr"), err)
 	}
 	contractStakeRegistry, err := stakeregistry.NewContractStakeRegistry(stakeRegistryAddr, ethClient)
 	if err != nil {
-		logger.Error("Failed to create contractStakeRegistry", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create contractStakeRegistry"), err)
 	}
 	contractOperatorStateRetriever, err := contractOperatorStateRetriever.NewContractOperatorStateRetriever(
 		operatorStateRetrieverAddr,
 		ethClient,
 	)
 	if err != nil {
-		logger.Error("Failed to create contractOperatorStateRetriever", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create contractOperatorStateRetriever"), err)
 	}
 	return NewAvsRegistryChainReader(
 		registryCoordinatorAddr,
@@ -169,12 +165,10 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtCurrentBlock(
 	}
 	curBlock, err := r.ethClient.BlockNumber(opts.Context)
 	if err != nil {
-		r.logger.Error("Failed to get current block number", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Cannot get current block number"), err)
 	}
 	if curBlock > math.MaxUint32 {
-		r.logger.Error("Current block number is too large to be converted to uint32")
-		return nil, err
+		return nil, errors.Join(errors.New("Current block number is too large to be converted to uint32"), err)
 	}
 	return r.GetOperatorsStakeInQuorumsAtBlock(opts, quorumNumbers, uint32(curBlock))
 }
@@ -192,8 +186,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtBlock(
 		quorumNumbers,
 		blockNumber)
 	if err != nil {
-		r.logger.Error("Failed to get operators state", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get operators state"), err)
 	}
 	return operatorStakes, nil
 }
@@ -207,12 +200,10 @@ func (r *AvsRegistryChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 	}
 	curBlock, err := r.ethClient.BlockNumber(opts.Context)
 	if err != nil {
-		r.logger.Error("Failed to get current block number", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get current block number"), err)
 	}
 	if curBlock > math.MaxUint32 {
-		r.logger.Error("Current block number is too large to be converted to uint32")
-		return nil, err
+		return nil, errors.Join(errors.New("Current block number is too large to be converted to uint32"), err)
 	}
 	operatorStakes, err := r.operatorStateRetriever.GetOperatorState(
 		opts,
@@ -221,8 +212,7 @@ func (r *AvsRegistryChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 		uint32(curBlock),
 	)
 	if err != nil {
-		r.logger.Error("Failed to get operators state", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get operators state"), err)
 	}
 	var quorumOperatorAddrs [][]common.Address
 	for _, quorum := range operatorStakes {
@@ -247,14 +237,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 		operatorId,
 		blockNumber)
 	if err != nil {
-		r.logger.Error(
-			"Failed to get operators state",
-			"err",
-			err,
-			"fn",
-			"AvsRegistryChainReader.GetOperatorsStakeInQuorumsOfOperatorAtBlock",
-		)
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Failed to get operators state"), err)
 	}
 	quorums := types.BitmapToQuorumIds(quorumBitmap)
 	return quorums, operatorStakes, nil
@@ -271,12 +254,10 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsOfOperatorAtCurrentBl
 	}
 	curBlock, err := r.ethClient.BlockNumber(opts.Context)
 	if err != nil {
-		r.logger.Error("Failed to get current block number", "err", err)
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Failed to get current block number"), err)
 	}
 	if curBlock > math.MaxUint32 {
-		r.logger.Error("Current block number is too large to be converted to uint32")
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Current block number is too large to be converted to uint32"), err)
 	}
 	opts.BlockNumber = big.NewInt(int64(curBlock))
 	return r.GetOperatorsStakeInQuorumsOfOperatorAtBlock(opts, operatorId, uint32(curBlock))
@@ -291,8 +272,7 @@ func (r *AvsRegistryChainReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlo
 ) (map[types.QuorumNum]types.StakeAmount, error) {
 	quorumBitmap, err := r.registryCoordinator.GetCurrentQuorumBitmap(opts, operatorId)
 	if err != nil {
-		r.logger.Error("Failed to get operator quorums", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get operator quorums"), err)
 	}
 	quorums := types.BitmapToQuorumIds(quorumBitmap)
 	quorumStakes := make(map[types.QuorumNum]types.StakeAmount)
@@ -303,8 +283,7 @@ func (r *AvsRegistryChainReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlo
 			quorum,
 		)
 		if err != nil {
-			r.logger.Error("Failed to get operator stake", "err", err)
-			return nil, err
+			return nil, errors.Join(errors.New("Failed to get operator stake"), err)
 		}
 		quorumStakes[quorum] = stake
 	}
@@ -325,8 +304,7 @@ func (r *AvsRegistryChainReader) GetCheckSignaturesIndices(
 		nonSignerOperatorIds,
 	)
 	if err != nil {
-		r.logger.Error("Failed to get check signatures indices", "err", err)
-		return opstateretriever.OperatorStateRetrieverCheckSignaturesIndices{}, err
+		return opstateretriever.OperatorStateRetrieverCheckSignaturesIndices{}, errors.Join(errors.New("Failed to get check signatures indices"), err)
 	}
 	return checkSignatureIndices, nil
 }
@@ -340,8 +318,7 @@ func (r *AvsRegistryChainReader) GetOperatorId(
 		operatorAddress,
 	)
 	if err != nil {
-		r.logger.Error("Failed to get operator id", "err", err)
-		return [32]byte{}, err
+		return [32]byte{}, errors.Join(errors.New("Failed to get operator id"), err)
 	}
 	return operatorId, nil
 }
@@ -355,8 +332,7 @@ func (r *AvsRegistryChainReader) GetOperatorFromId(
 		operatorId,
 	)
 	if err != nil {
-		r.logger.Error("Failed to get operator address", "err", err)
-		return gethcommon.Address{}, err
+		return gethcommon.Address{}, errors.Join(errors.New("Failed to get operator address"), err)
 	}
 	return operatorAddress, nil
 }
@@ -367,8 +343,7 @@ func (r *AvsRegistryChainReader) IsOperatorRegistered(
 ) (bool, error) {
 	operatorStatus, err := r.registryCoordinator.GetOperatorStatus(opts, operatorAddress)
 	if err != nil {
-		r.logger.Error("Cannot get operator status", "err", err)
-		return false, err
+		return false, errors.Join(errors.New("Failed to get operator status"), err)
 	}
 
 	// 0 = NEVER_REGISTERED, 1 = REGISTERED, 2 = DEREGISTERED
@@ -384,8 +359,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorPubKeys(
 
 	blsApkRegistryAbi, err := abi.JSON(bytes.NewReader(eigenabi.BLSApkRegistryAbi))
 	if err != nil {
-		r.logger.Error("Error getting Abi", "err", err)
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Cannot get Abi"), err)
 	}
 
 	query := ethereum.FilterQuery{
@@ -399,8 +373,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorPubKeys(
 
 	logs, err := r.ethClient.FilterLogs(ctx, query)
 	if err != nil {
-		r.logger.Error("Error filtering logs", "err", err)
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Cannot filter logs"), err)
 	}
 	r.logger.Info("avsRegistryChainReader.QueryExistingRegisteredOperatorPubKeys", "transactionLogs", logs)
 
@@ -415,8 +388,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorPubKeys(
 
 		event, err := blsApkRegistryAbi.Unpack("NewPubkeyRegistration", vLog.Data)
 		if err != nil {
-			r.logger.Error("Error unpacking event data", "err", err)
-			return nil, nil, err
+			return nil, nil, errors.Join(errors.New("Cannot unpack event data"), err)
 		}
 
 		G1Pubkey := event[0].(struct {

--- a/chainio/clients/avsregistry/subscriber.go
+++ b/chainio/clients/avsregistry/subscriber.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	blsapkreg "github.com/Layr-Labs/eigensdk-go/contracts/bindings/BLSApkRegistry"
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/Layr-Labs/eigensdk-go/types"
 )
 
 type AvsRegistrySubscriber interface {
@@ -41,7 +42,7 @@ func BuildAvsRegistryChainSubscriber(
 ) (*AvsRegistryChainSubscriber, error) {
 	blsapkreg, err := blsapkreg.NewContractBLSApkRegistry(blsApkRegistryAddr, ethWsClient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create BLSApkRegistry contract"), err)
+		return nil, types.WrapError(errors.New("Failed to create BLSApkRegistry contract"), err)
 	}
 	return NewAvsRegistryChainSubscriber(blsapkreg, logger)
 }
@@ -52,7 +53,7 @@ func (s *AvsRegistryChainSubscriber) SubscribeToNewPubkeyRegistrations() (chan *
 		&bind.WatchOpts{}, newPubkeyRegistrationChan, nil,
 	)
 	if err != nil {
-		return nil, nil, errors.Join(errors.New("Failed to subscribe to NewPubkeyRegistration events"), err)
+		return nil, nil, types.WrapError(errors.New("Failed to subscribe to NewPubkeyRegistration events"), err)
 	}
 	return newPubkeyRegistrationChan, sub, nil
 }

--- a/chainio/clients/avsregistry/subscriber.go
+++ b/chainio/clients/avsregistry/subscriber.go
@@ -1,6 +1,8 @@
 package avsregistry
 
 import (
+	"errors"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
@@ -39,8 +41,7 @@ func BuildAvsRegistryChainSubscriber(
 ) (*AvsRegistryChainSubscriber, error) {
 	blsapkreg, err := blsapkreg.NewContractBLSApkRegistry(blsApkRegistryAddr, ethWsClient)
 	if err != nil {
-		logger.Error("Failed to create BLSApkRegistry contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create BLSApkRegistry contract"), err)
 	}
 	return NewAvsRegistryChainSubscriber(blsapkreg, logger)
 }
@@ -51,8 +52,7 @@ func (s *AvsRegistryChainSubscriber) SubscribeToNewPubkeyRegistrations() (chan *
 		&bind.WatchOpts{}, newPubkeyRegistrationChan, nil,
 	)
 	if err != nil {
-		s.logger.Error("Failed to subscribe to NewPubkeyRegistration events", "err", err)
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Failed to subscribe to NewPubkeyRegistration events"), err)
 	}
 	return newPubkeyRegistrationChan, sub, nil
 }

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -116,6 +116,7 @@ func BuildAvsRegistryChainWriter(
 ) (*AvsRegistryChainWriter, error) {
 	registryCoordinator, err := regcoord.NewContractRegistryCoordinator(registryCoordinatorAddr, ethClient)
 	if err != nil {
+		logger.Error("Failed to create RegistryCoordinator contract", "err", err)
 		return nil, err
 	}
 	operatorStateRetriever, err := opstateretriever.NewContractOperatorStateRetriever(
@@ -123,42 +124,52 @@ func BuildAvsRegistryChainWriter(
 		ethClient,
 	)
 	if err != nil {
+		logger.Error("Failed to create OperatorStateRetriever contract", "err", err)
 		return nil, err
 	}
 	serviceManagerAddr, err := registryCoordinator.ServiceManager(&bind.CallOpts{})
 	if err != nil {
+		logger.Error("Failed to get ServiceManager address", "err", err)
 		return nil, err
 	}
 	serviceManager, err := smbase.NewContractServiceManagerBase(serviceManagerAddr, ethClient)
 	if err != nil {
+		logger.Error("Failed to create ServiceManager contract", "err", err)
 		return nil, err
 	}
 	blsApkRegistryAddr, err := registryCoordinator.BlsApkRegistry(&bind.CallOpts{})
 	if err != nil {
+		logger.Error("Failed to get BLSApkRegistry address", "err", err)
 		return nil, err
 	}
 	blsApkRegistry, err := blsapkregistry.NewContractBLSApkRegistry(blsApkRegistryAddr, ethClient)
 	if err != nil {
+		logger.Error("Failed to create BLSApkRegistry contract", "err", err)
 		return nil, err
 	}
 	stakeRegistryAddr, err := registryCoordinator.StakeRegistry(&bind.CallOpts{})
 	if err != nil {
+		logger.Error("Failed to get StakeRegistry address", "err", err)
 		return nil, err
 	}
 	stakeRegistry, err := stakeregistry.NewContractStakeRegistry(stakeRegistryAddr, ethClient)
 	if err != nil {
+		logger.Error("Failed to create StakeRegistry contract", "err", err)
 		return nil, err
 	}
 	delegationManagerAddr, err := stakeRegistry.Delegation(&bind.CallOpts{})
 	if err != nil {
+		logger.Error("Failed to get DelegationManager address", "err", err)
 		return nil, err
 	}
 	avsDirectoryAddr, err := serviceManager.AvsDirectory(&bind.CallOpts{})
 	if err != nil {
+		logger.Error("Failed to get AvsDirectory address", "err", err)
 		return nil, err
 	}
 	elReader, err := elcontracts.BuildELChainReader(delegationManagerAddr, avsDirectoryAddr, ethClient, logger)
 	if err != nil {
+		logger.Error("Failed to create ELChainReader", "err", err)
 		return nil, err
 	}
 	return NewAvsRegistryChainWriter(

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/utils"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -116,50 +117,50 @@ func BuildAvsRegistryChainWriter(
 ) (*AvsRegistryChainWriter, error) {
 	registryCoordinator, err := regcoord.NewContractRegistryCoordinator(registryCoordinatorAddr, ethClient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create RegistryCoordinator contract"), err)
+		return nil, types.WrapError(errors.New("Failed to create RegistryCoordinator contract"), err)
 	}
 	operatorStateRetriever, err := opstateretriever.NewContractOperatorStateRetriever(
 		operatorStateRetrieverAddr,
 		ethClient,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create OperatorStateRetriever contract"), err)
+		return nil, types.WrapError(errors.New("Failed to create OperatorStateRetriever contract"), err)
 	}
 	serviceManagerAddr, err := registryCoordinator.ServiceManager(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get ServiceManager address"), err)
+		return nil, types.WrapError(errors.New("Failed to get ServiceManager address"), err)
 	}
 	serviceManager, err := smbase.NewContractServiceManagerBase(serviceManagerAddr, ethClient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create ServiceManager contract"), err)
+		return nil, types.WrapError(errors.New("Failed to create ServiceManager contract"), err)
 	}
 	blsApkRegistryAddr, err := registryCoordinator.BlsApkRegistry(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get BLSApkRegistry address"), err)
+		return nil, types.WrapError(errors.New("Failed to get BLSApkRegistry address"), err)
 	}
 	blsApkRegistry, err := blsapkregistry.NewContractBLSApkRegistry(blsApkRegistryAddr, ethClient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create BLSApkRegistry contract"), err)
+		return nil, types.WrapError(errors.New("Failed to create BLSApkRegistry contract"), err)
 	}
 	stakeRegistryAddr, err := registryCoordinator.StakeRegistry(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get StakeRegistry address"), err)
+		return nil, types.WrapError(errors.New("Failed to get StakeRegistry address"), err)
 	}
 	stakeRegistry, err := stakeregistry.NewContractStakeRegistry(stakeRegistryAddr, ethClient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create StakeRegistry contract"), err)
+		return nil, types.WrapError(errors.New("Failed to create StakeRegistry contract"), err)
 	}
 	delegationManagerAddr, err := stakeRegistry.Delegation(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get DelegationManager address"), err)
+		return nil, types.WrapError(errors.New("Failed to get DelegationManager address"), err)
 	}
 	avsDirectoryAddr, err := serviceManager.AvsDirectory(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get AvsDirectory address"), err)
+		return nil, types.WrapError(errors.New("Failed to get AvsDirectory address"), err)
 	}
 	elReader, err := elcontracts.BuildELChainReader(delegationManagerAddr, avsDirectoryAddr, ethClient, logger)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create ELChainReader"), err)
+		return nil, types.WrapError(errors.New("Failed to create ELChainReader"), err)
 	}
 	return NewAvsRegistryChainWriter(
 		serviceManagerAddr,

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -116,61 +116,50 @@ func BuildAvsRegistryChainWriter(
 ) (*AvsRegistryChainWriter, error) {
 	registryCoordinator, err := regcoord.NewContractRegistryCoordinator(registryCoordinatorAddr, ethClient)
 	if err != nil {
-		logger.Error("Failed to create RegistryCoordinator contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create RegistryCoordinator contract"), err)
 	}
 	operatorStateRetriever, err := opstateretriever.NewContractOperatorStateRetriever(
 		operatorStateRetrieverAddr,
 		ethClient,
 	)
 	if err != nil {
-		logger.Error("Failed to create OperatorStateRetriever contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create OperatorStateRetriever contract"), err)
 	}
 	serviceManagerAddr, err := registryCoordinator.ServiceManager(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to get ServiceManager address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get ServiceManager address"), err)
 	}
 	serviceManager, err := smbase.NewContractServiceManagerBase(serviceManagerAddr, ethClient)
 	if err != nil {
-		logger.Error("Failed to create ServiceManager contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create ServiceManager contract"), err)
 	}
 	blsApkRegistryAddr, err := registryCoordinator.BlsApkRegistry(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to get BLSApkRegistry address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get BLSApkRegistry address"), err)
 	}
 	blsApkRegistry, err := blsapkregistry.NewContractBLSApkRegistry(blsApkRegistryAddr, ethClient)
 	if err != nil {
-		logger.Error("Failed to create BLSApkRegistry contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create BLSApkRegistry contract"), err)
 	}
 	stakeRegistryAddr, err := registryCoordinator.StakeRegistry(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to get StakeRegistry address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get StakeRegistry address"), err)
 	}
 	stakeRegistry, err := stakeregistry.NewContractStakeRegistry(stakeRegistryAddr, ethClient)
 	if err != nil {
-		logger.Error("Failed to create StakeRegistry contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create StakeRegistry contract"), err)
 	}
 	delegationManagerAddr, err := stakeRegistry.Delegation(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to get DelegationManager address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get DelegationManager address"), err)
 	}
 	avsDirectoryAddr, err := serviceManager.AvsDirectory(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to get AvsDirectory address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get AvsDirectory address"), err)
 	}
 	elReader, err := elcontracts.BuildELChainReader(delegationManagerAddr, avsDirectoryAddr, ethClient, logger)
 	if err != nil {
-		logger.Error("Failed to create ELChainReader", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create ELChainReader"), err)
 	}
 	return NewAvsRegistryChainWriter(
 		serviceManagerAddr,

--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/metrics"
 	"github.com/Layr-Labs/eigensdk-go/signerv2"
+	"github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -57,12 +58,12 @@ func BuildAll(
 	// creating two types of Eth clients: HTTP and WS
 	ethHttpClient, err := eth.NewClient(config.EthHttpUrl)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create Eth Http client"), err)
+		return nil, types.WrapError(errors.New("Failed to create Eth Http client"), err)
 	}
 
 	ethWsClient, err := eth.NewClient(config.EthWsUrl)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create Eth WS client"), err)
+		return nil, types.WrapError(errors.New("Failed to create Eth WS client"), err)
 	}
 
 	txMgr := txmgr.NewSimpleTxManager(ethHttpClient, logger, signerFn, signerAddr)
@@ -74,7 +75,7 @@ func BuildAll(
 		eigenMetrics,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create EL Reader, Writer and Subscriber"), err)
+		return nil, types.WrapError(errors.New("Failed to create EL Reader, Writer and Subscriber"), err)
 	}
 
 	// creating AVS clients: Reader and Writer
@@ -86,7 +87,7 @@ func BuildAll(
 		logger,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create AVS Registry Reader and Writer"), err)
+		return nil, types.WrapError(errors.New("Failed to create AVS Registry Reader and Writer"), err)
 	}
 
 	return &Clients{
@@ -117,7 +118,7 @@ func (config *BuildAllConfig) buildElClients(
 		logger,
 	)
 	if err != nil {
-		return nil, nil, errors.Join(errors.New("Failed to create AVSRegistryContractBindings"), err)
+		return nil, nil, types.WrapError(errors.New("Failed to create AVSRegistryContractBindings"), err)
 	}
 
 	delegationManagerAddr, err := avsRegistryContractBindings.StakeRegistry.Delegation(&bind.CallOpts{})
@@ -136,7 +137,7 @@ func (config *BuildAllConfig) buildElClients(
 		logger,
 	)
 	if err != nil {
-		return nil, nil, errors.Join(errors.New("Failed to create EigenlayerContractBindings"), err)
+		return nil, nil, types.WrapError(errors.New("Failed to create EigenlayerContractBindings"), err)
 	}
 
 	// get the Reader for the EL contracts
@@ -161,7 +162,7 @@ func (config *BuildAllConfig) buildElClients(
 		txMgr,
 	)
 	if err != nil {
-		return nil, nil, errors.Join(errors.New("Failed to create ELChainWriter"), err)
+		return nil, nil, types.WrapError(errors.New("Failed to create ELChainWriter"), err)
 	}
 
 	return elChainReader, elChainWriter, nil
@@ -182,7 +183,7 @@ func (config *BuildAllConfig) buildAvsClients(
 		logger,
 	)
 	if err != nil {
-		return nil, nil, nil, errors.Join(errors.New("Failed to create AVSRegistryContractBindings"), err)
+		return nil, nil, nil, types.WrapError(errors.New("Failed to create AVSRegistryContractBindings"), err)
 	}
 
 	avsRegistryChainReader := avsregistry.NewAvsRegistryChainReader(
@@ -207,7 +208,7 @@ func (config *BuildAllConfig) buildAvsClients(
 		txMgr,
 	)
 	if err != nil {
-		return nil, nil, nil, errors.Join(errors.New("Failed to create AVSRegistryChainWriter"), err)
+		return nil, nil, nil, types.WrapError(errors.New("Failed to create AVSRegistryChainWriter"), err)
 	}
 
 	// get the Subscriber for Avs Registry contracts
@@ -218,7 +219,7 @@ func (config *BuildAllConfig) buildAvsClients(
 		logger,
 	)
 	if err != nil {
-		return nil, nil, nil, errors.Join(errors.New("Failed to create ELChainSubscriber"), err)
+		return nil, nil, nil, types.WrapError(errors.New("Failed to create ELChainSubscriber"), err)
 	}
 
 	return avsRegistryChainReader, avsRegistrySubscriber, avsRegistryChainWriter, nil

--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -1,6 +1,8 @@
 package clients
 
 import (
+	"errors"
+
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
@@ -55,14 +57,12 @@ func BuildAll(
 	// creating two types of Eth clients: HTTP and WS
 	ethHttpClient, err := eth.NewClient(config.EthHttpUrl)
 	if err != nil {
-		logger.Error("Failed to create Eth Http client", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create Eth Http client"), err)
 	}
 
 	ethWsClient, err := eth.NewClient(config.EthWsUrl)
 	if err != nil {
-		logger.Error("Failed to create Eth WS client", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create Eth WS client"), err)
 	}
 
 	txMgr := txmgr.NewSimpleTxManager(ethHttpClient, logger, signerFn, signerAddr)
@@ -74,8 +74,7 @@ func BuildAll(
 		eigenMetrics,
 	)
 	if err != nil {
-		logger.Error("Failed to create EL Reader, Writer and Subscriber", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create EL Reader, Writer and Subscriber"), err)
 	}
 
 	// creating AVS clients: Reader and Writer
@@ -87,8 +86,7 @@ func BuildAll(
 		logger,
 	)
 	if err != nil {
-		logger.Error("Failed to create AVS Registry Reader and Writer", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create AVS Registry Reader and Writer"), err)
 	}
 
 	return &Clients{
@@ -119,8 +117,7 @@ func (config *BuildAllConfig) buildElClients(
 		logger,
 	)
 	if err != nil {
-		logger.Error("Failed to create AVSRegistryContractBindings", "err", err)
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Failed to create AVSRegistryContractBindings"), err)
 	}
 
 	delegationManagerAddr, err := avsRegistryContractBindings.StakeRegistry.Delegation(&bind.CallOpts{})
@@ -139,8 +136,7 @@ func (config *BuildAllConfig) buildElClients(
 		logger,
 	)
 	if err != nil {
-		logger.Error("Failed to create EigenlayerContractBindings", "err", err)
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Failed to create EigenlayerContractBindings"), err)
 	}
 
 	// get the Reader for the EL contracts
@@ -165,8 +161,7 @@ func (config *BuildAllConfig) buildElClients(
 		txMgr,
 	)
 	if err != nil {
-		logger.Error("Failed to create ELChainWriter", "err", err)
-		return nil, nil, err
+		return nil, nil, errors.Join(errors.New("Failed to create ELChainWriter"), err)
 	}
 
 	return elChainReader, elChainWriter, nil
@@ -187,8 +182,7 @@ func (config *BuildAllConfig) buildAvsClients(
 		logger,
 	)
 	if err != nil {
-		logger.Error("Failed to create AVSRegistryContractBindings", "err", err)
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Join(errors.New("Failed to create AVSRegistryContractBindings"), err)
 	}
 
 	avsRegistryChainReader := avsregistry.NewAvsRegistryChainReader(
@@ -213,8 +207,7 @@ func (config *BuildAllConfig) buildAvsClients(
 		txMgr,
 	)
 	if err != nil {
-		logger.Error("Failed to create AVSRegistryChainWriter", "err", err)
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Join(errors.New("Failed to create AVSRegistryChainWriter"), err)
 	}
 
 	// get the Subscriber for Avs Registry contracts
@@ -225,8 +218,7 @@ func (config *BuildAllConfig) buildAvsClients(
 		logger,
 	)
 	if err != nil {
-		logger.Error("Failed to create ELChainSubscriber", "err", err)
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Join(errors.New("Failed to create ELChainSubscriber"), err)
 	}
 
 	return avsRegistryChainReader, avsRegistrySubscriber, avsRegistryChainWriter, nil

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -1,6 +1,7 @@
 package elcontracts
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -150,13 +151,11 @@ func (r *ELChainReader) GetStrategyAndUnderlyingToken(
 ) (*strategy.ContractIStrategy, gethcommon.Address, error) {
 	contractStrategy, err := strategy.NewContractIStrategy(strategyAddr, r.ethClient)
 	if err != nil {
-		r.logger.Error("Failed to fetch strategy contract", "err", err)
-		return nil, common.Address{}, err
+		return nil, common.Address{}, errors.Join(errors.New("Failed to fetch strategy contract"), err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(opts)
 	if err != nil {
-		r.logger.Error("Failed to fetch token contract", "err", err)
-		return nil, common.Address{}, err
+		return nil, common.Address{}, errors.Join(errors.New("Failed to fetch token contract"), err)
 	}
 	return contractStrategy, underlyingTokenAddr, nil
 }
@@ -168,18 +167,15 @@ func (r *ELChainReader) GetStrategyAndUnderlyingERC20Token(
 ) (*strategy.ContractIStrategy, erc20.ContractIERC20Methods, gethcommon.Address, error) {
 	contractStrategy, err := strategy.NewContractIStrategy(strategyAddr, r.ethClient)
 	if err != nil {
-		r.logger.Error("Failed to fetch strategy contract", "err", err)
-		return nil, nil, common.Address{}, err
+		return nil, nil, common.Address{}, errors.Join(errors.New("Failed to fetch strategy contract"), err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(opts)
 	if err != nil {
-		r.logger.Error("Failed to fetch token contract", "err", err)
-		return nil, nil, common.Address{}, err
+		return nil, nil, common.Address{}, errors.Join(errors.New("Failed to fetch token contract"), err)
 	}
 	contractUnderlyingToken, err := erc20.NewContractIERC20(underlyingTokenAddr, r.ethClient)
 	if err != nil {
-		r.logger.Error("Failed to fetch token contract", "err", err)
-		return nil, nil, common.Address{}, err
+		return nil, nil, common.Address{}, errors.Join(errors.New("Failed to fetch token contract"), err)
 	}
 	return contractStrategy, contractUnderlyingToken, underlyingTokenAddr, nil
 }

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -151,11 +151,11 @@ func (r *ELChainReader) GetStrategyAndUnderlyingToken(
 ) (*strategy.ContractIStrategy, gethcommon.Address, error) {
 	contractStrategy, err := strategy.NewContractIStrategy(strategyAddr, r.ethClient)
 	if err != nil {
-		return nil, common.Address{}, errors.Join(errors.New("Failed to fetch strategy contract"), err)
+		return nil, common.Address{}, types.WrapError(errors.New("Failed to fetch strategy contract"), err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(opts)
 	if err != nil {
-		return nil, common.Address{}, errors.Join(errors.New("Failed to fetch token contract"), err)
+		return nil, common.Address{}, types.WrapError(errors.New("Failed to fetch token contract"), err)
 	}
 	return contractStrategy, underlyingTokenAddr, nil
 }
@@ -167,15 +167,15 @@ func (r *ELChainReader) GetStrategyAndUnderlyingERC20Token(
 ) (*strategy.ContractIStrategy, erc20.ContractIERC20Methods, gethcommon.Address, error) {
 	contractStrategy, err := strategy.NewContractIStrategy(strategyAddr, r.ethClient)
 	if err != nil {
-		return nil, nil, common.Address{}, errors.Join(errors.New("Failed to fetch strategy contract"), err)
+		return nil, nil, common.Address{}, types.WrapError(errors.New("Failed to fetch strategy contract"), err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(opts)
 	if err != nil {
-		return nil, nil, common.Address{}, errors.Join(errors.New("Failed to fetch token contract"), err)
+		return nil, nil, common.Address{}, types.WrapError(errors.New("Failed to fetch token contract"), err)
 	}
 	contractUnderlyingToken, err := erc20.NewContractIERC20(underlyingTokenAddr, r.ethClient)
 	if err != nil {
-		return nil, nil, common.Address{}, errors.Join(errors.New("Failed to fetch token contract"), err)
+		return nil, nil, common.Address{}, types.WrapError(errors.New("Failed to fetch token contract"), err)
 	}
 	return contractStrategy, contractUnderlyingToken, underlyingTokenAddr, nil
 }

--- a/chainio/utils/bindings.go
+++ b/chainio/utils/bindings.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
@@ -42,30 +43,30 @@ func NewEigenlayerContractBindings(
 ) (*EigenlayerContractBindings, error) {
 	contractDelegationManager, err := delegationmanager.NewContractDelegationManager(delegationManagerAddr, ethclient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create DelegationManager contract"), err)
+		return nil, types.WrapError(errors.New("Failed to create DelegationManager contract"), err)
 	}
 
 	slasherAddr, err := contractDelegationManager.Slasher(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch Slasher address"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch Slasher address"), err)
 	}
 	contractSlasher, err := slasher.NewContractISlasher(slasherAddr, ethclient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch Slasher contract"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch Slasher contract"), err)
 	}
 
 	strategyManagerAddr, err := contractDelegationManager.StrategyManager(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch StrategyManager address"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch StrategyManager address"), err)
 	}
 	contractStrategyManager, err := strategymanager.NewContractStrategyManager(strategyManagerAddr, ethclient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch StrategyManager contract"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch StrategyManager contract"), err)
 	}
 
 	avsDirectory, err := avsdirectory.NewContractAVSDirectory(avsDirectoryAddr, ethclient)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch AVSDirectory contract"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch AVSDirectory contract"), err)
 	}
 
 	return &EigenlayerContractBindings{
@@ -108,43 +109,43 @@ func NewAVSRegistryContractBindings(
 		ethclient,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to create BLSRegistryCoordinator contract"), err)
+		return nil, types.WrapError(errors.New("Failed to create BLSRegistryCoordinator contract"), err)
 	}
 
 	serviceManagerAddr, err := contractBlsRegistryCoordinator.ServiceManager(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch ServiceManager address"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch ServiceManager address"), err)
 	}
 	contractServiceManager, err := servicemanager.NewContractServiceManagerBase(
 		serviceManagerAddr,
 		ethclient,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch ServiceManager contract"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch ServiceManager contract"), err)
 	}
 
 	stakeregistryAddr, err := contractBlsRegistryCoordinator.StakeRegistry(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch StakeRegistry address"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch StakeRegistry address"), err)
 	}
 	contractStakeRegistry, err := stakeregistry.NewContractStakeRegistry(
 		stakeregistryAddr,
 		ethclient,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch StakeRegistry contract"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch StakeRegistry contract"), err)
 	}
 
 	blsApkRegistryAddr, err := contractBlsRegistryCoordinator.BlsApkRegistry(&bind.CallOpts{})
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch BLSPubkeyRegistry address"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch BLSPubkeyRegistry address"), err)
 	}
 	contractBlsApkRegistry, err := blsapkregistry.NewContractBLSApkRegistry(
 		blsApkRegistryAddr,
 		ethclient,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch BLSPubkeyRegistry contract"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch BLSPubkeyRegistry contract"), err)
 	}
 
 	contractOperatorStateRetriever, err := opstateretriever.NewContractOperatorStateRetriever(
@@ -152,7 +153,7 @@ func NewAVSRegistryContractBindings(
 		ethclient,
 	)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to fetch OperatorStateRetriever contract"), err)
+		return nil, types.WrapError(errors.New("Failed to fetch OperatorStateRetriever contract"), err)
 	}
 
 	return &AvsRegistryContractBindings{

--- a/chainio/utils/bindings.go
+++ b/chainio/utils/bindings.go
@@ -3,6 +3,8 @@
 package utils
 
 import (
+	"errors"
+
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -40,36 +42,30 @@ func NewEigenlayerContractBindings(
 ) (*EigenlayerContractBindings, error) {
 	contractDelegationManager, err := delegationmanager.NewContractDelegationManager(delegationManagerAddr, ethclient)
 	if err != nil {
-		logger.Error("Failed to fetch DelegationManager contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create DelegationManager contract"), err)
 	}
 
 	slasherAddr, err := contractDelegationManager.Slasher(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to fetch Slasher address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch Slasher address"), err)
 	}
 	contractSlasher, err := slasher.NewContractISlasher(slasherAddr, ethclient)
 	if err != nil {
-		logger.Error("Failed to fetch Slasher contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch Slasher contract"), err)
 	}
 
 	strategyManagerAddr, err := contractDelegationManager.StrategyManager(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to fetch StrategyManager address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch StrategyManager address"), err)
 	}
 	contractStrategyManager, err := strategymanager.NewContractStrategyManager(strategyManagerAddr, ethclient)
 	if err != nil {
-		logger.Error("Failed to fetch StrategyManager contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch StrategyManager contract"), err)
 	}
 
 	avsDirectory, err := avsdirectory.NewContractAVSDirectory(avsDirectoryAddr, ethclient)
 	if err != nil {
-		logger.Error("Failed to fetch AVSDirectory contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch AVSDirectory contract"), err)
 	}
 
 	return &EigenlayerContractBindings{
@@ -112,50 +108,43 @@ func NewAVSRegistryContractBindings(
 		ethclient,
 	)
 	if err != nil {
-		logger.Error("Failed to fetch BLSRegistryCoordinator contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to create BLSRegistryCoordinator contract"), err)
 	}
 
 	serviceManagerAddr, err := contractBlsRegistryCoordinator.ServiceManager(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to fetch ServiceManager address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch ServiceManager address"), err)
 	}
 	contractServiceManager, err := servicemanager.NewContractServiceManagerBase(
 		serviceManagerAddr,
 		ethclient,
 	)
 	if err != nil {
-		logger.Error("Failed to fetch ServiceManager contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch ServiceManager contract"), err)
 	}
 
 	stakeregistryAddr, err := contractBlsRegistryCoordinator.StakeRegistry(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to fetch StakeRegistry address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch StakeRegistry address"), err)
 	}
 	contractStakeRegistry, err := stakeregistry.NewContractStakeRegistry(
 		stakeregistryAddr,
 		ethclient,
 	)
 	if err != nil {
-		logger.Error("Failed to fetch StakeRegistry contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch StakeRegistry contract"), err)
 	}
 
 	blsApkRegistryAddr, err := contractBlsRegistryCoordinator.BlsApkRegistry(&bind.CallOpts{})
 	if err != nil {
-		logger.Error("Failed to fetch BLSPubkeyRegistry address", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch BLSPubkeyRegistry address"), err)
 	}
 	contractBlsApkRegistry, err := blsapkregistry.NewContractBLSApkRegistry(
 		blsApkRegistryAddr,
 		ethclient,
 	)
 	if err != nil {
-		logger.Error("Failed to fetch BLSPubkeyRegistry contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch BLSPubkeyRegistry contract"), err)
 	}
 
 	contractOperatorStateRetriever, err := opstateretriever.NewContractOperatorStateRetriever(
@@ -163,8 +152,7 @@ func NewAVSRegistryContractBindings(
 		ethclient,
 	)
 	if err != nil {
-		logger.Error("Failed to fetch OperatorStateRetriever contract", "err", err)
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to fetch OperatorStateRetriever contract"), err)
 	}
 
 	return &AvsRegistryContractBindings{

--- a/metrics/collectors/economic/economic.go
+++ b/metrics/collectors/economic/economic.go
@@ -114,8 +114,7 @@ func (ec *Collector) initOperatorId() error {
 	if ec.operatorId == [32]byte{} {
 		operatorId, err := ec.avsRegistryReader.GetOperatorId(&bind.CallOpts{}, ec.operatorAddr)
 		if err != nil {
-			ec.logger.Error("Failed to get operator id", "err", err)
-			return err
+			return errors.Join(errors.New("Failed to get operator id"), err)
 		}
 		if operatorId == [32]byte{} {
 			return errors.New("operator not registered")

--- a/metrics/collectors/economic/economic.go
+++ b/metrics/collectors/economic/economic.go
@@ -114,7 +114,7 @@ func (ec *Collector) initOperatorId() error {
 	if ec.operatorId == [32]byte{} {
 		operatorId, err := ec.avsRegistryReader.GetOperatorId(&bind.CallOpts{}, ec.operatorAddr)
 		if err != nil {
-			return errors.Join(errors.New("Failed to get operator id"), err)
+			return types.WrapError(errors.New("Failed to get operator id"), err)
 		}
 		if operatorId == [32]byte{} {
 			return errors.New("operator not registered")

--- a/metrics/eigenmetrics.go
+++ b/metrics/eigenmetrics.go
@@ -3,6 +3,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
@@ -86,9 +87,10 @@ func (m *EigenMetrics) Start(ctx context.Context, reg prometheus.Gatherer) <-cha
 		))
 		err := http.ListenAndServe(m.ipPortAddress, nil)
 		if err != nil {
-			m.logger.Error("Prometheus server failed", "err", err)
+			errC <- errors.Join(errors.New("Prometheus server failed"), err)
+		} else {
+			errC <- nil
 		}
-		errC <- err
 	}()
 	return errC
 }

--- a/metrics/eigenmetrics.go
+++ b/metrics/eigenmetrics.go
@@ -87,7 +87,7 @@ func (m *EigenMetrics) Start(ctx context.Context, reg prometheus.Gatherer) <-cha
 		))
 		err := http.ListenAndServe(m.ipPortAddress, nil)
 		if err != nil {
-			errC <- errors.Join(errors.New("Prometheus server failed"), err)
+			errC <- types.WrapError(errors.New("Prometheus server failed"), err)
 		} else {
 			errC <- nil
 		}

--- a/nodeapi/nodeapi.go
+++ b/nodeapi/nodeapi.go
@@ -5,7 +5,7 @@ package nodeapi
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -86,8 +86,7 @@ func (api *NodeApi) UpdateServiceStatus(serviceId string, serviceStatus ServiceS
 			return nil
 		}
 	}
-	api.logger.Error("Service not found", "serviceId", serviceId)
-	return errors.New("service not found")
+	return fmt.Errorf("Service with serviceId %v not found", serviceId)
 }
 
 func (api *NodeApi) DeregisterService(serviceId string) error {
@@ -97,8 +96,7 @@ func (api *NodeApi) DeregisterService(serviceId string) error {
 			return nil
 		}
 	}
-	api.logger.Error("Service not found", "serviceId", serviceId)
-	return errors.New("service not found")
+	return fmt.Errorf("Service with serviceId %v not found", serviceId)
 }
 
 // Start starts the node api server in a goroutine

--- a/services/avsregistry/avsregistry_chaincaller.go
+++ b/services/avsregistry/avsregistry_chaincaller.go
@@ -37,7 +37,7 @@ func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context
 	// Get operator state for each quorum by querying BLSOperatorStateRetriever (this call is why this service implementation is called ChainCaller)
 	operatorsStakesInQuorums, err := ar.AvsRegistryReader.GetOperatorsStakeInQuorumsAtBlock(&bind.CallOpts{Context: ctx}, quorumNumbers, blockNumber)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get operator state"), err)
+		return nil, types.WrapError(errors.New("Failed to get operator state"), err)
 	}
 	numquorums := len(quorumNumbers)
 	if len(operatorsStakesInQuorums) != numquorums {
@@ -48,7 +48,7 @@ func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context
 		for _, operator := range operatorsStakesInQuorums[quorumIdx] {
 			pubkeys, err := ar.getOperatorPubkeys(ctx, operator.OperatorId)
 			if err != nil {
-				return nil, errors.Join(errors.New("Failed to find pubkeys for operator while building operatorsAvsState"), err)
+				return nil, types.WrapError(errors.New("Failed to find pubkeys for operator while building operatorsAvsState"), err)
 			}
 			if operatorAvsState, ok := operatorsAvsState[operator.OperatorId]; ok {
 				operatorAvsState.StakePerQuorum[quorumNum] = operator.Stake
@@ -72,7 +72,7 @@ func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context
 func (ar *AvsRegistryServiceChainCaller) GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error) {
 	operatorsAvsState, err := ar.GetOperatorsAvsStateAtBlock(ctx, quorumNumbers, blockNumber)
 	if err != nil {
-		return nil, errors.Join(errors.New("Failed to get quorum state"), err)
+		return nil, types.WrapError(errors.New("Failed to get quorum state"), err)
 	}
 	quorumsAvsState := make(map[types.QuorumNum]types.QuorumAvsState)
 	for _, quorumNum := range quorumNumbers {
@@ -105,11 +105,11 @@ func (ar *AvsRegistryServiceChainCaller) GetQuorumsAvsStateAtBlock(ctx context.C
 func (ar *AvsRegistryServiceChainCaller) getOperatorPubkeys(ctx context.Context, operatorId types.OperatorId) (types.OperatorPubkeys, error) {
 	operatorAddr, err := ar.AvsRegistryReader.GetOperatorFromId(&bind.CallOpts{Context: ctx}, operatorId)
 	if err != nil {
-		return types.OperatorPubkeys{}, errors.Join(errors.New("Failed to get operator address from pubkey hash"), err)
+		return types.OperatorPubkeys{}, types.WrapError(errors.New("Failed to get operator address from pubkey hash"), err)
 	}
 	pubkeys, ok := ar.operatorPubkeysService.GetOperatorPubkeys(ctx, operatorAddr)
 	if !ok {
-		return types.OperatorPubkeys{}, errors.Join(fmt.Errorf("Failed to get operator pubkeys from pubkey compendium service (operatorAddr: %v, operatorId: %v)", operatorAddr, operatorId), err)
+		return types.OperatorPubkeys{}, types.WrapError(fmt.Errorf("Failed to get operator pubkeys from pubkey compendium service (operatorAddr: %v, operatorId: %v)", operatorAddr, operatorId), err)
 	}
 	return pubkeys, nil
 }

--- a/services/avsregistry/avsregistry_chaincaller.go
+++ b/services/avsregistry/avsregistry_chaincaller.go
@@ -2,6 +2,8 @@ package avsregistry
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/big"
 
 	avsregistry "github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
@@ -35,8 +37,7 @@ func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context
 	// Get operator state for each quorum by querying BLSOperatorStateRetriever (this call is why this service implementation is called ChainCaller)
 	operatorsStakesInQuorums, err := ar.AvsRegistryReader.GetOperatorsStakeInQuorumsAtBlock(&bind.CallOpts{Context: ctx}, quorumNumbers, blockNumber)
 	if err != nil {
-		ar.logger.Error("Failed to get operator state", "err", err, "service", "AvsRegistryServiceChainCaller")
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get operator state"), err)
 	}
 	numquorums := len(quorumNumbers)
 	if len(operatorsStakesInQuorums) != numquorums {
@@ -47,8 +48,7 @@ func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context
 		for _, operator := range operatorsStakesInQuorums[quorumIdx] {
 			pubkeys, err := ar.getOperatorPubkeys(ctx, operator.OperatorId)
 			if err != nil {
-				ar.logger.Error("Failed find pubkeys for operator while building operatorsAvsState", "err", err, "service", "AvsRegistryServiceChainCaller")
-				return nil, err
+				return nil, errors.Join(errors.New("Failed to find pubkeys for operator while building operatorsAvsState"), err)
 			}
 			if operatorAvsState, ok := operatorsAvsState[operator.OperatorId]; ok {
 				operatorAvsState.StakePerQuorum[quorumNum] = operator.Stake
@@ -72,8 +72,7 @@ func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context
 func (ar *AvsRegistryServiceChainCaller) GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error) {
 	operatorsAvsState, err := ar.GetOperatorsAvsStateAtBlock(ctx, quorumNumbers, blockNumber)
 	if err != nil {
-		ar.logger.Error("Failed to get quorum state", "err", err, "service", "AvsRegistryServiceChainCaller")
-		return nil, err
+		return nil, errors.Join(errors.New("Failed to get quorum state"), err)
 	}
 	quorumsAvsState := make(map[types.QuorumNum]types.QuorumAvsState)
 	for _, quorumNum := range quorumNumbers {
@@ -106,13 +105,11 @@ func (ar *AvsRegistryServiceChainCaller) GetQuorumsAvsStateAtBlock(ctx context.C
 func (ar *AvsRegistryServiceChainCaller) getOperatorPubkeys(ctx context.Context, operatorId types.OperatorId) (types.OperatorPubkeys, error) {
 	operatorAddr, err := ar.AvsRegistryReader.GetOperatorFromId(&bind.CallOpts{Context: ctx}, operatorId)
 	if err != nil {
-		ar.logger.Error("Failed to get operator address from pubkey hash", "err", err, "service", "AvsRegistryServiceChainCaller")
-		return types.OperatorPubkeys{}, err
+		return types.OperatorPubkeys{}, errors.Join(errors.New("Failed to get operator address from pubkey hash"), err)
 	}
 	pubkeys, ok := ar.operatorPubkeysService.GetOperatorPubkeys(ctx, operatorAddr)
 	if !ok {
-		ar.logger.Error("Failed to get operator pubkeys from pubkey compendium service", "service", "AvsRegistryServiceChainCaller", "operatorAddr", operatorAddr, "operatorId", operatorId)
-		return types.OperatorPubkeys{}, err
+		return types.OperatorPubkeys{}, errors.Join(fmt.Errorf("Failed to get operator pubkeys from pubkey compendium service (operatorAddr: %v, operatorId: %v)", operatorAddr, operatorId), err)
 	}
 	return pubkeys, nil
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -276,7 +276,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 				indices, err := a.avsRegistryService.GetCheckSignaturesIndices(&bind.CallOpts{}, taskCreatedBlock, quorumNumbers, nonSignersOperatorIds)
 				if err != nil {
 					a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-						Err: errors.Join(errors.New("Failed to get check signatures indices"), err),
+						Err: types.WrapError(errors.New("Failed to get check signatures indices"), err),
 					}
 					return
 				}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -275,9 +275,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 				}
 				indices, err := a.avsRegistryService.GetCheckSignaturesIndices(&bind.CallOpts{}, taskCreatedBlock, quorumNumbers, nonSignersOperatorIds)
 				if err != nil {
-					a.logger.Error("Failed to get check signatures indices", "err", err)
 					a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-						Err: err,
+						Err: errors.Join(errors.New("Failed to get check signatures indices"), err),
 					}
 					return
 				}
@@ -347,11 +346,9 @@ func (a *BlsAggregatorService) verifySignature(
 	)
 	signatureVerified, err := signedTaskResponseDigest.BlsSignature.Verify(operatorG2Pubkey, signedTaskResponseDigest.TaskResponseDigest)
 	if err != nil {
-		a.logger.Error(SignatureVerificationError(err).Error())
 		return SignatureVerificationError(err)
 	}
 	if !signatureVerified {
-		a.logger.Error(IncorrectSignatureError.Error())
 		return IncorrectSignatureError
 	}
 	return nil

--- a/signer/basic_signer.go
+++ b/signer/basic_signer.go
@@ -10,12 +10,13 @@ import (
 	sdkethclient "github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/utils"
+	"github.com/Layr-Labs/eigensdk-go/types"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 // exported as the default so that users can call NewBasicSigner with it if they don't know any better
@@ -39,7 +40,7 @@ func NewBasicSigner(
 
 	accountAddress, err := utils.EcdsaPrivateKeyToAddress(privateKey)
 	if err != nil {
-		return nil, errors.Join(errors.New("Cannot get account address"), err)
+		return nil, types.WrapError(errors.New("Cannot get account address"), err)
 	}
 
 	return &BasicSigner{
@@ -59,11 +60,11 @@ func NewBasicSigner(
 func (s *BasicSigner) GetNoSendTransactOpts() (*bind.TransactOpts, error) {
 	chainIDBigInt, err := s.ethClient.ChainID(context.Background())
 	if err != nil {
-		return nil, errors.Join(errors.New("Cannot get chainId"), err)
+		return nil, types.WrapError(errors.New("Cannot get chainId"), err)
 	}
 	opts, err := bind.NewKeyedTransactorWithChainID(s.privateKey, chainIDBigInt)
 	if err != nil {
-		return nil, errors.Join(errors.New("Cannot create NoSendTransactOpts"), err)
+		return nil, types.WrapError(errors.New("Cannot create NoSendTransactOpts"), err)
 	}
 	opts.NoSend = true
 	return opts, nil
@@ -79,9 +80,9 @@ func (s *BasicSigner) GetNoSendTransactOpts() (*bind.TransactOpts, error) {
 // https://github.com/ethereum-optimism/optimism/blob/ec266098641820c50c39c31048aa4e953bece464/batch-submitter/drivers/sequencer/driver.go#L314
 func (s *BasicSigner) EstimateGasPriceAndLimitAndSendTx(
 	ctx context.Context,
-	tx *types.Transaction,
+	tx *gethtypes.Transaction,
 	tag string,
-) (*types.Receipt, error) {
+) (*gethtypes.Receipt, error) {
 	s.logger.Debug("Entering EstimateGasPriceAndLimitAndSendTx function...")
 	defer s.logger.Debug("Exiting EstimateGasPriceAndLimitAndSendTx function...")
 
@@ -122,7 +123,7 @@ func (s *BasicSigner) EstimateGasPriceAndLimitAndSendTx(
 
 	opts, err := bind.NewKeyedTransactorWithChainID(s.privateKey, tx.ChainId())
 	if err != nil {
-		return nil, errors.Join(errors.New("Cannot create transactOpts"), err)
+		return nil, types.WrapError(errors.New("Cannot create transactOpts"), err)
 	}
 	opts.Context = ctx
 	opts.Nonce = new(big.Int).SetUint64(tx.Nonce())
@@ -141,7 +142,7 @@ func (s *BasicSigner) EstimateGasPriceAndLimitAndSendTx(
 
 	tx, err = contract.RawTransact(opts, tx.Data())
 	if err != nil {
-		return nil, errors.Join(fmt.Errorf("Failed to send transaction with tag: %v", tag), err)
+		return nil, types.WrapError(fmt.Errorf("Failed to send transaction with tag: %v", tag), err)
 	}
 
 	receipt, err := s.EnsureTransactionEvaled(
@@ -155,10 +156,10 @@ func (s *BasicSigner) EstimateGasPriceAndLimitAndSendTx(
 	return receipt, err
 }
 
-func (s *BasicSigner) EnsureTransactionEvaled(tx *types.Transaction, tag string) (*types.Receipt, error) {
+func (s *BasicSigner) EnsureTransactionEvaled(tx *gethtypes.Transaction, tag string) (*gethtypes.Receipt, error) {
 	receipt, err := bind.WaitMined(context.Background(), s.ethClient, tx)
 	if err != nil {
-		return nil, errors.Join(fmt.Errorf("Failed to wait for transaction to mine with tag: %v", tag), err)
+		return nil, types.WrapError(fmt.Errorf("Failed to wait for transaction to mine with tag: %v", tag), err)
 	}
 	if receipt.Status != 1 {
 		return nil, fmt.Errorf("Transaction failed (tag: %v, txHash: %v, status: %v, gasUsed: %v)", tag, tx.Hash().Hex(), receipt.Status, receipt.GasUsed)

--- a/types/errors.go
+++ b/types/errors.go
@@ -37,6 +37,6 @@ var (
 	ErrReadingMetadataUrlResponse = errors.New("error reading metadata url body")
 )
 
-func wrapError(mainErr error, subErr error) error {
+func WrapError(mainErr error, subErr error) error {
 	return fmt.Errorf("%s: %s", mainErr.Error(), subErr.Error())
 }

--- a/types/operator.go
+++ b/types/operator.go
@@ -45,7 +45,7 @@ func (o Operator) Validate() error {
 
 	err := checkIfUrlIsValid(o.MetadataUrl)
 	if err != nil {
-		return wrapError(ErrInvalidMetadataUrl, err)
+		return WrapError(ErrInvalidMetadataUrl, err)
 	}
 
 	resp, err := http.Get(o.MetadataUrl)
@@ -62,7 +62,7 @@ func (o Operator) Validate() error {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return wrapError(ErrReadingMetadataUrlResponse, err)
+		return WrapError(ErrReadingMetadataUrlResponse, err)
 	}
 
 	operatorMetadata := OperatorMetadata{}

--- a/types/operator_metadata.go
+++ b/types/operator_metadata.go
@@ -71,14 +71,14 @@ func (om *OperatorMetadata) Validate() error {
 	if len(om.Website) != 0 {
 		err := checkIfUrlIsValid(om.Website)
 		if err != nil {
-			return wrapError(ErrInvalidWebsiteUrl, err)
+			return WrapError(ErrInvalidWebsiteUrl, err)
 		}
 	}
 
 	if len(om.Twitter) != 0 {
 		err := checkIfUrlIsValid(om.Twitter)
 		if err != nil {
-			return wrapError(ErrInvalidTwitterUrl, err)
+			return WrapError(ErrInvalidTwitterUrl, err)
 		}
 	}
 

--- a/types/operator_metadata_test.go
+++ b/types/operator_metadata_test.go
@@ -108,7 +108,7 @@ func TestOperatorMetadata(t *testing.T) {
 				Twitter:     "https://twitter.com/test",
 				Website:     "https",
 			},
-			expectedError: wrapError(ErrInvalidWebsiteUrl, ErrInvalidUrl),
+			expectedError: WrapError(ErrInvalidWebsiteUrl, ErrInvalidUrl),
 		},
 		{
 			name: "Invalid metadata - invalid website url #2",
@@ -119,7 +119,7 @@ func TestOperatorMetadata(t *testing.T) {
 				Twitter:     "https://twitter.com/test",
 				Website:     "https:/test.com",
 			},
-			expectedError: wrapError(ErrInvalidWebsiteUrl, ErrInvalidUrl),
+			expectedError: WrapError(ErrInvalidWebsiteUrl, ErrInvalidUrl),
 		},
 		{
 			name: "Invalid metadata - invalid website url #3",
@@ -130,7 +130,7 @@ func TestOperatorMetadata(t *testing.T) {
 				Twitter:     "https://twitter.com/test",
 				Website:     "ps://test.com",
 			},
-			expectedError: wrapError(ErrInvalidWebsiteUrl, ErrInvalidUrl),
+			expectedError: WrapError(ErrInvalidWebsiteUrl, ErrInvalidUrl),
 		},
 		{
 			name: "Invalid metadata - invalid twitter url #1",
@@ -141,7 +141,7 @@ func TestOperatorMetadata(t *testing.T) {
 				Twitter:     "http",
 				Website:     "https://test.com",
 			},
-			expectedError: wrapError(ErrInvalidTwitterUrl, ErrInvalidUrl),
+			expectedError: WrapError(ErrInvalidTwitterUrl, ErrInvalidUrl),
 		},
 		{
 			name: "Invalid metadata - invalid twitter url #2",
@@ -152,7 +152,7 @@ func TestOperatorMetadata(t *testing.T) {
 				Twitter:     "ht://twitter.com/test",
 				Website:     "https://test.com",
 			},
-			expectedError: wrapError(ErrInvalidTwitterUrl, ErrInvalidUrl),
+			expectedError: WrapError(ErrInvalidTwitterUrl, ErrInvalidUrl),
 		},
 		{
 			name: "Invalid metadata - invalid twitter url #3",
@@ -163,7 +163,7 @@ func TestOperatorMetadata(t *testing.T) {
 				Twitter:     "https:/twitt",
 				Website:     "https://test.com",
 			},
-			expectedError: wrapError(ErrInvalidTwitterUrl, ErrInvalidUrl),
+			expectedError: WrapError(ErrInvalidTwitterUrl, ErrInvalidUrl),
 		},
 	}
 

--- a/types/operator_test.go
+++ b/types/operator_test.go
@@ -47,7 +47,7 @@ func TestOperatorValidate(t *testing.T) {
 				MetadataUrl:               "",
 			},
 			wantErr:     true,
-			expectedErr: wrapError(ErrInvalidMetadataUrl, ErrEmptyUrl),
+			expectedErr: WrapError(ErrInvalidMetadataUrl, ErrEmptyUrl),
 		},
 		{
 			name: "failed operator validation - localhost metadata url",
@@ -59,7 +59,7 @@ func TestOperatorValidate(t *testing.T) {
 				MetadataUrl:               "http://localhost:8080/metadata.json",
 			},
 			wantErr:     true,
-			expectedErr: wrapError(ErrInvalidMetadataUrl, ErrUrlPointingToLocalServer),
+			expectedErr: WrapError(ErrInvalidMetadataUrl, ErrUrlPointingToLocalServer),
 		},
 		{
 			name: "failed operator validation - 127.0.0.1 metadata url",
@@ -71,7 +71,7 @@ func TestOperatorValidate(t *testing.T) {
 				MetadataUrl:               "http://127.0.0.1:8080/metadata.json",
 			},
 			wantErr:     true,
-			expectedErr: wrapError(ErrInvalidMetadataUrl, ErrUrlPointingToLocalServer),
+			expectedErr: WrapError(ErrInvalidMetadataUrl, ErrUrlPointingToLocalServer),
 		},
 		{
 			name: "failed operator validation - bad metadata",


### PR DESCRIPTION
some avs teams who are forking our clients and remove some contracts such as the apkRegistry end up with bugs here, and the errors were not informative, so added logging lines for them.