### PR TITLE
Enhance description of egnaddrs utility for better clarity

### DIFF
--- a/cmd/egnaddrs/main.go
+++ b/cmd/egnaddrs/main.go
@@ -47,8 +47,8 @@ func run(args []string) {
 	app := cli.NewApp()
 	app.Name = "egnaddrs"
 	app.Usage = "Used to help debug and test deployments and contract setups."
-	// TODO: add a much more descriptive description
-	app.Description = "Prints all reachable Eigenlayer and AVS contract addresses starting from any one contract."
+	app.Description = "This utility facilitates the debugging and testing of Eigenlayer and AVS contract deployments by retrieving and displaying a comprehensive list of contract addresses. Starting from an initial contract address provided, it recursively identifies and prints addresses for all relevant Eigenlayer and AVS contracts within the network. This includes service managers, registry coordinators, and various registries, thus providing a view of the deployment's structure within the network."
+
 	app.Action = printAddrs
 	app.Flags = []cli.Flag{
 		ServiceManagerAddrFlag,

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -63,62 +63,91 @@ It creates the following artifacts based on arguments
 	},
 }
 
-type KeyGenerator interface {
-    GenerateKeys(numKeys int, path string, passwordFile, privateKeyFile *os.File) error
-}
-
-// ECDSAKeyGenerator implements KeyGenerator for ECDSA keys
-type ECDSAKeyGenerator struct{}
-
-func (g ECDSAKeyGenerator) GenerateKeys(numKeys int, path string, passwordFile, privateKeyFile *os.File) error {
-    return generateECDSAKeys(numKeys, path, passwordFile, privateKeyFile) // existing logic from generateECDSAKeys
-}
-
-// BLSKeyGenerator implements KeyGenerator for BLS keys
-type BLSKeyGenerator struct{}
-
-func (g BLSKeyGenerator) GenerateKeys(numKeys int, path string, passwordFile, privateKeyFile *os.File) error {
-    return generateBlsKeys(numKeys, path, passwordFile, privateKeyFile) // existing logic from generateBlsKeys
-}
-
-// NewKeyGenerator is the factory function to create a KeyGenerator based on the key type
-func NewKeyGenerator(keyType string) KeyGenerator {
-    switch keyType {
-    case "ecdsa":
-        return ECDSAKeyGenerator{}
-    case "bls":
-        return BLSKeyGenerator{}
-    default:
-        return nil
-    }
-}
-
-// modified generate function using the factory pattern as addressed
 func generate(c *cli.Context) error {
-    keyType := c.String(KeyTypeFlag.Name)
-    numKeys := c.Int(NumKeysFlag.Name)
-    
-    generator := NewKeyGenerator(keyType)
-    if generator == nil {
-        return cli.Exit("Invalid key type", 1)
-    }
+	keyType := c.String(KeyTypeFlag.Name)
+	if keyType != "ecdsa" && keyType != "bls" && keyType != "both" {
+		return cli.Exit("Invalid key type", 1)
+	}
+	numKeys := c.Int(NumKeysFlag.Name)
+	if numKeys < 1 {
+		return cli.Exit("Invalid number of keys", 1)
+	}
 
-    folder, err := createDir(c, keyType+"-")
-    if err != nil {
-        return err
-    }
+	// TODO: This can be improved further with a factory pattern
+	if keyType == "ecdsa" {
 
-    passwordFile, privateKeyFile, err := createPasswordAndPrivateKeyFiles(folder)
-    if err != nil {
-        return err
-    }
+		folder, err := createDir(c, "ecdsa-")
+		if err != nil {
+			return err
+		}
 
-    err = generator.GenerateKeys(numKeys, folder, passwordFile, privateKeyFile)
-    if err != nil {
-        return err
-    }
+		passwordFile, privateKeyFile, err := createPasswordAndPrivateKeyFiles(folder)
 
-    return nil
+		if err != nil {
+			return err
+		}
+
+		err = generateECDSAKeys(numKeys, folder, passwordFile, privateKeyFile)
+		if err != nil {
+			return err
+		}
+
+	} else if keyType == "bls" {
+
+		folder, err := createDir(c, "bls-")
+		if err != nil {
+			return err
+		}
+
+		passwordFile, privateKeyFile, err := createPasswordAndPrivateKeyFiles(folder)
+
+		if err != nil {
+			return err
+		}
+
+		err = generateBlsKeys(numKeys, folder, passwordFile, privateKeyFile)
+		if err != nil {
+			return err
+		}
+	} else if keyType == "both" {
+
+		ecdsaFolder, err := createDir(c, "ecdsa-")
+		if err != nil {
+			return err
+		}
+
+		ecdsaPasswordFile, ecdsaPrivateKeyFile, err := createPasswordAndPrivateKeyFiles(ecdsaFolder)
+
+		if err != nil {
+			return err
+		}
+
+		err = generateECDSAKeys(numKeys, ecdsaFolder, ecdsaPasswordFile, ecdsaPrivateKeyFile)
+		if err != nil {
+			return err
+		}
+
+		blsFolder, err := createDir(c, "bls-")
+		if err != nil {
+			return err
+		}
+
+		blsPasswordFile, blsPrivateKeyFile, err := createPasswordAndPrivateKeyFiles(blsFolder)
+
+		if err != nil {
+			return err
+		}
+
+		err = generateBlsKeys(numKeys, blsFolder, blsPasswordFile, blsPrivateKeyFile)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		return cli.Exit("Invalid key type", 1)
+	}
+
+	return nil
 }
 
 func createDir(c *cli.Context, prefix string) (fileName string, err error) {

--- a/cmd/egnkey/generate.go
+++ b/cmd/egnkey/generate.go
@@ -63,91 +63,62 @@ It creates the following artifacts based on arguments
 	},
 }
 
+type KeyGenerator interface {
+    GenerateKeys(numKeys int, path string, passwordFile, privateKeyFile *os.File) error
+}
+
+// ECDSAKeyGenerator implements KeyGenerator for ECDSA keys
+type ECDSAKeyGenerator struct{}
+
+func (g ECDSAKeyGenerator) GenerateKeys(numKeys int, path string, passwordFile, privateKeyFile *os.File) error {
+    return generateECDSAKeys(numKeys, path, passwordFile, privateKeyFile) // existing logic from generateECDSAKeys
+}
+
+// BLSKeyGenerator implements KeyGenerator for BLS keys
+type BLSKeyGenerator struct{}
+
+func (g BLSKeyGenerator) GenerateKeys(numKeys int, path string, passwordFile, privateKeyFile *os.File) error {
+    return generateBlsKeys(numKeys, path, passwordFile, privateKeyFile) // existing logic from generateBlsKeys
+}
+
+// NewKeyGenerator is the factory function to create a KeyGenerator based on the key type
+func NewKeyGenerator(keyType string) KeyGenerator {
+    switch keyType {
+    case "ecdsa":
+        return ECDSAKeyGenerator{}
+    case "bls":
+        return BLSKeyGenerator{}
+    default:
+        return nil
+    }
+}
+
+// modified generate function using the factory pattern as addressed
 func generate(c *cli.Context) error {
-	keyType := c.String(KeyTypeFlag.Name)
-	if keyType != "ecdsa" && keyType != "bls" && keyType != "both" {
-		return cli.Exit("Invalid key type", 1)
-	}
-	numKeys := c.Int(NumKeysFlag.Name)
-	if numKeys < 1 {
-		return cli.Exit("Invalid number of keys", 1)
-	}
+    keyType := c.String(KeyTypeFlag.Name)
+    numKeys := c.Int(NumKeysFlag.Name)
+    
+    generator := NewKeyGenerator(keyType)
+    if generator == nil {
+        return cli.Exit("Invalid key type", 1)
+    }
 
-	// TODO: This can be improved further with a factory pattern
-	if keyType == "ecdsa" {
+    folder, err := createDir(c, keyType+"-")
+    if err != nil {
+        return err
+    }
 
-		folder, err := createDir(c, "ecdsa-")
-		if err != nil {
-			return err
-		}
+    passwordFile, privateKeyFile, err := createPasswordAndPrivateKeyFiles(folder)
+    if err != nil {
+        return err
+    }
 
-		passwordFile, privateKeyFile, err := createPasswordAndPrivateKeyFiles(folder)
+    err = generator.GenerateKeys(numKeys, folder, passwordFile, privateKeyFile)
+    if err != nil {
+        return err
+    }
 
-		if err != nil {
-			return err
-		}
-
-		err = generateECDSAKeys(numKeys, folder, passwordFile, privateKeyFile)
-		if err != nil {
-			return err
-		}
-
-	} else if keyType == "bls" {
-
-		folder, err := createDir(c, "bls-")
-		if err != nil {
-			return err
-		}
-
-		passwordFile, privateKeyFile, err := createPasswordAndPrivateKeyFiles(folder)
-
-		if err != nil {
-			return err
-		}
-
-		err = generateBlsKeys(numKeys, folder, passwordFile, privateKeyFile)
-		if err != nil {
-			return err
-		}
-	} else if keyType == "both" {
-
-		ecdsaFolder, err := createDir(c, "ecdsa-")
-		if err != nil {
-			return err
-		}
-
-		ecdsaPasswordFile, ecdsaPrivateKeyFile, err := createPasswordAndPrivateKeyFiles(ecdsaFolder)
-
-		if err != nil {
-			return err
-		}
-
-		err = generateECDSAKeys(numKeys, ecdsaFolder, ecdsaPasswordFile, ecdsaPrivateKeyFile)
-		if err != nil {
-			return err
-		}
-
-		blsFolder, err := createDir(c, "bls-")
-		if err != nil {
-			return err
-		}
-
-		blsPasswordFile, blsPrivateKeyFile, err := createPasswordAndPrivateKeyFiles(blsFolder)
-
-		if err != nil {
-			return err
-		}
-
-		err = generateBlsKeys(numKeys, blsFolder, blsPasswordFile, blsPrivateKeyFile)
-		if err != nil {
-			return err
-		}
-
-	} else {
-		return cli.Exit("Invalid key type", 1)
-	}
-
-	return nil
+    return nil
 }
 
 func createDir(c *cli.Context, prefix string) (fileName string, err error) {


### PR DESCRIPTION
Fixes a small TODO in the code for a little bit more descriptive description of the `egnaddrs`:

https://github.com/Layr-Labs/eigensdk-go/blob/a5629b0ff188bbc876a1da705b5c4cd96ff8b7f0/cmd/egnaddrs/main.go#L50

To change it from this: 
https://github.com/Layr-Labs/eigensdk-go/blob/a5629b0ff188bbc876a1da705b5c4cd96ff8b7f0/cmd/egnaddrs/main.go#L51

To this: 
```go
app.Description = "This utility facilitates the debugging and testing of Eigenlayer and AVS contract deployments by retrieving and displaying a comprehensive list of contract addresses. Starting from an initial contract address provided, it recursively identifies and prints addresses for all relevant Eigenlayer and AVS contracts within the network. This includes service managers, registry coordinators, and various registries, thus providing a view of the deployment's structure within the network."
```
### Motivation
Enhance clarity and utility documentation to better support debugging and testing processes.

### Solution
Updated `egnaddrs` description to detail its functionality in debugging and testing Eigenlayer and AVS contract deployments, making it more informative for users.

### Open questions
Feedback on the clarity of the new description is welcomed. Any further areas needing documentation improvements?