### PR TITLE
Refactor `generate-bindings.sh`: Improve modularity and quoting

### DIFF
--- a/contracts/generate-bindings.sh
+++ b/contracts/generate-bindings.sh
@@ -8,46 +8,65 @@ script_path=$(
 
 # build abigen-with-interfaces docker image if it doesn't exist
 if [[ "$(docker images -q abigen-with-interfaces 2> /dev/null)" == "" ]]; then
-    docker build -t abigen-with-interfaces -f abigen-with-interfaces.Dockerfile $script_path
+    docker build -t abigen-with-interfaces -f abigen-with-interfaces.Dockerfile "$script_path"
 fi
 
-# TODO: refactor this function.. it got really ugly with the dockerizing of abigen
-function create_binding {
-    contract_dir=$1
-    contract=$2
-    binding_dir=$3
-    echo $contract
-    mkdir -p $binding_dir/${contract}
-    contract_json="$contract_dir/out/${contract}.sol/${contract}.json"
-    solc_abi=$(cat ${contract_json} | jq -r '.abi')
-    solc_bin=$(cat ${contract_json} | jq -r '.bytecode.object')
+function extract_abi_bytecode {
+    local contract_json="$1"
+    local solc_abi
+    local solc_bin
+
+    solc_abi=$(cat "${contract_json}" | jq -r '.abi')
+    solc_bin=$(cat "${contract_json}" | jq -r '.bytecode.object')
 
     mkdir -p data
-    echo ${solc_abi} >data/tmp.abi
-    echo ${solc_bin} >data/tmp.bin
+    echo "${solc_abi}" > data/tmp.abi
+    echo "${solc_bin}" > data/tmp.bin
+}
 
-    rm -f $binding_dir/${contract}/binding.go
-    docker run -v $(realpath $binding_dir):/home/binding_dir -v .:/home/repo abigen-with-interfaces --bin=/home/repo/data/tmp.bin --abi=/home/repo/data/tmp.abi --pkg=contract${contract} --out=/home/binding_dir/${contract}/binding.go
+function create_directories {
+    local binding_dir="$1"
+    local contract="$2"
+    
+    mkdir -p "${binding_dir}/${contract}"
+    rm -f "${binding_dir}/${contract}/binding.go"
+}
+
+function run_docker_command {
+    local binding_dir="$1"
+    local contract="$2"
+
+    docker run -v "$(realpath "${binding_dir}"):/home/binding_dir" -v .:/home/repo abigen-with-interfaces --bin=/home/repo/data/tmp.bin --abi=/home/repo/data/tmp.abi --pkg=contract${contract} --out=/home/binding_dir/${contract}/binding.go
     rm -rf data/tmp.abi data/tmp.bin
 }
 
-EIGENLAYER_MIDDLEWARE_PATH=$script_path/lib/eigenlayer-middleware
-cd $EIGENLAYER_MIDDLEWARE_PATH
+function create_binding {
+    local contract_dir="$1"
+    local contract="$2"
+    local binding_dir="$3"
+    local contract_json="${contract_dir}/out/${contract}.sol/${contract}.json"
+
+    echo "${contract}"
+    extract_abi_bytecode "${contract_json}"
+    create_directories "${binding_dir}" "${contract}"
+    run_docker_command "${binding_dir}" "${contract}"
+}
+
+EIGENLAYER_MIDDLEWARE_PATH="${script_path}/lib/eigenlayer-middleware"
+cd "${EIGENLAYER_MIDDLEWARE_PATH}"
 # you might want to run forge clean if the contracts have changed
 forge build
 
-# No idea why but ordering of the contracts matters here... when I move them around sometimes bindings fail
 avs_contracts="RegistryCoordinator OperatorStateRetriever StakeRegistry BLSApkRegistry IBLSSignatureChecker ServiceManagerBase"
-for contract in $avs_contracts; do
-    create_binding . $contract ../../bindings
+for contract in ${avs_contracts}; do
+    create_binding . "${contract}" ../../bindings
 done
 
-EIGENLAYER_CONTRACT_PATH=$EIGENLAYER_MIDDLEWARE_PATH/lib/eigenlayer-contracts
-cd $EIGENLAYER_CONTRACT_PATH
+EIGENLAYER_CONTRACT_PATH="${EIGENLAYER_MIDDLEWARE_PATH}/lib/eigenlayer-contracts"
+cd "${EIGENLAYER_CONTRACT_PATH}"
 forge build
 
-# No idea why but the ordering of the contracts matters, and for some orderings abigen fails...
 el_contracts="DelegationManager ISlasher StrategyManager EigenPod EigenPodManager IStrategy IERC20 AVSDirectory"
-for contract in $el_contracts; do
-    create_binding . $contract ../../../../bindings
+for contract in ${el_contracts}; do
+    create_binding . "${contract}" ../../../../bindings
 done


### PR DESCRIPTION
Fixes a TODO: 
https://github.com/Layr-Labs/eigensdk-go/blob/bfab929c131da84358295100cdac39dc5cbfe1a7/contracts/generate-bindings.sh#L14

### Motivation
The primary motivation behind this pull request is to enhance the readability and maintainability of the contracts/generate-bindings.sh script. The refactoring focuses on improving the create_binding function and incorporates best practices for scripting, including proper variable quoting and modularization. 

### Solution
The key technical decisions in this pull request involve:

- **Modularization**: The `create_binding` function has been refactored into smaller, more focused functions (extract_abi_bytecode, create_directories, and run_docker_command) to improve code organization and readability.
- **Quoting**: Double quotes have been added around variable references to ensure the correct handling of spaces and special characters, reducing the risk of unexpected behavior.

### Open questions
 Feedback on the refactoring and any suggestions for further improvements are highly encouraged and appreciated. 