### PR TITLE
[Hotwallet] Return sender address & set gas fee

### DIFF
--- a/chainio/clients/fireblocks/client.go
+++ b/chainio/clients/fireblocks/client.go
@@ -48,6 +48,9 @@ type Client interface {
 	// GetTransaction makes a GetTransaction request to the Fireblocks API
 	// It returns the transaction details for the given transaction ID.
 	GetTransaction(ctx context.Context, txID string) (*Transaction, error)
+	// GetAssetAddresses makes a GetAssetAddresses request to the Fireblocks API
+	// It returns the addresses for the given asset ID and vault ID.
+	GetAssetAddresses(ctx context.Context, vaultID string, assetID AssetID) ([]AssetAddress, error)
 }
 
 type client struct {

--- a/chainio/clients/fireblocks/client_test.go
+++ b/chainio/clients/fireblocks/client_test.go
@@ -55,6 +55,7 @@ func TestContractCall(t *testing.T) {
 		"0",
 		"0x6057361d00000000000000000000000000000000000000000000000000000000000f4240",
 		"",
+		fireblocks.FeeLevelHigh,
 	)
 	resp, err := c.ContractCall(context.Background(), req)
 	assert.NoError(t, err)
@@ -80,4 +81,17 @@ func TestGetTransaction(t *testing.T) {
 	tx, err := c.GetTransaction(context.Background(), txID)
 	assert.NoError(t, err)
 	t.Logf("Transaction: %+v", tx)
+}
+
+func TestGetAssetAddresses(t *testing.T) {
+	t.Skip("skipping test as it's meant for manual runs only")
+
+	c := newFireblocksClient(t)
+	vaultID := "FILL_ME_IN"
+	assetID := fireblocks.AssetID("FILL_ME_IN")
+	addresses, err := c.GetAssetAddresses(context.Background(), vaultID, assetID)
+	assert.NoError(t, err)
+	for _, address := range addresses {
+		t.Logf("Address: %+v", address)
+	}
 }

--- a/chainio/clients/fireblocks/contract_call.go
+++ b/chainio/clients/fireblocks/contract_call.go
@@ -8,6 +8,7 @@ import (
 )
 
 type TransactionOperation string
+type FeeLevel string
 
 const (
 	ContractCall TransactionOperation = "CONTRACT_CALL"
@@ -16,6 +17,10 @@ const (
 	Burn         TransactionOperation = "BURN"
 	TypedMessage TransactionOperation = "TYPED_MESSAGE"
 	Raw          TransactionOperation = "RAW"
+
+	FeeLevelHigh   FeeLevel = "HIGH"
+	FeeLevelMedium FeeLevel = "MEDIUM"
+	FeeLevelLow    FeeLevel = "LOW"
 )
 
 type account struct {
@@ -38,6 +43,10 @@ type ContractCallRequest struct {
 	// In case a transaction is stuck, specify the hash of the stuck transaction to replace it
 	// by this transaction with a higher fee, or to replace it with this transaction with a zero fee and drop it from the blockchain.
 	ReplaceTxByHash string `json:"replaceTxByHash"`
+	// FeeLevel is the fee level for the transaction which Fireblocks estimates based on the current network conditions.
+	// The fee level can be HIGH, MEDIUM, or LOW.
+	FeeLevel FeeLevel `json:"feeLevel"`
+	// TODO: add maxFee and priorityFee
 }
 
 type ContractCallResponse struct {
@@ -53,6 +62,7 @@ func NewContractCallRequest(
 	amount string,
 	calldata string,
 	replaceTxByHash string,
+	feeLevel FeeLevel,
 ) *ContractCallRequest {
 	return &ContractCallRequest{
 		Operation:    ContractCall,
@@ -72,6 +82,7 @@ func NewContractCallRequest(
 			Calldata: calldata,
 		},
 		ReplaceTxByHash: replaceTxByHash,
+		FeeLevel:        feeLevel,
 	}
 }
 

--- a/chainio/clients/fireblocks/contract_call.go
+++ b/chainio/clients/fireblocks/contract_call.go
@@ -45,6 +45,7 @@ type ContractCallRequest struct {
 	ReplaceTxByHash string `json:"replaceTxByHash"`
 	// FeeLevel is the fee level for the transaction which Fireblocks estimates based on the current network conditions.
 	// The fee level can be HIGH, MEDIUM, or LOW.
+	// Ref: https://developers.fireblocks.com/docs/gas-estimation#estimated-network-fee
 	FeeLevel FeeLevel `json:"feeLevel"`
 	// TODO: add maxFee and priorityFee
 }

--- a/chainio/clients/fireblocks/get_asset_addresses.go
+++ b/chainio/clients/fireblocks/get_asset_addresses.go
@@ -1,0 +1,35 @@
+package fireblocks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type AssetAddress struct {
+	AssetID           AssetID `json:"assetId"`
+	Address           string  `json:"address"`
+	Tag               string  `json:"tag"`
+	Description       string  `json:"description"`
+	Type              string  `json:"type"`
+	LegacyAddress     string  `json:"legacyAddress"`
+	EnterpriseAddress string  `json:"enterpriseAddress"`
+	UserDefined       bool    `json:"userDefined"`
+}
+
+func (f *client) GetAssetAddresses(ctx context.Context, vaultID string, assetID AssetID) ([]AssetAddress, error) {
+	f.logger.Debug("Fireblocks get asset addressees", "vaultID", vaultID, "assetID", assetID)
+	url := fmt.Sprintf("/v1/vault/accounts/%s/%s/addresses", vaultID, assetID)
+	res, err := f.makeRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error making request: %w", err)
+	}
+	var addresses []AssetAddress
+	err = json.NewDecoder(strings.NewReader(string(res))).Decode(&addresses)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response body: %w", err)
+	}
+
+	return addresses, nil
+}

--- a/chainio/clients/mocks/fireblocks.go
+++ b/chainio/clients/mocks/fireblocks.go
@@ -55,6 +55,21 @@ func (mr *MockFireblocksClientMockRecorder) ContractCall(arg0, arg1 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractCall", reflect.TypeOf((*MockFireblocksClient)(nil).ContractCall), arg0, arg1)
 }
 
+// GetAssetAddresses mocks base method.
+func (m *MockFireblocksClient) GetAssetAddresses(arg0 context.Context, arg1 string, arg2 fireblocks.AssetID) ([]fireblocks.AssetAddress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAssetAddresses", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]fireblocks.AssetAddress)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssetAddresses indicates an expected call of GetAssetAddresses.
+func (mr *MockFireblocksClientMockRecorder) GetAssetAddresses(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetAddresses", reflect.TypeOf((*MockFireblocksClient)(nil).GetAssetAddresses), arg0, arg1, arg2)
+}
+
 // GetTransaction mocks base method.
 func (m *MockFireblocksClient) GetTransaction(arg0 context.Context, arg1 string) (*fireblocks.Transaction, error) {
 	m.ctrl.T.Helper()

--- a/chainio/clients/mocks/wallet.go
+++ b/chainio/clients/mocks/wallet.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	common "github.com/ethereum/go-ethereum/common"
 	types "github.com/ethereum/go-ethereum/core/types"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -68,4 +69,19 @@ func (m *MockWallet) SendTransaction(arg0 context.Context, arg1 *types.Transacti
 func (mr *MockWalletMockRecorder) SendTransaction(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransaction", reflect.TypeOf((*MockWallet)(nil).SendTransaction), arg0, arg1)
+}
+
+// SenderAddress mocks base method.
+func (m *MockWallet) SenderAddress(arg0 context.Context) (common.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SenderAddress", arg0)
+	ret0, _ := ret[0].(common.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SenderAddress indicates an expected call of SenderAddress.
+func (mr *MockWalletMockRecorder) SenderAddress(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SenderAddress", reflect.TypeOf((*MockWallet)(nil).SenderAddress), arg0)
 }

--- a/chainio/clients/wallet/privatekey_wallet.go
+++ b/chainio/clients/wallet/privatekey_wallet.go
@@ -92,6 +92,10 @@ func (t *privateKeyWallet) GetTransactionReceipt(ctx context.Context, txID TxID)
 	return t.ethClient.TransactionReceipt(ctx, txHash)
 }
 
+func (t *privateKeyWallet) SenderAddress(ctx context.Context) (common.Address, error) {
+	return t.address, nil
+}
+
 // estimateGasAndNonce we are explicitly implementing this because
 // * We want to support legacy transactions (i.e. not dynamic fee)
 // * We want to support gas management, i.e. add buffer to gas limit

--- a/chainio/clients/wallet/wallet.go
+++ b/chainio/clients/wallet/wallet.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -16,4 +17,6 @@ type TxID = string
 type Wallet interface {
 	SendTransaction(ctx context.Context, tx *types.Transaction) (TxID, error)
 	GetTransactionReceipt(ctx context.Context, txID TxID) (*types.Receipt, error)
+	// SenderAddress returns the address of the wallet
+	SenderAddress(ctx context.Context) (common.Address, error)
 }


### PR DESCRIPTION
This PR adds a `SenderAddress` method to `Wallet` interface, which returns the address of the sender.
It also set a `HIGH` gas fee (configured by Fireblocks) to increase the chance of transactions being confirmed sooner. 