### PR TITLE
Updates to slog to make it the default feature-full logger

### DIFF
--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"runtime"
@@ -22,44 +23,34 @@ type SLogger struct {
 
 var _ Logger = (*SLogger)(nil)
 
-func NewSlogTextLogger(env LogLevel) *SLogger {
-	var handler slog.Handler
-	if env == Production {
-		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelInfo, // prints info and above (default behavior but we add to be explicit)
-		}).
-			WithAttrs([]slog.Attr{slog.String("env", string(env))}) // add a default tag with env name
-	} else if env == Development {
-		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			AddSource: true,            // we add source information in development mode only
-			Level:     slog.LevelDebug, // prints debug and above
-		}).
-			WithAttrs([]slog.Attr{slog.String("env", string(env))}) // add a default tag with env name
-	} else {
-		panic(fmt.Sprintf("Unknown environment. Expected %s or %s. Received %s.", Development, Production, env))
-	}
+// NewSlogTextLogger creates a new SLogger with a text handler
+//
+//	outputWriter is the writer to write the logs to (typically os.Stdout,
+//	  but can also use a io.MultiWriter(os.Stdout, file) to write to multiple outputs)
+//	logLevel is the minimum level to log
+//	logSource if true, adds source information to the log
+func NewSlogTextLogger(outputWriter io.Writer, logLevel slog.Level, logSource bool) *SLogger {
+	handler := slog.NewTextHandler(outputWriter, &slog.HandlerOptions{
+		Level:     logLevel, // prints debug and above
+		AddSource: logSource,
+	})
 	logger := slog.New(handler)
 	return &SLogger{
 		logger,
 	}
 }
 
-func NewSlogJsonLogger(env LogLevel) *SLogger {
-	var handler slog.Handler
-	if env == Production {
-		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelInfo, // prints info and above (default behavior but we add to be explicit)
-		}).
-			WithAttrs([]slog.Attr{slog.String("env", string(env))}) // add a default tag with env name
-	} else if env == Development {
-		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			AddSource: true,            // we add source information in development mode only
-			Level:     slog.LevelDebug, // prints debug and above
-		}).
-			WithAttrs([]slog.Attr{slog.String("env", string(env))}) // add a default tag with env name
-	} else {
-		panic(fmt.Sprintf("Unknown environment. Expected %s or %s. Received %s.", Development, Production, env))
-	}
+// NewSlogJsonLogger creates a new SLogger with a Json handler
+//
+//	outputWriter is the writer to write the logs to (typically os.Stdout,
+//	  but can also use a io.MultiWriter(os.Stdout, file) to write to multiple outputs)
+//	logLevel is the minimum level to log
+//	logSource if true, adds source information to the log
+func NewSlogJsonLogger(outputWriter io.Writer, logLevel slog.Level, logSource bool) *SLogger {
+	handler := slog.NewJSONHandler(outputWriter, &slog.HandlerOptions{
+		Level:     logLevel, // prints debug and above
+		AddSource: logSource,
+	})
 	logger := slog.New(handler)
 	return &SLogger{
 		logger,

--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -18,15 +18,13 @@ var _ Logger = (*SLogger)(nil)
 
 // NewSlogTextLogger creates a new SLogger with a text handler
 //
-//	outputWriter is the writer to write the logs to (typically os.Stdout,
-//	  but can also use a io.MultiWriter(os.Stdout, file) to write to multiple outputs)
-//	logLevel is the minimum level to log
-//	logSource if true, adds source information to the log
-func NewSlogTextLogger(outputWriter io.Writer, logLevel slog.Level, logSource bool) *SLogger {
-	handler := slog.NewTextHandler(outputWriter, &slog.HandlerOptions{
-		Level:     logLevel, // prints logLevel and above
-		AddSource: logSource,
-	})
+//		outputWriter is the writer to write the logs to (typically os.Stdout,
+//		  but can also use a io.MultiWriter(os.Stdout, file) to write to multiple outputs)
+//	 	handlerOptions is the options for the handler, such as
+//		Level is the minimum level to log
+//		AddSource if true, adds source information to the log
+func NewSlogTextLogger(outputWriter io.Writer, handlerOpts *slog.HandlerOptions) *SLogger {
+	handler := slog.NewTextHandler(outputWriter, handlerOpts)
 	logger := slog.New(handler)
 	return &SLogger{
 		logger,
@@ -35,15 +33,13 @@ func NewSlogTextLogger(outputWriter io.Writer, logLevel slog.Level, logSource bo
 
 // NewSlogJsonLogger creates a new SLogger with a Json handler
 //
-//	outputWriter is the writer to write the logs to (typically os.Stdout,
-//	  but can also use a io.MultiWriter(os.Stdout, file) to write to multiple outputs)
-//	logLevel is the minimum level to log
-//	logSource if true, adds source information to the log
-func NewSlogJsonLogger(outputWriter io.Writer, logLevel slog.Level, logSource bool) *SLogger {
-	handler := slog.NewJSONHandler(outputWriter, &slog.HandlerOptions{
-		Level:     logLevel, // prints logLevel and above
-		AddSource: logSource,
-	})
+//		outputWriter is the writer to write the logs to (typically os.Stdout,
+//		  but can also use a io.MultiWriter(os.Stdout, file) to write to multiple outputs)
+//	 	handlerOptions is the options for the handler, such as
+//		Level is the minimum level to log
+//		AddSource if true, adds source information to the log
+func NewSlogJsonLogger(outputWriter io.Writer, handlerOpts *slog.HandlerOptions) *SLogger {
+	handler := slog.NewJSONHandler(outputWriter, handlerOpts)
 	logger := slog.New(handler)
 	return &SLogger{
 		logger,

--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -24,7 +24,7 @@ var _ Logger = (*SLogger)(nil)
 //	logSource if true, adds source information to the log
 func NewSlogTextLogger(outputWriter io.Writer, logLevel slog.Level, logSource bool) *SLogger {
 	handler := slog.NewTextHandler(outputWriter, &slog.HandlerOptions{
-		Level:     logLevel, // prints debug and above
+		Level:     logLevel, // prints logLevel and above
 		AddSource: logSource,
 	})
 	logger := slog.New(handler)
@@ -41,7 +41,7 @@ func NewSlogTextLogger(outputWriter io.Writer, logLevel slog.Level, logSource bo
 //	logSource if true, adds source information to the log
 func NewSlogJsonLogger(outputWriter io.Writer, logLevel slog.Level, logSource bool) *SLogger {
 	handler := slog.NewJSONHandler(outputWriter, &slog.HandlerOptions{
-		Level:     logLevel, // prints debug and above
+		Level:     logLevel, // prints logLevel and above
 		AddSource: logSource,
 	})
 	logger := slog.New(handler)

--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -10,13 +10,6 @@ import (
 	"time"
 )
 
-type SlogHandlerType string
-
-const (
-	SLogHandlerTypeJson     SlogHandlerType = "json" // prints debug and above
-	SLogHandlerTypeJsonText SlogHandlerType = "text" // prints info and above
-)
-
 type SLogger struct {
 	*slog.Logger
 }

--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -5,6 +5,15 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
+	"time"
+)
+
+type SlogHandlerType string
+
+const (
+	SLogHandlerTypeJson     SlogHandlerType = "json" // prints debug and above
+	SLogHandlerTypeJsonText SlogHandlerType = "text" // prints info and above
 )
 
 type SLogger struct {
@@ -13,66 +22,101 @@ type SLogger struct {
 
 var _ Logger = (*SLogger)(nil)
 
-func NewSlogLogger(env LogLevel) Logger {
+func NewSlogTextLogger(env LogLevel) Logger {
+	var levelHandler *LevelHandler
 	if env == Production {
-		jsonHandler := slog.NewJSONHandler(os.Stdout, nil).WithAttrs([]slog.Attr{slog.String("env", string(env))})
-		levelHandler := NewLevelHandler(slog.LevelInfo, jsonHandler) // production logs only info and above
-		logger := slog.New(levelHandler)
-		return &SLogger{
-			logger: logger,
-		}
+		textHandler := slog.NewTextHandler(os.Stdout, nil).WithAttrs([]slog.Attr{slog.String("env", string(env))})
+		levelHandler = NewLevelHandler(slog.LevelInfo, textHandler) // production logs only info and above
 	} else if env == Development {
-		jsonHandler := slog.NewJSONHandler(os.Stdout, nil).WithAttrs([]slog.Attr{slog.String("env", string(env))})
-		levelHandler := NewLevelHandler(slog.LevelDebug, jsonHandler) // development logs everything
-		logger := slog.New(levelHandler)
-		return &SLogger{
-			logger: logger,
-		}
+		// we add source information in development mode only
+		textHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}).WithAttrs([]slog.Attr{slog.String("env", string(env))})
+		levelHandler = NewLevelHandler(slog.LevelDebug, textHandler) // development logs everything
 	} else {
 		panic(fmt.Sprintf("Unknown environment. Expected %s or %s. Received %s.", Development, Production, env))
+	}
+	logger := slog.New(levelHandler)
+	return &SLogger{
+		logger: logger,
+	}
+}
+
+func NewSlogJsonLogger(env LogLevel) Logger {
+	var levelHandler *LevelHandler
+	if env == Production {
+		jsonHandler := slog.NewJSONHandler(os.Stdout, nil).WithAttrs([]slog.Attr{slog.String("env", string(env))})
+		levelHandler = NewLevelHandler(slog.LevelInfo, jsonHandler) // production logs only info and above
+	} else if env == Development {
+		// we add source information in development mode only
+		jsonHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}).WithAttrs([]slog.Attr{slog.String("env", string(env))})
+		levelHandler = NewLevelHandler(slog.LevelDebug, jsonHandler) // development logs everything
+	} else {
+		panic(fmt.Sprintf("Unknown environment. Expected %s or %s. Received %s.", Development, Production, env))
+	}
+	logger := slog.New(levelHandler)
+	return &SLogger{
+		logger: logger,
 	}
 }
 
 func (s SLogger) Debug(msg string, tags ...any) {
-	s.logger.Debug(msg, tags...)
+	s.logCorrectSource(slog.LevelDebug, msg, tags...)
 }
 
 func (s SLogger) Info(msg string, tags ...any) {
-	s.logger.Info(msg, tags...)
+	s.logCorrectSource(slog.LevelInfo, msg, tags...)
 }
 
 func (s SLogger) Warn(msg string, tags ...any) {
-	s.logger.Warn(msg, tags...)
+	s.logCorrectSource(slog.LevelWarn, msg, tags...)
 }
 
 func (s SLogger) Error(msg string, tags ...any) {
-	s.logger.Error(msg, tags...)
+	s.logCorrectSource(slog.LevelError, msg, tags...)
 }
 
 func (s SLogger) Fatal(msg string, tags ...any) {
-	s.logger.Error(msg, tags...)
+	s.logCorrectSource(slog.LevelError, msg, tags...)
 	os.Exit(1)
+}
+
+// logCorrectSource logs the message with the correct source information
+// adapted from https://pkg.go.dev/log/slog#example-package-Wrapping
+func (s SLogger) logCorrectSource(level slog.Level, msg string, tags ...any) {
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:]) // skip [Callers, logCorrectSource, Info/Debug/Warn/Error/Fatal]
+	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	r.Add(tags...)
+	_ = s.logger.Handler().Handle(context.Background(), r)
 }
 
 func (s SLogger) Debugf(template string, args ...interface{}) {
-	s.logger.Debug(fmt.Sprintf(template, args...))
+	s.logfCorrectSource(slog.LevelDebug, template, args...)
 }
 
 func (s SLogger) Infof(template string, args ...interface{}) {
-	s.logger.Info(fmt.Sprintf(template, args...))
+	s.logfCorrectSource(slog.LevelInfo, template, args...)
 }
 
 func (s SLogger) Warnf(template string, args ...interface{}) {
-	s.logger.Warn(fmt.Sprintf(template, args...))
+	s.logfCorrectSource(slog.LevelWarn, template, args...)
 }
 
 func (s SLogger) Errorf(template string, args ...interface{}) {
-	s.logger.Error(fmt.Sprintf(template, args...))
+	s.logfCorrectSource(slog.LevelError, template, args...)
 }
 
 func (s SLogger) Fatalf(template string, args ...interface{}) {
-	s.logger.Error(fmt.Sprintf(template, args...))
+	s.logfCorrectSource(slog.LevelError, template, args...)
 	os.Exit(1)
+}
+
+// logfCorrectSource logs the message with the correct source information
+// adapted from https://pkg.go.dev/log/slog#example-package-Wrapping
+func (s SLogger) logfCorrectSource(level slog.Level, template string, args ...interface{}) {
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:]) // skip [Callers, logfCorrectSource, Info/Debug/Warn/Error/Fatal]
+	r := slog.NewRecord(time.Now(), level, fmt.Sprintf(template, args...), pcs[0])
+	_ = s.logger.Handler().Handle(context.Background(), r)
 }
 
 // Taken from https://pkg.go.dev/log/slog@master#example-Handler-LevelHandler

--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -17,12 +17,12 @@ const (
 )
 
 type SLogger struct {
-	logger *slog.Logger
+	*slog.Logger
 }
 
 var _ Logger = (*SLogger)(nil)
 
-func NewSlogTextLogger(env LogLevel) Logger {
+func NewSlogTextLogger(env LogLevel) *SLogger {
 	var handler slog.Handler
 	if env == Production {
 		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -40,11 +40,11 @@ func NewSlogTextLogger(env LogLevel) Logger {
 	}
 	logger := slog.New(handler)
 	return &SLogger{
-		logger: logger,
+		logger,
 	}
 }
 
-func NewSlogJsonLogger(env LogLevel) Logger {
+func NewSlogJsonLogger(env LogLevel) *SLogger {
 	var handler slog.Handler
 	if env == Production {
 		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -62,7 +62,7 @@ func NewSlogJsonLogger(env LogLevel) Logger {
 	}
 	logger := slog.New(handler)
 	return &SLogger{
-		logger: logger,
+		logger,
 	}
 }
 
@@ -94,7 +94,7 @@ func (s SLogger) logCorrectSource(level slog.Level, msg string, tags ...any) {
 	runtime.Callers(3, pcs[:]) // skip [Callers, logCorrectSource, Info/Debug/Warn/Error/Fatal]
 	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
 	r.Add(tags...)
-	_ = s.logger.Handler().Handle(context.Background(), r)
+	_ = s.Handler().Handle(context.Background(), r)
 }
 
 func (s SLogger) Debugf(template string, args ...interface{}) {
@@ -124,5 +124,5 @@ func (s SLogger) logfCorrectSource(level slog.Level, template string, args ...in
 	var pcs [1]uintptr
 	runtime.Callers(3, pcs[:]) // skip [Callers, logfCorrectSource, Info/Debug/Warn/Error/Fatal]
 	r := slog.NewRecord(time.Now(), level, fmt.Sprintf(template, args...), pcs[0])
-	_ = s.logger.Handler().Handle(context.Background(), r)
+	_ = s.Handler().Handle(context.Background(), r)
 }

--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -23,36 +23,44 @@ type SLogger struct {
 var _ Logger = (*SLogger)(nil)
 
 func NewSlogTextLogger(env LogLevel) Logger {
-	var levelHandler *LevelHandler
+	var handler slog.Handler
 	if env == Production {
-		textHandler := slog.NewTextHandler(os.Stdout, nil).WithAttrs([]slog.Attr{slog.String("env", string(env))})
-		levelHandler = NewLevelHandler(slog.LevelInfo, textHandler) // production logs only info and above
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo, // prints info and above (default behavior but we add to be explicit)
+		}).
+			WithAttrs([]slog.Attr{slog.String("env", string(env))}) // add a default tag with env name
 	} else if env == Development {
-		// we add source information in development mode only
-		textHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}).WithAttrs([]slog.Attr{slog.String("env", string(env))})
-		levelHandler = NewLevelHandler(slog.LevelDebug, textHandler) // development logs everything
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			AddSource: true,            // we add source information in development mode only
+			Level:     slog.LevelDebug, // prints debug and above
+		}).
+			WithAttrs([]slog.Attr{slog.String("env", string(env))}) // add a default tag with env name
 	} else {
 		panic(fmt.Sprintf("Unknown environment. Expected %s or %s. Received %s.", Development, Production, env))
 	}
-	logger := slog.New(levelHandler)
+	logger := slog.New(handler)
 	return &SLogger{
 		logger: logger,
 	}
 }
 
 func NewSlogJsonLogger(env LogLevel) Logger {
-	var levelHandler *LevelHandler
+	var handler slog.Handler
 	if env == Production {
-		jsonHandler := slog.NewJSONHandler(os.Stdout, nil).WithAttrs([]slog.Attr{slog.String("env", string(env))})
-		levelHandler = NewLevelHandler(slog.LevelInfo, jsonHandler) // production logs only info and above
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo, // prints info and above (default behavior but we add to be explicit)
+		}).
+			WithAttrs([]slog.Attr{slog.String("env", string(env))}) // add a default tag with env name
 	} else if env == Development {
-		// we add source information in development mode only
-		jsonHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}).WithAttrs([]slog.Attr{slog.String("env", string(env))})
-		levelHandler = NewLevelHandler(slog.LevelDebug, jsonHandler) // development logs everything
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			AddSource: true,            // we add source information in development mode only
+			Level:     slog.LevelDebug, // prints debug and above
+		}).
+			WithAttrs([]slog.Attr{slog.String("env", string(env))}) // add a default tag with env name
 	} else {
 		panic(fmt.Sprintf("Unknown environment. Expected %s or %s. Received %s.", Development, Production, env))
 	}
-	logger := slog.New(levelHandler)
+	logger := slog.New(handler)
 	return &SLogger{
 		logger: logger,
 	}
@@ -117,49 +125,4 @@ func (s SLogger) logfCorrectSource(level slog.Level, template string, args ...in
 	runtime.Callers(3, pcs[:]) // skip [Callers, logfCorrectSource, Info/Debug/Warn/Error/Fatal]
 	r := slog.NewRecord(time.Now(), level, fmt.Sprintf(template, args...), pcs[0])
 	_ = s.logger.Handler().Handle(context.Background(), r)
-}
-
-// Taken from https://pkg.go.dev/log/slog@master#example-Handler-LevelHandler
-// A LevelHandler wraps a Handler with an Enabled method
-// that returns false for levels below a minimum.
-// This permits our logger to only log messages of a certain level or higher
-type LevelHandler struct {
-	level   slog.Leveler
-	handler slog.Handler
-}
-
-// NewLevelHandler returns a LevelHandler with the given level.
-// All methods except Enabled delegate to h.
-func NewLevelHandler(level slog.Leveler, h slog.Handler) *LevelHandler {
-	// Optimization: avoid chains of LevelHandlers.
-	if lh, ok := h.(*LevelHandler); ok {
-		h = lh.Handler()
-	}
-	return &LevelHandler{level, h}
-}
-
-// Enabled implements Handler.Enabled by reporting whether
-// level is at least as large as h's level.
-func (h *LevelHandler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= h.level.Level()
-}
-
-// Handle implements Handler.Handle.
-func (h *LevelHandler) Handle(ctx context.Context, r slog.Record) error {
-	return h.handler.Handle(ctx, r)
-}
-
-// WithAttrs implements Handler.WithAttrs.
-func (h *LevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return NewLevelHandler(h.level, h.handler.WithAttrs(attrs))
-}
-
-// WithGroup implements Handler.WithGroup.
-func (h *LevelHandler) WithGroup(name string) slog.Handler {
-	return NewLevelHandler(h.level, h.handler.WithGroup(name))
-}
-
-// Handler returns the Handler wrapped by h.
-func (h *LevelHandler) Handler() slog.Handler {
-	return h.handler
 }


### PR DESCRIPTION
Started looking into slog:
- https://go.dev/blog/slog
- https://www.youtube.com/watch?v=8rnI2xLrdeM

and agree with @dmanc at this point that we should probably start adopting slog as our standard logger everywhere. Been playing with it a bit and our current interface is super limiting wrt what can be done with slog (for eg can't pass a context to logging functions right now, which can be used to also log traceIds). The blog above mentions this
<img width="952" alt="image" src="https://github.com/Layr-Labs/eigensdk-go/assets/9342524/3fe6217f-b72a-42dc-95c0-78e8360246e6">

This draft PR is a wip for adding features to the slogger itself. But we'll eventually need to find a way to adapt our main interface, probably in a next PR. This will require more discussions.

Features added thus far:
- Only print required log level (production logger will only print info and above logs, whereas the development one will also print debug logs) ~~[4c03592](https://github.com/Layr-Labs/eigensdk-go/pull/127/commits/4c0359225bdb90f6a83c1ae0116f190dd7b42992)~~ Found a much easier way to do this: [df441e7](https://github.com/Layr-Labs/eigensdk-go/pull/127/commits/df441e7ad9bb8b835ef3295e8b86c5be4cfbb7c6)
- Separate constructor into two, one for TextHandler and one for JsonHandler (I'm personally becoming a big fan of golang's key-value text format) [52c50b7](https://github.com/Layr-Labs/eigensdk-go/pull/127/commits/52c50b741847ac6fc2478d61b5ca280c84e9b7f3)
- Print proper source file information (see image below*) [52c50b7](https://github.com/Layr-Labs/eigensdk-go/pull/127/commits/52c50b741847ac6fc2478d61b5ca280c84e9b7f3)
- make the slog logger an embedded struct (instead of named field) so that we have access to its method. Also return the SLogger struct instead of Logger interface from constructors so that users can use those methods (.WithGroup for eg) [d5b616a](https://github.com/Layr-Labs/eigensdk-go/pull/127/commits/d5b616ab162bf0415e9a9b3363f2c0a7761eeb63)


* because of our log interface and structs that wrap the underlying logger, the srouce information getting printed was always the wrapper location, instead of its caller, which is useless:
![image](https://github.com/Layr-Labs/eigensdk-go/assets/9342524/fae1b3c2-1574-4431-ba77-5370bbfaa318)