### PR TITLE
[Fireblocks] Don't replace transaction if txHash not available

### DIFF
--- a/chainio/clients/wallet/fireblocks_wallet.go
+++ b/chainio/clients/wallet/fireblocks_wallet.go
@@ -152,8 +152,6 @@ func (t *fireblocksWallet) SendTransaction(ctx context.Context, tx *types.Transa
 		}
 		if fireblockTx.TxHash != "" {
 			replaceTxByHash = fireblockTx.TxHash
-		} else {
-			return "", fmt.Errorf("failed to get transaction hash with nonce %d", nonce)
 		}
 	}
 


### PR DESCRIPTION
`fireblockTx.TxHash` isn't available if the transaction has not been broadcasted to the network. We don't need to specify `replaceTxByHash` in this case. 
<img width="564" alt="Screenshot 2024-03-22 at 1 36 58 PM" src="https://github.com/Layr-Labs/eigensdk-go/assets/100327837/fa95faf6-e5d2-4b5c-9df1-53b4dc0a059a">
