### PR TITLE
Add basic types with slog logvalues

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -29,30 +29,30 @@ type AvsRegistryReader interface {
 
 	GetOperatorsStakeInQuorumsAtCurrentBlock(
 		opts *bind.CallOpts,
-		quorumNumbers []byte,
+		quorumNumbers types.QuorumNums,
 	) ([][]opstateretriever.OperatorStateRetrieverOperator, error)
 
 	GetOperatorsStakeInQuorumsAtBlock(
 		opts *bind.CallOpts,
-		quorumNumbers []byte,
+		quorumNumbers types.QuorumNums,
 		blockNumber uint32,
 	) ([][]opstateretriever.OperatorStateRetrieverOperator, error)
 
 	GetOperatorAddrsInQuorumsAtCurrentBlock(
 		opts *bind.CallOpts,
-		quorumNumbers []byte,
+		quorumNumbers types.QuorumNums,
 	) ([][]common.Address, error)
 
 	GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 		opts *bind.CallOpts,
 		operatorId types.OperatorId,
 		blockNumber uint32,
-	) ([]types.QuorumNum, [][]opstateretriever.OperatorStateRetrieverOperator, error)
+	) (types.QuorumNums, [][]opstateretriever.OperatorStateRetrieverOperator, error)
 
 	GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(
 		opts *bind.CallOpts,
 		operatorId types.OperatorId,
-	) ([]types.QuorumNum, [][]opstateretriever.OperatorStateRetrieverOperator, error)
+	) (types.QuorumNums, [][]opstateretriever.OperatorStateRetrieverOperator, error)
 
 	GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(
 		opts *bind.CallOpts,
@@ -62,8 +62,8 @@ type AvsRegistryReader interface {
 	GetCheckSignaturesIndices(
 		opts *bind.CallOpts,
 		referenceBlockNumber uint32,
-		quorumNumbers []byte,
-		nonSignerOperatorIds [][32]byte,
+		quorumNumbers types.QuorumNums,
+		nonSignerOperatorIds []types.OperatorId,
 	) (opstateretriever.OperatorStateRetrieverCheckSignaturesIndices, error)
 
 	GetOperatorId(opts *bind.CallOpts, operatorAddress gethcommon.Address) ([32]byte, error)
@@ -158,7 +158,7 @@ func (r *AvsRegistryChainReader) GetQuorumCount(opts *bind.CallOpts) (uint8, err
 
 func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtCurrentBlock(
 	opts *bind.CallOpts,
-	quorumNumbers []byte,
+	quorumNumbers types.QuorumNums,
 ) ([][]opstateretriever.OperatorStateRetrieverOperator, error) {
 	if opts.Context == nil {
 		opts.Context = context.Background()
@@ -177,13 +177,13 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtCurrentBlock(
 // and the blockNumber in opts should be the block number of the latest block (or set to nil, which is equivalent)
 func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtBlock(
 	opts *bind.CallOpts,
-	quorumNumbers []byte,
+	quorumNumbers types.QuorumNums,
 	blockNumber uint32,
 ) ([][]opstateretriever.OperatorStateRetrieverOperator, error) {
 	operatorStakes, err := r.operatorStateRetriever.GetOperatorState(
 		opts,
 		r.registryCoordinatorAddr,
-		quorumNumbers,
+		quorumNumbers.Underlying(),
 		blockNumber)
 	if err != nil {
 		return nil, types.WrapError(errors.New("Failed to get operators state"), err)
@@ -193,7 +193,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtBlock(
 
 func (r *AvsRegistryChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 	opts *bind.CallOpts,
-	quorumNumbers []byte,
+	quorumNumbers types.QuorumNums,
 ) ([][]common.Address, error) {
 	if opts.Context == nil {
 		opts.Context = context.Background()
@@ -208,7 +208,7 @@ func (r *AvsRegistryChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 	operatorStakes, err := r.operatorStateRetriever.GetOperatorState(
 		opts,
 		r.registryCoordinatorAddr,
-		quorumNumbers,
+		quorumNumbers.Underlying(),
 		uint32(curBlock),
 	)
 	if err != nil {
@@ -230,7 +230,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 	opts *bind.CallOpts,
 	operatorId types.OperatorId,
 	blockNumber uint32,
-) ([]types.QuorumNum, [][]opstateretriever.OperatorStateRetrieverOperator, error) {
+) (types.QuorumNums, [][]opstateretriever.OperatorStateRetrieverOperator, error) {
 	quorumBitmap, operatorStakes, err := r.operatorStateRetriever.GetOperatorState0(
 		opts,
 		r.registryCoordinatorAddr,
@@ -248,7 +248,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(
 	opts *bind.CallOpts,
 	operatorId types.OperatorId,
-) ([]types.QuorumNum, [][]opstateretriever.OperatorStateRetrieverOperator, error) {
+) (types.QuorumNums, [][]opstateretriever.OperatorStateRetrieverOperator, error) {
 	if opts.Context == nil {
 		opts.Context = context.Background()
 	}
@@ -280,7 +280,7 @@ func (r *AvsRegistryChainReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlo
 		stake, err := r.stakeRegistry.GetCurrentStake(
 			&bind.CallOpts{},
 			operatorId,
-			quorum,
+			uint8(quorum),
 		)
 		if err != nil {
 			return nil, types.WrapError(errors.New("Failed to get operator stake"), err)
@@ -293,15 +293,19 @@ func (r *AvsRegistryChainReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlo
 func (r *AvsRegistryChainReader) GetCheckSignaturesIndices(
 	opts *bind.CallOpts,
 	referenceBlockNumber uint32,
-	quorumNumbers []byte,
-	nonSignerOperatorIds [][32]byte,
+	quorumNumbers types.QuorumNums,
+	nonSignerOperatorIds []types.OperatorId,
 ) (opstateretriever.OperatorStateRetrieverCheckSignaturesIndices, error) {
+	nonSignerOperatorIdsBytes := make([][32]byte, len(nonSignerOperatorIds))
+	for i, id := range nonSignerOperatorIds {
+		nonSignerOperatorIdsBytes[i] = id
+	}
 	checkSignatureIndices, err := r.operatorStateRetriever.GetCheckSignaturesIndices(
 		opts,
 		r.registryCoordinatorAddr,
 		referenceBlockNumber,
-		quorumNumbers,
-		nonSignerOperatorIds,
+		quorumNumbers.Underlying(),
+		nonSignerOperatorIdsBytes,
 	)
 	if err != nil {
 		return opstateretriever.OperatorStateRetrieverCheckSignaturesIndices{}, types.WrapError(errors.New("Failed to get check signatures indices"), err)
@@ -375,7 +379,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorPubKeys(
 	if err != nil {
 		return nil, nil, types.WrapError(errors.New("Cannot filter logs"), err)
 	}
-	r.logger.Info("avsRegistryChainReader.QueryExistingRegisteredOperatorPubKeys", "transactionLogs", logs)
+	r.logger.Debug("avsRegistryChainReader.QueryExistingRegisteredOperatorPubKeys", "transactionLogs", logs)
 
 	operatorAddresses := make([]types.OperatorAddr, 0)
 	operatorPubkeys := make([]types.OperatorPubkeys, 0)

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -183,7 +183,7 @@ func (r *AvsRegistryChainReader) GetOperatorsStakeInQuorumsAtBlock(
 	operatorStakes, err := r.operatorStateRetriever.GetOperatorState(
 		opts,
 		r.registryCoordinatorAddr,
-		quorumNumbers.Underlying(),
+		quorumNumbers.UnderlyingType(),
 		blockNumber)
 	if err != nil {
 		return nil, types.WrapError(errors.New("Failed to get operators state"), err)
@@ -208,7 +208,7 @@ func (r *AvsRegistryChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 	operatorStakes, err := r.operatorStateRetriever.GetOperatorState(
 		opts,
 		r.registryCoordinatorAddr,
-		quorumNumbers.Underlying(),
+		quorumNumbers.UnderlyingType(),
 		uint32(curBlock),
 	)
 	if err != nil {
@@ -304,7 +304,7 @@ func (r *AvsRegistryChainReader) GetCheckSignaturesIndices(
 		opts,
 		r.registryCoordinatorAddr,
 		referenceBlockNumber,
-		quorumNumbers.Underlying(),
+		quorumNumbers.UnderlyingType(),
 		nonSignerOperatorIdsBytes,
 	)
 	if err != nil {

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -243,7 +243,7 @@ func (w *AvsRegistryChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordina
 	// in that case, need to call churner to kick out another operator. See eigenDA's node/operator.go implementation
 	tx, err := w.registryCoordinator.RegisterOperator(
 		noSendTxOpts,
-		quorumNumbers.Underlying(),
+		quorumNumbers.UnderlyingType(),
 		socket,
 		pubkeyRegParams,
 		operatorSignatureWithSaltAndExpiry,
@@ -269,7 +269,7 @@ func (w *AvsRegistryChainWriter) UpdateStakesOfEntireOperatorSetForQuorums(
 	if err != nil {
 		return nil, err
 	}
-	tx, err := w.registryCoordinator.UpdateOperatorsForQuorum(noSendTxOpts, operatorsPerQuorum, quorumNumbers.Underlying())
+	tx, err := w.registryCoordinator.UpdateOperatorsForQuorum(noSendTxOpts, operatorsPerQuorum, quorumNumbers.UnderlyingType())
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func (w *AvsRegistryChainWriter) DeregisterOperator(
 	if err != nil {
 		return nil, err
 	}
-	tx, err := w.registryCoordinator.DeregisterOperator(noSendTxOpts, quorumNumbers.Underlying())
+	tx, err := w.registryCoordinator.DeregisterOperator(noSendTxOpts, quorumNumbers.UnderlyingType())
 	if err != nil {
 		return nil, err
 	}

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/types"
-	sdkutils "github.com/Layr-Labs/eigensdk-go/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -40,7 +39,7 @@ type AvsRegistryWriter interface {
 		operatorToAvsRegistrationSigSalt [32]byte,
 		operatorToAvsRegistrationSigExpiry *big.Int,
 		blsKeyPair *bls.KeyPair,
-		quorumNumbers []byte,
+		quorumNumbers types.QuorumNums,
 		socket string,
 	) (*gethtypes.Receipt, error)
 
@@ -52,7 +51,7 @@ type AvsRegistryWriter interface {
 	UpdateStakesOfEntireOperatorSetForQuorums(
 		ctx context.Context,
 		operatorsPerQuorum [][]gethcommon.Address,
-		quorumNumbers []byte,
+		quorumNumbers types.QuorumNums,
 	) (*gethtypes.Receipt, error)
 
 	// UpdateStakesOfOperatorSubsetForAllQuorums is meant to be used by single operators (or teams of operators,
@@ -66,7 +65,7 @@ type AvsRegistryWriter interface {
 
 	DeregisterOperator(
 		ctx context.Context,
-		quorumNumbers []byte,
+		quorumNumbers types.QuorumNums,
 		pubkey regcoord.BN254G1Point,
 	) (*gethtypes.Receipt, error)
 }
@@ -190,12 +189,12 @@ func (w *AvsRegistryChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordina
 	operatorToAvsRegistrationSigSalt [32]byte,
 	operatorToAvsRegistrationSigExpiry *big.Int,
 	blsKeyPair *bls.KeyPair,
-	quorumNumbers []byte,
+	quorumNumbers types.QuorumNums,
 	socket string,
 ) (*gethtypes.Receipt, error) {
-	w.logger.Info("registering operator with the AVS's registry coordinator")
-	// params to register bls pubkey with bls apk registry
 	operatorAddr := crypto.PubkeyToAddress(operatorEcdsaPrivateKey.PublicKey)
+	w.logger.Info("registering operator with the AVS's registry coordinator", "avs-service-manager", w.serviceManagerAddr, "operator", operatorAddr, "quorumNumbers", quorumNumbers)
+	// params to register bls pubkey with bls apk registry
 	g1HashedMsgToSign, err := w.registryCoordinator.PubkeyRegistrationMessageHash(&bind.CallOpts{}, operatorAddr)
 	if err != nil {
 		return nil, err
@@ -244,7 +243,7 @@ func (w *AvsRegistryChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordina
 	// in that case, need to call churner to kick out another operator. See eigenDA's node/operator.go implementation
 	tx, err := w.registryCoordinator.RegisterOperator(
 		noSendTxOpts,
-		quorumNumbers,
+		quorumNumbers.Underlying(),
 		socket,
 		pubkeyRegParams,
 		operatorSignatureWithSaltAndExpiry,
@@ -256,21 +255,21 @@ func (w *AvsRegistryChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordina
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Info("succesfully registered operator with AVS registry coordinator", "tx hash", receipt.TxHash.String())
+	w.logger.Info("successfully registered operator with AVS registry coordinator", "tx hash", receipt.TxHash.String(), "avs-service-manager", w.serviceManagerAddr, "operator", operatorAddr, "quorumNumbers", quorumNumbers)
 	return receipt, nil
 }
 
 func (w *AvsRegistryChainWriter) UpdateStakesOfEntireOperatorSetForQuorums(
 	ctx context.Context,
 	operatorsPerQuorum [][]gethcommon.Address,
-	quorumNumbers []byte,
+	quorumNumbers types.QuorumNums,
 ) (*gethtypes.Receipt, error) {
-	w.logger.Info("updating stakes for entire operator set", "quorumNumbers", sdkutils.ConvertQuorumsBytesToInts(quorumNumbers))
+	w.logger.Info("updating stakes for entire operator set", "quorumNumbers", quorumNumbers)
 	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
 	if err != nil {
 		return nil, err
 	}
-	tx, err := w.registryCoordinator.UpdateOperatorsForQuorum(noSendTxOpts, operatorsPerQuorum, quorumNumbers)
+	tx, err := w.registryCoordinator.UpdateOperatorsForQuorum(noSendTxOpts, operatorsPerQuorum, quorumNumbers.Underlying())
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +277,7 @@ func (w *AvsRegistryChainWriter) UpdateStakesOfEntireOperatorSetForQuorums(
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
-	w.logger.Info("succesfully updated stakes for entire operator set", "tx hash", receipt.TxHash.String(), "quorumNumbers", sdkutils.ConvertQuorumsBytesToInts(quorumNumbers))
+	w.logger.Info("succesfully updated stakes for entire operator set", "tx hash", receipt.TxHash.String(), "quorumNumbers", quorumNumbers)
 	return receipt, nil
 
 }
@@ -307,7 +306,7 @@ func (w *AvsRegistryChainWriter) UpdateStakesOfOperatorSubsetForAllQuorums(
 
 func (w *AvsRegistryChainWriter) DeregisterOperator(
 	ctx context.Context,
-	quorumNumbers []byte,
+	quorumNumbers types.QuorumNums,
 	pubkey regcoord.BN254G1Point,
 ) (*gethtypes.Receipt, error) {
 	w.logger.Info("deregistering operator with the AVS's registry coordinator")
@@ -315,7 +314,7 @@ func (w *AvsRegistryChainWriter) DeregisterOperator(
 	if err != nil {
 		return nil, err
 	}
-	tx, err := w.registryCoordinator.DeregisterOperator(noSendTxOpts, quorumNumbers)
+	tx, err := w.registryCoordinator.DeregisterOperator(noSendTxOpts, quorumNumbers.Underlying())
 	if err != nil {
 		return nil, err
 	}

--- a/chainio/mocks/avsRegistryContractsReader.go
+++ b/chainio/mocks/avsRegistryContractsReader.go
@@ -45,7 +45,7 @@ func (m *MockAvsRegistryReader) EXPECT() *MockAvsRegistryReaderMockRecorder {
 }
 
 // GetCheckSignaturesIndices mocks base method.
-func (m *MockAvsRegistryReader) GetCheckSignaturesIndices(arg0 *bind.CallOpts, arg1 uint32, arg2 []byte, arg3 [][32]byte) (contractOperatorStateRetriever.OperatorStateRetrieverCheckSignaturesIndices, error) {
+func (m *MockAvsRegistryReader) GetCheckSignaturesIndices(arg0 *bind.CallOpts, arg1 uint32, arg2 types.QuorumNums, arg3 []types.Bytes32) (contractOperatorStateRetriever.OperatorStateRetrieverCheckSignaturesIndices, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCheckSignaturesIndices", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(contractOperatorStateRetriever.OperatorStateRetrieverCheckSignaturesIndices)
@@ -60,7 +60,7 @@ func (mr *MockAvsRegistryReaderMockRecorder) GetCheckSignaturesIndices(arg0, arg
 }
 
 // GetOperatorAddrsInQuorumsAtCurrentBlock mocks base method.
-func (m *MockAvsRegistryReader) GetOperatorAddrsInQuorumsAtCurrentBlock(arg0 *bind.CallOpts, arg1 []byte) ([][]common.Address, error) {
+func (m *MockAvsRegistryReader) GetOperatorAddrsInQuorumsAtCurrentBlock(arg0 *bind.CallOpts, arg1 types.QuorumNums) ([][]common.Address, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorAddrsInQuorumsAtCurrentBlock", arg0, arg1)
 	ret0, _ := ret[0].([][]common.Address)
@@ -75,7 +75,7 @@ func (mr *MockAvsRegistryReaderMockRecorder) GetOperatorAddrsInQuorumsAtCurrentB
 }
 
 // GetOperatorFromId mocks base method.
-func (m *MockAvsRegistryReader) GetOperatorFromId(arg0 *bind.CallOpts, arg1 [32]byte) (common.Address, error) {
+func (m *MockAvsRegistryReader) GetOperatorFromId(arg0 *bind.CallOpts, arg1 types.Bytes32) (common.Address, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorFromId", arg0, arg1)
 	ret0, _ := ret[0].(common.Address)
@@ -105,10 +105,10 @@ func (mr *MockAvsRegistryReaderMockRecorder) GetOperatorId(arg0, arg1 any) *gomo
 }
 
 // GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock mocks base method.
-func (m *MockAvsRegistryReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(arg0 *bind.CallOpts, arg1 [32]byte) (map[byte]*big.Int, error) {
+func (m *MockAvsRegistryReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(arg0 *bind.CallOpts, arg1 types.Bytes32) (map[types.QuorumNum]*big.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock", arg0, arg1)
-	ret0, _ := ret[0].(map[byte]*big.Int)
+	ret0, _ := ret[0].(map[types.QuorumNum]*big.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -120,7 +120,7 @@ func (mr *MockAvsRegistryReaderMockRecorder) GetOperatorStakeInQuorumsOfOperator
 }
 
 // GetOperatorsStakeInQuorumsAtBlock mocks base method.
-func (m *MockAvsRegistryReader) GetOperatorsStakeInQuorumsAtBlock(arg0 *bind.CallOpts, arg1 []byte, arg2 uint32) ([][]contractOperatorStateRetriever.OperatorStateRetrieverOperator, error) {
+func (m *MockAvsRegistryReader) GetOperatorsStakeInQuorumsAtBlock(arg0 *bind.CallOpts, arg1 types.QuorumNums, arg2 uint32) ([][]contractOperatorStateRetriever.OperatorStateRetrieverOperator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorsStakeInQuorumsAtBlock", arg0, arg1, arg2)
 	ret0, _ := ret[0].([][]contractOperatorStateRetriever.OperatorStateRetrieverOperator)
@@ -135,7 +135,7 @@ func (mr *MockAvsRegistryReaderMockRecorder) GetOperatorsStakeInQuorumsAtBlock(a
 }
 
 // GetOperatorsStakeInQuorumsAtCurrentBlock mocks base method.
-func (m *MockAvsRegistryReader) GetOperatorsStakeInQuorumsAtCurrentBlock(arg0 *bind.CallOpts, arg1 []byte) ([][]contractOperatorStateRetriever.OperatorStateRetrieverOperator, error) {
+func (m *MockAvsRegistryReader) GetOperatorsStakeInQuorumsAtCurrentBlock(arg0 *bind.CallOpts, arg1 types.QuorumNums) ([][]contractOperatorStateRetriever.OperatorStateRetrieverOperator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorsStakeInQuorumsAtCurrentBlock", arg0, arg1)
 	ret0, _ := ret[0].([][]contractOperatorStateRetriever.OperatorStateRetrieverOperator)
@@ -150,10 +150,10 @@ func (mr *MockAvsRegistryReaderMockRecorder) GetOperatorsStakeInQuorumsAtCurrent
 }
 
 // GetOperatorsStakeInQuorumsOfOperatorAtBlock mocks base method.
-func (m *MockAvsRegistryReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(arg0 *bind.CallOpts, arg1 [32]byte, arg2 uint32) ([]byte, [][]contractOperatorStateRetriever.OperatorStateRetrieverOperator, error) {
+func (m *MockAvsRegistryReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(arg0 *bind.CallOpts, arg1 types.Bytes32, arg2 uint32) (types.QuorumNums, [][]contractOperatorStateRetriever.OperatorStateRetrieverOperator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorsStakeInQuorumsOfOperatorAtBlock", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(types.QuorumNums)
 	ret1, _ := ret[1].([][]contractOperatorStateRetriever.OperatorStateRetrieverOperator)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -166,10 +166,10 @@ func (mr *MockAvsRegistryReaderMockRecorder) GetOperatorsStakeInQuorumsOfOperato
 }
 
 // GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock mocks base method.
-func (m *MockAvsRegistryReader) GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(arg0 *bind.CallOpts, arg1 [32]byte) ([]byte, [][]contractOperatorStateRetriever.OperatorStateRetrieverOperator, error) {
+func (m *MockAvsRegistryReader) GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(arg0 *bind.CallOpts, arg1 types.Bytes32) (types.QuorumNums, [][]contractOperatorStateRetriever.OperatorStateRetrieverOperator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock", arg0, arg1)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(types.QuorumNums)
 	ret1, _ := ret[1].([][]contractOperatorStateRetriever.OperatorStateRetrieverOperator)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/chainio/mocks/avsRegistryContractsWriter.go
+++ b/chainio/mocks/avsRegistryContractsWriter.go
@@ -17,8 +17,9 @@ import (
 
 	contractRegistryCoordinator "github.com/Layr-Labs/eigensdk-go/contracts/bindings/RegistryCoordinator"
 	bls "github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	types "github.com/Layr-Labs/eigensdk-go/types"
 	common "github.com/ethereum/go-ethereum/common"
-	types "github.com/ethereum/go-ethereum/core/types"
+	types0 "github.com/ethereum/go-ethereum/core/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -46,10 +47,10 @@ func (m *MockAvsRegistryWriter) EXPECT() *MockAvsRegistryWriterMockRecorder {
 }
 
 // DeregisterOperator mocks base method.
-func (m *MockAvsRegistryWriter) DeregisterOperator(arg0 context.Context, arg1 []byte, arg2 contractRegistryCoordinator.BN254G1Point) (*types.Receipt, error) {
+func (m *MockAvsRegistryWriter) DeregisterOperator(arg0 context.Context, arg1 types.QuorumNums, arg2 contractRegistryCoordinator.BN254G1Point) (*types0.Receipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterOperator", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*types.Receipt)
+	ret0, _ := ret[0].(*types0.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -61,10 +62,10 @@ func (mr *MockAvsRegistryWriterMockRecorder) DeregisterOperator(arg0, arg1, arg2
 }
 
 // RegisterOperatorInQuorumWithAVSRegistryCoordinator mocks base method.
-func (m *MockAvsRegistryWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(arg0 context.Context, arg1 *ecdsa.PrivateKey, arg2 [32]byte, arg3 *big.Int, arg4 *bls.KeyPair, arg5 []byte, arg6 string) (*types.Receipt, error) {
+func (m *MockAvsRegistryWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(arg0 context.Context, arg1 *ecdsa.PrivateKey, arg2 [32]byte, arg3 *big.Int, arg4 *bls.KeyPair, arg5 types.QuorumNums, arg6 string) (*types0.Receipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterOperatorInQuorumWithAVSRegistryCoordinator", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
-	ret0, _ := ret[0].(*types.Receipt)
+	ret0, _ := ret[0].(*types0.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -76,10 +77,10 @@ func (mr *MockAvsRegistryWriterMockRecorder) RegisterOperatorInQuorumWithAVSRegi
 }
 
 // UpdateStakesOfEntireOperatorSetForQuorums mocks base method.
-func (m *MockAvsRegistryWriter) UpdateStakesOfEntireOperatorSetForQuorums(arg0 context.Context, arg1 [][]common.Address, arg2 []byte) (*types.Receipt, error) {
+func (m *MockAvsRegistryWriter) UpdateStakesOfEntireOperatorSetForQuorums(arg0 context.Context, arg1 [][]common.Address, arg2 types.QuorumNums) (*types0.Receipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStakesOfEntireOperatorSetForQuorums", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*types.Receipt)
+	ret0, _ := ret[0].(*types0.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -91,10 +92,10 @@ func (mr *MockAvsRegistryWriterMockRecorder) UpdateStakesOfEntireOperatorSetForQ
 }
 
 // UpdateStakesOfOperatorSubsetForAllQuorums mocks base method.
-func (m *MockAvsRegistryWriter) UpdateStakesOfOperatorSubsetForAllQuorums(arg0 context.Context, arg1 []common.Address) (*types.Receipt, error) {
+func (m *MockAvsRegistryWriter) UpdateStakesOfOperatorSubsetForAllQuorums(arg0 context.Context, arg1 []common.Address) (*types0.Receipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStakesOfOperatorSubsetForAllQuorums", arg0, arg1)
-	ret0, _ := ret[0].(*types.Receipt)
+	ret0, _ := ret[0].(*types0.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/chainio/txmgr/txmgr.go
+++ b/chainio/txmgr/txmgr.go
@@ -67,7 +67,7 @@ func NewSimpleTxManager(
 func (m *SimpleTxManager) Send(ctx context.Context, tx *types.Transaction) (*types.Receipt, error) {
 	txID, err := m.wallet.SendTransaction(ctx, tx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(errors.New("send: failed to estimate gas and nonce"), err)
 	}
 
 	receipt, err := m.waitForReceipt(ctx, txID)

--- a/crypto/bls/data.go
+++ b/crypto/bls/data.go
@@ -3,6 +3,9 @@ package bls
 // TODO: move these somewhere more appropriate.
 //
 //	these are avs types, nothing to do with bls
+//
+// also there's already an OperatorId in types, but we can't use it here because it would form a circular import
+// since types using bls.Signature.. we prob just need to move all of these types to types/avs.go or something
 type OperatorId = [32]byte
 type OperatorIndex uint
 

--- a/services/avsregistry/avsregistry.go
+++ b/services/avsregistry/avsregistry.go
@@ -13,11 +13,11 @@ import (
 type AvsRegistryService interface {
 	// GetOperatorsAvsState returns the state of an avs wrt to a list of quorums at a certain block.
 	// The state includes the operatorId, pubkey, and staking amount in each quorum.
-	GetOperatorsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.OperatorId]types.OperatorAvsState, error)
+	GetOperatorsAvsStateAtBlock(ctx context.Context, quorumNumbers types.QuorumNums, blockNumber types.BlockNum) (map[types.OperatorId]types.OperatorAvsState, error)
 	// GetQuorumsAvsStateAtBlock returns the aggregated data for a list of quorums at a certain block.
 	// The aggregated data includes the aggregated pubkey and total stake in each quorum.
 	// This information is derivable from the Operators Avs State (returned from GetOperatorsAvsStateAtBlock), but this function is provided for convenience.
-	GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error)
+	GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers types.QuorumNums, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error)
 	// GetCheckSignaturesIndices returns the registry indices of the nonsigner operators specified by nonSignerOperatorIds who were registered at referenceBlockNumber.
-	GetCheckSignaturesIndices(opts *bind.CallOpts, referenceBlockNumber types.BlockNum, quorumNumbers []types.QuorumNum, nonSignerOperatorIds []types.OperatorId) (opstateretriever.OperatorStateRetrieverCheckSignaturesIndices, error)
+	GetCheckSignaturesIndices(opts *bind.CallOpts, referenceBlockNumber types.BlockNum, quorumNumbers types.QuorumNums, nonSignerOperatorIds []types.OperatorId) (opstateretriever.OperatorStateRetrieverCheckSignaturesIndices, error)
 }

--- a/services/avsregistry/avsregistry_chaincaller.go
+++ b/services/avsregistry/avsregistry_chaincaller.go
@@ -32,7 +32,7 @@ func NewAvsRegistryServiceChainCaller(avsRegistryReader avsregistry.AvsRegistryR
 	}
 }
 
-func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.OperatorId]types.OperatorAvsState, error) {
+func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context.Context, quorumNumbers types.QuorumNums, blockNumber types.BlockNum) (map[types.OperatorId]types.OperatorAvsState, error) {
 	operatorsAvsState := make(map[types.OperatorId]types.OperatorAvsState)
 	// Get operator state for each quorum by querying BLSOperatorStateRetriever (this call is why this service implementation is called ChainCaller)
 	operatorsStakesInQuorums, err := ar.AvsRegistryReader.GetOperatorsStakeInQuorumsAtBlock(&bind.CallOpts{Context: ctx}, quorumNumbers, blockNumber)
@@ -69,7 +69,7 @@ func (ar *AvsRegistryServiceChainCaller) GetOperatorsAvsStateAtBlock(ctx context
 	return operatorsAvsState, nil
 }
 
-func (ar *AvsRegistryServiceChainCaller) GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error) {
+func (ar *AvsRegistryServiceChainCaller) GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers types.QuorumNums, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error) {
 	operatorsAvsState, err := ar.GetOperatorsAvsStateAtBlock(ctx, quorumNumbers, blockNumber)
 	if err != nil {
 		return nil, types.WrapError(errors.New("Failed to get quorum state"), err)

--- a/services/avsregistry/avsregistry_chaincaller_test.go
+++ b/services/avsregistry/avsregistry_chaincaller_test.go
@@ -92,7 +92,7 @@ func TestAvsRegistryServiceChainCaller_GetOperatorsAvsState(t *testing.T) {
 	var tests = []struct {
 		name                      string
 		mocksInitializationFunc   func(*chainiomocks.MockAvsRegistryReader, *servicemocks.MockOperatorPubkeysService)
-		queryQuorumNumbers        []types.QuorumNum
+		queryQuorumNumbers        types.QuorumNums
 		queryBlockNum             types.BlockNum
 		wantErr                   error
 		wantOperatorsAvsStateDict map[types.OperatorId]types.OperatorAvsState
@@ -100,7 +100,7 @@ func TestAvsRegistryServiceChainCaller_GetOperatorsAvsState(t *testing.T) {
 		{
 			name: "should return operatorsAvsState",
 			mocksInitializationFunc: func(mockAvsRegistryReader *chainiomocks.MockAvsRegistryReader, mockOperatorPubkeysService *servicemocks.MockOperatorPubkeysService) {
-				mockAvsRegistryReader.EXPECT().GetOperatorsStakeInQuorumsAtBlock(gomock.Any(), []types.QuorumNum{1}, types.BlockNum(1)).Return([][]opstateretrievar.OperatorStateRetrieverOperator{
+				mockAvsRegistryReader.EXPECT().GetOperatorsStakeInQuorumsAtBlock(gomock.Any(), types.QuorumNums{1}, types.BlockNum(1)).Return([][]opstateretrievar.OperatorStateRetrieverOperator{
 					{
 						{
 							OperatorId: testOperator.operatorId,
@@ -111,7 +111,7 @@ func TestAvsRegistryServiceChainCaller_GetOperatorsAvsState(t *testing.T) {
 				mockAvsRegistryReader.EXPECT().GetOperatorFromId(gomock.Any(), testOperator.operatorId).Return(testOperator.operatorAddr, nil)
 				mockOperatorPubkeysService.EXPECT().GetOperatorPubkeys(gomock.Any(), testOperator.operatorAddr).Return(testOperator.pubkeys, true)
 			},
-			queryQuorumNumbers: []types.QuorumNum{1},
+			queryQuorumNumbers: types.QuorumNums{1},
 			queryBlockNum:      1,
 			wantErr:            nil,
 			wantOperatorsAvsStateDict: map[types.OperatorId]types.OperatorAvsState{
@@ -164,7 +164,7 @@ func TestAvsRegistryServiceChainCaller_GetQuorumsAvsState(t *testing.T) {
 	var tests = []struct {
 		name                    string
 		mocksInitializationFunc func(*chainiomocks.MockAvsRegistryReader, *servicemocks.MockOperatorPubkeysService)
-		queryQuorumNumbers      []types.QuorumNum
+		queryQuorumNumbers      types.QuorumNums
 		queryBlockNum           types.BlockNum
 		wantErr                 error
 		wantQuorumsAvsStateDict map[types.QuorumNum]types.QuorumAvsState
@@ -172,7 +172,7 @@ func TestAvsRegistryServiceChainCaller_GetQuorumsAvsState(t *testing.T) {
 		{
 			name: "should return operatorsAvsState",
 			mocksInitializationFunc: func(mockAvsRegistryReader *chainiomocks.MockAvsRegistryReader, mockOperatorPubkeysService *servicemocks.MockOperatorPubkeysService) {
-				mockAvsRegistryReader.EXPECT().GetOperatorsStakeInQuorumsAtBlock(gomock.Any(), []types.QuorumNum{1}, types.BlockNum(1)).Return([][]opstateretrievar.OperatorStateRetrieverOperator{
+				mockAvsRegistryReader.EXPECT().GetOperatorsStakeInQuorumsAtBlock(gomock.Any(), types.QuorumNums{1}, types.BlockNum(1)).Return([][]opstateretrievar.OperatorStateRetrieverOperator{
 					{
 						{
 							OperatorId: testOperator.operatorId,
@@ -183,7 +183,7 @@ func TestAvsRegistryServiceChainCaller_GetQuorumsAvsState(t *testing.T) {
 				mockAvsRegistryReader.EXPECT().GetOperatorFromId(gomock.Any(), testOperator.operatorId).Return(testOperator.operatorAddr, nil)
 				mockOperatorPubkeysService.EXPECT().GetOperatorPubkeys(gomock.Any(), testOperator.operatorAddr).Return(testOperator.pubkeys, true)
 			},
-			queryQuorumNumbers: []types.QuorumNum{1},
+			queryQuorumNumbers: types.QuorumNums{1},
 			queryBlockNum:      1,
 			wantErr:            nil,
 			wantQuorumsAvsStateDict: map[types.QuorumNum]types.QuorumAvsState{

--- a/services/avsregistry/avsregistry_fake.go
+++ b/services/avsregistry/avsregistry_fake.go
@@ -34,7 +34,7 @@ func NewFakeAvsRegistryService(blockNum types.BlockNum, operators []types.TestOp
 
 var _ AvsRegistryService = (*FakeAvsRegistryService)(nil)
 
-func (f *FakeAvsRegistryService) GetOperatorsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.OperatorId]types.OperatorAvsState, error) {
+func (f *FakeAvsRegistryService) GetOperatorsAvsStateAtBlock(ctx context.Context, quorumNumbers types.QuorumNums, blockNumber types.BlockNum) (map[types.OperatorId]types.OperatorAvsState, error) {
 	operatorsAvsState, ok := f.operators[blockNumber]
 	if !ok {
 		return nil, errors.New("block number not found")
@@ -42,7 +42,7 @@ func (f *FakeAvsRegistryService) GetOperatorsAvsStateAtBlock(ctx context.Context
 	return operatorsAvsState, nil
 }
 
-func (f *FakeAvsRegistryService) GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers []types.QuorumNum, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error) {
+func (f *FakeAvsRegistryService) GetQuorumsAvsStateAtBlock(ctx context.Context, quorumNumbers types.QuorumNums, blockNumber types.BlockNum) (map[types.QuorumNum]types.QuorumAvsState, error) {
 	operatorsAvsState, ok := f.operators[blockNumber]
 	if !ok {
 		return nil, errors.New("block number not found")
@@ -70,7 +70,7 @@ func (f *FakeAvsRegistryService) GetQuorumsAvsStateAtBlock(ctx context.Context, 
 
 func (f *FakeAvsRegistryService) GetCheckSignaturesIndices(
 	opts *bind.CallOpts, referenceBlockNumber types.BlockNum,
-	quorumNumbers []types.QuorumNum, nonSignerOperatorIds []types.OperatorId,
+	quorumNumbers types.QuorumNums, nonSignerOperatorIds []types.OperatorId,
 ) (opstateretriever.OperatorStateRetrieverCheckSignaturesIndices, error) {
 	return opstateretriever.OperatorStateRetrieverCheckSignaturesIndices{}, nil
 }

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -31,7 +31,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		blockNum := uint32(1)
 		taskIndex := types.TaskIndex(0)
-		quorumNumbers := []types.QuorumNum{0}
+		quorumNumbers := types.QuorumNums{0}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{100}
 		taskResponseDigest := types.TaskResponseDigest{123}
 		blsSig := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
@@ -74,7 +74,7 @@ func TestBlsAgg(t *testing.T) {
 			BlsKeypair:     newBlsKeyPairPanics("0x3"),
 		}
 		taskIndex := types.TaskIndex(0)
-		quorumNumbers := []types.QuorumNum{0}
+		quorumNumbers := types.QuorumNums{0}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{100}
 		taskResponseDigest := types.TaskResponseDigest{123}
 		blockNum := uint32(1)
@@ -127,7 +127,7 @@ func TestBlsAgg(t *testing.T) {
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 		}
 		taskIndex := types.TaskIndex(0)
-		quorumNumbers := []types.QuorumNum{0, 1}
+		quorumNumbers := types.QuorumNums{0, 1}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{100, 100}
 		taskResponseDigest := types.TaskResponseDigest{123}
 		blockNum := uint32(1)
@@ -172,7 +172,7 @@ func TestBlsAgg(t *testing.T) {
 			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 		}
-		quorumNumbers := []types.QuorumNum{0, 1}
+		quorumNumbers := types.QuorumNums{0, 1}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{100, 100}
 		blockNum := uint32(1)
 
@@ -248,7 +248,7 @@ func TestBlsAgg(t *testing.T) {
 			BlsKeypair:     newBlsKeyPairPanics("0x1"),
 		}
 		taskIndex := types.TaskIndex(0)
-		quorumNumbers := []types.QuorumNum{0}
+		quorumNumbers := types.QuorumNums{0}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{100}
 		blockNum := uint32(1)
 
@@ -277,7 +277,7 @@ func TestBlsAgg(t *testing.T) {
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 		}
 		taskIndex := types.TaskIndex(0)
-		quorumNumbers := []types.QuorumNum{0}
+		quorumNumbers := types.QuorumNums{0}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{50}
 		taskResponseDigest := types.TaskResponseDigest{123}
 		blsSig := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
@@ -317,7 +317,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		blockNum := uint32(1)
 		taskIndex := types.TaskIndex(0)
-		quorumNumbers := []types.QuorumNum{0}
+		quorumNumbers := types.QuorumNums{0}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{60}
 		taskResponseDigest := types.TaskResponseDigest{123}
 		blsSig := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
@@ -371,7 +371,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		blockNum := uint32(1)
 		taskIndex := types.TaskIndex(0)
-		quorumNumbers := []types.QuorumNum{0}
+		quorumNumbers := types.QuorumNums{0}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{100}
 
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
@@ -419,7 +419,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		blockNum := uint32(1)
 		taskIndex := types.TaskIndex(0)
-		quorumNumbers := []types.QuorumNum{0}
+		quorumNumbers := types.QuorumNums{0}
 		quorumThresholdPercentages := []types.QuorumThresholdPercentage{100}
 
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1, testOperator2})

--- a/services/mocks/avsregistry.go
+++ b/services/mocks/avsregistry.go
@@ -42,7 +42,7 @@ func (m *MockAvsRegistryService) EXPECT() *MockAvsRegistryServiceMockRecorder {
 }
 
 // GetCheckSignaturesIndices mocks base method.
-func (m *MockAvsRegistryService) GetCheckSignaturesIndices(arg0 *bind.CallOpts, arg1 uint32, arg2 []byte, arg3 [][32]byte) (contractOperatorStateRetriever.OperatorStateRetrieverCheckSignaturesIndices, error) {
+func (m *MockAvsRegistryService) GetCheckSignaturesIndices(arg0 *bind.CallOpts, arg1 uint32, arg2 types.QuorumNums, arg3 []types.Bytes32) (contractOperatorStateRetriever.OperatorStateRetrieverCheckSignaturesIndices, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCheckSignaturesIndices", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(contractOperatorStateRetriever.OperatorStateRetrieverCheckSignaturesIndices)
@@ -57,10 +57,10 @@ func (mr *MockAvsRegistryServiceMockRecorder) GetCheckSignaturesIndices(arg0, ar
 }
 
 // GetOperatorsAvsStateAtBlock mocks base method.
-func (m *MockAvsRegistryService) GetOperatorsAvsStateAtBlock(arg0 context.Context, arg1 []byte, arg2 uint32) (map[[32]byte]types.OperatorAvsState, error) {
+func (m *MockAvsRegistryService) GetOperatorsAvsStateAtBlock(arg0 context.Context, arg1 types.QuorumNums, arg2 uint32) (map[types.Bytes32]types.OperatorAvsState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorsAvsStateAtBlock", arg0, arg1, arg2)
-	ret0, _ := ret[0].(map[[32]byte]types.OperatorAvsState)
+	ret0, _ := ret[0].(map[types.Bytes32]types.OperatorAvsState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -72,10 +72,10 @@ func (mr *MockAvsRegistryServiceMockRecorder) GetOperatorsAvsStateAtBlock(arg0, 
 }
 
 // GetQuorumsAvsStateAtBlock mocks base method.
-func (m *MockAvsRegistryService) GetQuorumsAvsStateAtBlock(arg0 context.Context, arg1 []byte, arg2 uint32) (map[byte]types.QuorumAvsState, error) {
+func (m *MockAvsRegistryService) GetQuorumsAvsStateAtBlock(arg0 context.Context, arg1 types.QuorumNums, arg2 uint32) (map[types.QuorumNum]types.QuorumAvsState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetQuorumsAvsStateAtBlock", arg0, arg1, arg2)
-	ret0, _ := ret[0].(map[byte]types.QuorumAvsState)
+	ret0, _ := ret[0].(map[types.QuorumNum]types.QuorumAvsState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/services/mocks/blsagg/blsaggregation.go
+++ b/services/mocks/blsagg/blsaggregation.go
@@ -57,7 +57,7 @@ func (mr *MockBlsAggregationServiceMockRecorder) GetResponseChannel() *gomock.Ca
 }
 
 // InitializeNewTask mocks base method.
-func (m *MockBlsAggregationService) InitializeNewTask(arg0, arg1 uint32, arg2 []byte, arg3 []uint32, arg4 time.Duration) error {
+func (m *MockBlsAggregationService) InitializeNewTask(arg0, arg1 uint32, arg2 types.QuorumNums, arg3 types.QuorumThresholdPercentages, arg4 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitializeNewTask", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -71,7 +71,7 @@ func (mr *MockBlsAggregationServiceMockRecorder) InitializeNewTask(arg0, arg1, a
 }
 
 // ProcessNewSignature mocks base method.
-func (m *MockBlsAggregationService) ProcessNewSignature(arg0 context.Context, arg1 uint32, arg2 types.TaskResponseDigest, arg3 *bls.Signature, arg4 [32]byte) error {
+func (m *MockBlsAggregationService) ProcessNewSignature(arg0 context.Context, arg1 uint32, arg2 types.Bytes32, arg3 *bls.Signature, arg4 [32]byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessNewSignature", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)

--- a/services/operatorpubkeys/operatorpubkeys_inmemory.go
+++ b/services/operatorpubkeys/operatorpubkeys_inmemory.go
@@ -106,7 +106,7 @@ func (ops *OperatorPubkeysServiceInMemory) startServiceInGoroutine(ctx context.C
 					G2Pubkey: bls.NewG2Point(newPubkeyRegistrationEvent.PubkeyG2.X, newPubkeyRegistrationEvent.PubkeyG2.Y),
 				}
 				ops.logger.Debug("Added operator pubkeys to pubkey dict",
-					"service", "OperatorPubkeysServiceInMemory", "operatorAddr", operatorAddr,
+					"service", "OperatorPubkeysServiceInMemory", "block", newPubkeyRegistrationEvent.Raw.BlockNumber, "operatorAddr", operatorAddr,
 					"G1pubkey", pubkeyDict[operatorAddr].G1Pubkey, "G2pubkey", pubkeyDict[operatorAddr].G2Pubkey,
 				)
 			// Receive a query from GetOperatorPubkeys

--- a/types/avs.go
+++ b/types/avs.go
@@ -1,13 +1,25 @@
 package types
 
-import "github.com/Layr-Labs/eigensdk-go/crypto/bls"
+import (
+	"log/slog"
+
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+)
 
 type TaskIndex = uint32
-type TaskResponseDigest [32]byte
+type TaskResponseDigest = Bytes32
 
 type SignedTaskResponseDigest struct {
 	TaskResponseDigest          TaskResponseDigest
 	BlsSignature                *bls.Signature
-	OperatorId                  bls.OperatorId
-	SignatureVerificationErrorC chan error
+	OperatorId                  OperatorId
+	SignatureVerificationErrorC chan error `json:"-"` // removed from json because channels are not marshallable
+}
+
+func (strd SignedTaskResponseDigest) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Any("taskResponseDigest", strd.TaskResponseDigest),
+		slog.Any("blsSignature", strd.BlsSignature),
+		slog.Any("operatorId", strd.OperatorId),
+	)
 }

--- a/types/basic.go
+++ b/types/basic.go
@@ -14,6 +14,6 @@ func (m Bytes32) LogValue() slog.Value {
 	return slog.StringValue(hex.EncodeToString(m[:]))
 }
 
-func (m *Bytes32) GetUnderlyingBytes() []byte {
-	return m[:]
+func (m *Bytes32) UnderlyingType() [32]byte {
+	return *m
 }

--- a/types/basic.go
+++ b/types/basic.go
@@ -1,0 +1,19 @@
+package types
+
+// This file defines internal types that have custom LogValues (for go's slog), to make debugging easier
+
+import (
+	"encoding/hex"
+	"log/slog"
+)
+
+// make TaskResponseDigests print as hex encoded strings instead of a sequence of bytes
+type Bytes32 [32]byte
+
+func (m Bytes32) LogValue() slog.Value {
+	return slog.StringValue(hex.EncodeToString(m[:]))
+}
+
+func (m *Bytes32) GetUnderlyingBytes() []byte {
+	return m[:]
+}

--- a/types/operator.go
+++ b/types/operator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/big"
 	"net/http"
 
@@ -88,9 +89,50 @@ type StakeAmount = *big.Int
 
 // OperatorId is the ID of an operator, defined by the AVS registry
 // It is currently the hash of the operator's G1 pubkey (in the bls pubkey registry)
-type OperatorId = [32]byte
-type QuorumNum = uint8
-type QuorumThresholdPercentage = uint32
+type OperatorId = Bytes32
+type QuorumNums []QuorumNum
+
+func (q QuorumNums) LogValue() slog.Value {
+	return slog.StringValue(fmt.Sprintf("%v", q))
+}
+
+func (q QuorumNums) Underlying() []uint8 {
+	underlying := make([]uint8, len(q))
+	for i, v := range q {
+		underlying[i] = v.Underlying()
+	}
+	return underlying
+}
+
+type QuorumNum uint8
+
+func (q QuorumNum) LogValue() slog.Value {
+	return slog.StringValue(fmt.Sprintf("%d", q))
+}
+func (q QuorumNum) Underlying() uint8 {
+	return uint8(q)
+}
+
+type QuorumThresholdPercentages []QuorumThresholdPercentage
+
+func (q QuorumThresholdPercentages) LogValue() slog.Value {
+	return slog.StringValue(fmt.Sprintf("%v", q))
+}
+
+func (q QuorumThresholdPercentages) Underlying() []uint8 {
+	underlying := make([]uint8, len(q))
+	for i, v := range q {
+		underlying[i] = uint8(v)
+	}
+	return underlying
+}
+
+type QuorumThresholdPercentage uint8
+
+func (q QuorumThresholdPercentage) LogValue() slog.Value {
+	return slog.StringValue(fmt.Sprintf("%d", q))
+}
+
 type BlockNum = uint32
 
 // AvsOperator represents the operator state in AVS registries

--- a/types/operator.go
+++ b/types/operator.go
@@ -96,10 +96,10 @@ func (q QuorumNums) LogValue() slog.Value {
 	return slog.StringValue(fmt.Sprintf("%v", q))
 }
 
-func (q QuorumNums) Underlying() []uint8 {
+func (q QuorumNums) UnderlyingType() []uint8 {
 	underlying := make([]uint8, len(q))
 	for i, v := range q {
-		underlying[i] = v.Underlying()
+		underlying[i] = v.UnderlyingType()
 	}
 	return underlying
 }
@@ -109,7 +109,7 @@ type QuorumNum uint8
 func (q QuorumNum) LogValue() slog.Value {
 	return slog.StringValue(fmt.Sprintf("%d", q))
 }
-func (q QuorumNum) Underlying() uint8 {
+func (q QuorumNum) UnderlyingType() uint8 {
 	return uint8(q)
 }
 
@@ -119,7 +119,7 @@ func (q QuorumThresholdPercentages) LogValue() slog.Value {
 	return slog.StringValue(fmt.Sprintf("%v", q))
 }
 
-func (q QuorumThresholdPercentages) Underlying() []uint8 {
+func (q QuorumThresholdPercentages) UnderlyingType() []uint8 {
 	underlying := make([]uint8, len(q))
 	for i, v := range q {
 		underlying[i] = uint8(v)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -76,11 +76,3 @@ func IsValidEthereumAddress(address string) bool {
 	re := regexp.MustCompile("^0x[0-9a-fA-F]{40}$")
 	return re.MatchString(address)
 }
-
-func ConvertQuorumsBytesToInts(quorums []byte) []int {
-	var quorumsInts []int
-	for _, quorum := range quorums {
-		quorumsInts = append(quorumsInts, int(quorum))
-	}
-	return quorumsInts
-}


### PR DESCRIPTION
Some of our core types were hard to read because they were logged as base64 encoded values, or just long byte strings.
This PR creates a few new basic types that have slog LogValues to print them in a more human-readable way.