### PR TITLE
Fix variable size bytes output for operator id fn

### DIFF
--- a/crypto/bls/attestation.go
+++ b/crypto/bls/attestation.go
@@ -144,7 +144,7 @@ func (s *Signature) Verify(pubkey *G2Point, message [32]byte) (bool, error) {
 func (p *G1Point) GetOperatorID() OperatorId {
 	x := p.X.BigInt(new(big.Int))
 	y := p.Y.BigInt(new(big.Int))
-	return crypto.Keccak256Hash(append(x.Bytes(), y.Bytes()...))
+	return crypto.Keccak256Hash(append(x.FillBytes(new([32]byte)[:]), y.FillBytes(new([32]byte)[:])...))
 }
 
 type PrivateKey = fr.Element


### PR DESCRIPTION
### Motivation
current impl of `GetOperatorID()` uses `big.Int.Bytes()` fn which is not fixed in size
for values such as:
```
g1.x = 5057380699593752404133723351400442269436321976269356819697538492070112962825
g1.y = 63181752827174633838690742712527804366333094176439493577707800024549061549

g1.x.Bytes() = 0x0b2e6043f9172f0910023e406597d9c42571c7b810c35052c896ddaaee96a909
g1.y.Bytes() = 0x23c27576442b69b7d8497b55ced346743564d58ef3e070578ed99d64c673ad
id = 0x62abc5097efdd84a760cc6b55661f858379fe409aecd9e50e9dc92b22af5c0a0
```
the g1.y.Bytes() is not [32]byte sized and produces an invalid pubkey hash

### Solution
using the `FillBytes(new([32]byte)[:])` we use proper fixed sized byte arrays to produce the hash
```
g1.x.Bytes() = 0x0b2e6043f9172f0910023e406597d9c42571c7b810c35052c896ddaaee96a909
g1.y.Bytes() = 0x0023c27576442b69b7d8497b55ced346743564d58ef3e070578ed99d64c673ad
id = 0x011f431d33c8ac9df5f8b5aab5d52747bcbd268c11bd4403042d216757f8959c
```