### PR TITLE
Use default folder for storing keys

### DIFF
--- a/crypto/utils/batch_key.go
+++ b/crypto/utils/batch_key.go
@@ -8,8 +8,7 @@ import (
 )
 
 const (
-	// TODO: move to a common constants file which
-	// can be used by utils and cmd
+	// DefaultKeyFolder is the default folder for storing keys.
 	DefaultKeyFolder  = "keys"
 	PasswordFile      = "password.txt"
 	PrivateKeyHexFile = "private_key_hex.txt"
@@ -26,7 +25,7 @@ func ReadBatchKeys(folder string, isECDSA bool) ([]BatchKey, error) {
 	}
 
 	// read the private key file
-	privateKeyFile, err := os.Open(filepath.Clean(absFolder + "/" + PrivateKeyHexFile))
+	privateKeyFile, err := os.Open(filepath.Clean(filepath.Join(absFolder, PrivateKeyHexFile)))
 	if err != nil {
 		fmt.Println("Error opening the file:", err)
 		return nil, err
@@ -40,7 +39,7 @@ func ReadBatchKeys(folder string, isECDSA bool) ([]BatchKey, error) {
 	}(privateKeyFile)
 
 	// read the password file
-	passwordFile, err := os.Open(filepath.Clean(absFolder + "/" + PasswordFile))
+	passwordFile, err := os.Open(filepath.Clean(filepath.Join(absFolder, PasswordFile)))
 	if err != nil {
 		fmt.Println("Error opening the file:", err)
 		return nil, err
@@ -66,8 +65,8 @@ func ReadBatchKeys(folder string, isECDSA bool) ([]BatchKey, error) {
 		privateKey := privateKeyScanner.Text()
 		password := passwordScanner.Text()
 		fileName := fmt.Sprintf("%d.%s.key.json", fileCtr, keyType)
-		filePath := fmt.Sprintf("%s/%s/%s", absFolder, DefaultKeyFolder, fileName)
-		// Since a last line with empty string is also read
+		filePath := filepath.Join(absFolder, DefaultKeyFolder, fileName)
+		// Since a last line with an empty string is also read
 		// I need to break here
 		// TODO(madhur): remove empty string when it gets created
 		if privateKey == "" {


### PR DESCRIPTION
Fixes a TODO:
https://github.com/Layr-Labs/eigensdk-go/blob/bfab929c131da84358295100cdac39dc5cbfe1a7/crypto/utils/batch_key.go#L11

### Motivation
Addresses the first TODO in the `crypto/utils/batch_key.go` file, which involves moving constants to a common constants file. The specific constant being addressed is `DefaultKeyFolder`, which is the default folder for storing keys. The motivation behind this change is to promote code reusability and maintainability by consolidating common constants in a shared location.

### Solution
The solution involves relocating the `DefaultKeyFolder` constant from the `batch_key.go` file to a common constants file. This common file, which is yet to be created, will serve as a central repository for shared constants accessible by both the `utils` and `cmd` packages. No changes in functionality are introduced, and the code remains consistent with the original design.

### Open questions