### PR TITLE
Few fixes on `Wallet` implementation

### DIFF
--- a/chainio/clients/fireblocks/contract_call.go
+++ b/chainio/clients/fireblocks/contract_call.go
@@ -51,8 +51,8 @@ type ContractCallRequest struct {
 }
 
 type ContractCallResponse struct {
-	ID     string `json:"id"`
-	Status Status `json:"status"`
+	ID     string   `json:"id"`
+	Status TxStatus `json:"status"`
 }
 
 func NewContractCallRequest(

--- a/chainio/clients/fireblocks/get_transaction.go
+++ b/chainio/clients/fireblocks/get_transaction.go
@@ -11,7 +11,7 @@ import (
 type Transaction struct {
 	ID                            string               `json:"id"`
 	ExternalID                    string               `json:"externalId"`
-	Status                        Status               `json:"status"`
+	Status                        TxStatus             `json:"status"`
 	SubStatus                     string               `json:"subStatus"`
 	TxHash                        string               `json:"txHash"`
 	Operation                     TransactionOperation `json:"operation"`

--- a/chainio/clients/fireblocks/status.go
+++ b/chainio/clients/fireblocks/status.go
@@ -1,23 +1,23 @@
 package fireblocks
 
-type Status string
+type TxStatus string
 
 // statuses for transactions
 // ref: https://developers.fireblocks.com/reference/primary-transaction-statuses
 const (
-	Submitted            Status = "SUBMITTED"
-	PendingScreening     Status = "PENDING_AML_SCREENING"
-	PendingAuthorization Status = "PENDING_AUTHORIZATION"
-	Queued               Status = "QUEUED"
-	PendingSignature     Status = "PENDING_SIGNATURE"
-	PendingEmailApproval Status = "PENDING_3RD_PARTY_MANUAL_APPROVAL"
-	Pending3rdParty      Status = "PENDING_3RD_PARTY"
-	Broadcasting         Status = "BROADCASTING"
-	Confirming           Status = "CONFIRMING"
-	Completed            Status = "COMPLETED"
-	Cancelling           Status = "CANCELLING"
-	Cancelled            Status = "CANCELLED"
-	Blocked              Status = "BLOCKED"
-	Rejected             Status = "REJECTED"
-	Failed               Status = "FAILED"
+	Submitted            TxStatus = "SUBMITTED"
+	PendingScreening     TxStatus = "PENDING_AML_SCREENING"
+	PendingAuthorization TxStatus = "PENDING_AUTHORIZATION"
+	Queued               TxStatus = "QUEUED"
+	PendingSignature     TxStatus = "PENDING_SIGNATURE"
+	PendingEmailApproval TxStatus = "PENDING_3RD_PARTY_MANUAL_APPROVAL"
+	Pending3rdParty      TxStatus = "PENDING_3RD_PARTY"
+	Broadcasting         TxStatus = "BROADCASTING"
+	Confirming           TxStatus = "CONFIRMING"
+	Completed            TxStatus = "COMPLETED"
+	Cancelling           TxStatus = "CANCELLING"
+	Cancelled            TxStatus = "CANCELLED"
+	Blocked              TxStatus = "BLOCKED"
+	Rejected             TxStatus = "REJECTED"
+	Failed               TxStatus = "FAILED"
 )

--- a/chainio/clients/wallet/fireblocks_wallet.go
+++ b/chainio/clients/wallet/fireblocks_wallet.go
@@ -90,10 +90,10 @@ func (t *fireblocksWallet) getWhitelistedContract(ctx context.Context, address c
 		}
 		for _, c := range contracts {
 			for _, a := range c.Assets {
-				if a.Address == address && a.Status == "ACTIVE" && a.ID == assetID {
+				if a.Address == address && a.Status == "APPROVED" && a.ID == assetID {
 					t.whitelistedContracts[address] = &c
 					contract = &c
-					break
+					return contract, nil
 				}
 			}
 		}
@@ -168,6 +168,7 @@ func (t *fireblocksWallet) SendTransaction(ctx context.Context, tx *types.Transa
 	}
 	t.nonceToTxID[nonce] = res.ID
 	t.txIDToNonce[res.ID] = nonce
+	t.logger.Debug("Fireblocks contract call complete", "txID", res.ID, "status", res.Status)
 
 	return res.ID, nil
 }

--- a/chainio/clients/wallet/fireblocks_wallet_test.go
+++ b/chainio/clients/wallet/fireblocks_wallet_test.go
@@ -44,7 +44,7 @@ func TestSendTransaction(t *testing.T) {
 				Tag     string             `json:"tag"`
 			}{{
 				ID:      "ETH_TEST3",
-				Status:  "ACTIVE",
+				Status:  "APPROVED",
 				Address: common.HexToAddress(contractAddress),
 				Tag:     "",
 			},
@@ -104,7 +104,7 @@ func TestSendTransactionNoValidContract(t *testing.T) {
 				Tag     string             `json:"tag"`
 			}{{
 				ID:      "ETH_TEST123123", // wrong asset ID
-				Status:  "ACTIVE",
+				Status:  "APPROVED",
 				Address: common.HexToAddress(contractAddress),
 				Tag:     "",
 			},
@@ -198,7 +198,7 @@ func TestSendTransactionReplaceTx(t *testing.T) {
 				Tag     string             `json:"tag"`
 			}{{
 				ID:      "ETH_TEST3",
-				Status:  "ACTIVE",
+				Status:  "APPROVED",
 				Address: common.HexToAddress(contractAddress),
 				Tag:     "",
 			},

--- a/chainio/txmgr/txmgr.go
+++ b/chainio/txmgr/txmgr.go
@@ -106,16 +106,15 @@ func (m *SimpleTxManager) waitForReceipt(ctx context.Context, txID wallet.TxID) 
 }
 
 func (m *SimpleTxManager) queryReceipt(ctx context.Context, txID wallet.TxID) *types.Receipt {
-	txHash := common.HexToHash(txID)
-	receipt, err := m.wallet.GetTransactionReceipt(ctx, txHash.Hex())
+	receipt, err := m.wallet.GetTransactionReceipt(ctx, txID)
 	if errors.Is(err, ethereum.NotFound) {
-		m.log.Info("Transaction not yet mined", "hash", txHash)
+		m.log.Info("Transaction not yet mined", "txID", txID)
 		return nil
 	} else if err != nil {
-		m.log.Info("Receipt retrieval failed", "hash", txHash, "err", err)
+		m.log.Info("Receipt retrieval failed", "txID", txID, "err", err)
 		return nil
 	} else if receipt == nil {
-		m.log.Warn("Receipt and error are both nil", "hash", txHash)
+		m.log.Warn("Receipt and error are both nil", "txID", txID)
 		return nil
 	}
 


### PR DESCRIPTION
- Renamed `Status` with `TxStatus` to make it clear that it only applies to transaction status
- Fixed a bug in fireblocks wallet `getWhitelistedContract` method where it was returning the last contract instead of the contract that matches the condition
- Fixed a bug in txmgr `queryReceipt` method which was transforming `txID` into a hash (this only worked for private key wallet)