### PR TITLE
Remove signer from txn manager

### DIFF
--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -80,11 +80,11 @@ func BuildAll(
 		panic(err)
 	}
 
-	txSender, err := wallet.NewPrivateKeyWallet(ethHttpClient, signerV2, addr, logger)
+	pkWallet, err := wallet.NewPrivateKeyWallet(ethHttpClient, signerV2, addr, logger)
 	if err != nil {
 		return nil, types.WrapError(errors.New("Failed to create transaction sender"), err)
 	}
-	txMgr := txmgr.NewSimpleTxManager(txSender, ethHttpClient, logger, signerV2, addr)
+	txMgr := txmgr.NewSimpleTxManager(pkWallet, ethHttpClient, logger, addr)
 	// creating EL clients: Reader, Writer and Subscriber
 	elChainReader, elChainWriter, err := config.buildElClients(
 		ethHttpClient,

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -194,7 +194,7 @@ func (w *ELChainWriter) DepositERC20IntoStrategy(
 
 	tx, err := underlyingTokenContract.Approve(noSendTxOpts, w.strategyManagerAddr, amount)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(errors.New("failed to approve token transfer"), err)
 	}
 	_, err = w.txMgr.Send(ctx, tx)
 	if err != nil {

--- a/chainio/txmgr/txmgr.go
+++ b/chainio/txmgr/txmgr.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
 	"github.com/Layr-Labs/eigensdk-go/logging"
-	"github.com/Layr-Labs/eigensdk-go/signerv2"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -31,11 +30,10 @@ type TxManager interface {
 }
 
 type SimpleTxManager struct {
-	wallet   wallet.Wallet
-	client   eth.Client
-	signerFn signerv2.SignerFn
-	log      logging.Logger
-	sender   common.Address
+	wallet wallet.Wallet
+	client eth.Client
+	log    logging.Logger
+	sender common.Address
 }
 
 var _ TxManager = (*SimpleTxManager)(nil)
@@ -46,15 +44,13 @@ func NewSimpleTxManager(
 	wallet wallet.Wallet,
 	client eth.Client,
 	log logging.Logger,
-	signerFn signerv2.SignerFn,
 	sender common.Address,
 ) *SimpleTxManager {
 	return &SimpleTxManager{
-		wallet:   wallet,
-		client:   client,
-		log:      log,
-		signerFn: signerFn,
-		sender:   sender,
+		wallet: wallet,
+		client: client,
+		log:    log,
+		sender: sender,
 	}
 }
 
@@ -82,16 +78,9 @@ func (m *SimpleTxManager) Send(ctx context.Context, tx *types.Transaction) (*typ
 // GetNoSendTxOpts This generates a noSend TransactOpts so that we can use
 // this to generate the transaction without actually sending it
 func (m *SimpleTxManager) GetNoSendTxOpts() (*bind.TransactOpts, error) {
-	signer, err := m.signerFn(context.Background(), m.sender)
-	if err != nil {
-		return nil, err
-	}
-	noSendTxOpts := &bind.TransactOpts{
-		From:   m.sender,
-		Signer: signer,
+	return &bind.TransactOpts{
 		NoSend: true,
-	}
-	return noSendTxOpts, nil
+	}, nil
 }
 
 func (m *SimpleTxManager) waitForReceipt(ctx context.Context, txID wallet.TxID) (*types.Receipt, error) {

--- a/chainio/txmgr/txmgr.go
+++ b/chainio/txmgr/txmgr.go
@@ -75,11 +75,17 @@ func (m *SimpleTxManager) Send(ctx context.Context, tx *types.Transaction) (*typ
 	return receipt, nil
 }
 
+func NoopSigner(addr common.Address, tx *types.Transaction) (*types.Transaction, error) {
+	return tx, nil
+}
+
 // GetNoSendTxOpts This generates a noSend TransactOpts so that we can use
 // this to generate the transaction without actually sending it
 func (m *SimpleTxManager) GetNoSendTxOpts() (*bind.TransactOpts, error) {
 	return &bind.TransactOpts{
+		From:   m.sender,
 		NoSend: true,
+		Signer: NoopSigner,
 	}, nil
 }
 


### PR DESCRIPTION
Removing signer from `TxManager` so that it's agnostic to the type of `wallet`. 
`TransactOpts` will be populated when the transaction is broadcasted in `TxManager.wallet`.