### PR TITLE
image-type-error-msg-spacing-fix

### DIFF
--- a/types/errors.go
+++ b/types/errors.go
@@ -21,7 +21,7 @@ var (
 
 	ErrInvalidImageMimeType  = errors.New("invalid image mime-type. only png is supported")
 	ErrInvalidImageExtension = errors.New(
-		"invalid image extension. only " + strings.Join(ImageExtensions, ",") + "is supported",
+		"invalid image extension. only " + strings.Join(ImageExtensions, ",") + " is supported",
 	)
 
 	// Metadata Errors


### PR DESCRIPTION
Fixes # 
<img width="377" alt="Screenshot 2024-03-11 at 2 39 30 AM" src="https://github.com/Layr-Labs/eigensdk-go/assets/119534349/860c6f07-0259-407a-afce-a6a50c717cc4">
There is a space missing after the supported extensions.

### Motivation
The primary motivation behind this pull request is to enhance the readability of the error message that is logged on the console when the type of the image in the logo URL is not in the supported list of extensions.

### Solution
Added a space after the supported types of extensions for the logo image to enhance the readability.