### PR TITLE
[Fireblocks] Pass in gas info when calling contract

### DIFF
--- a/chainio/clients/fireblocks/client_test.go
+++ b/chainio/clients/fireblocks/client_test.go
@@ -54,7 +54,11 @@ func TestContractCall(t *testing.T) {
 		destinationAccountID,
 		"0",
 		"0x6057361d00000000000000000000000000000000000000000000000000000000000f4240",
-		"",
+		"", // replaceTxByHash
+		"", // gasPrice
+		"", // gasLimit
+		"", // maxFee
+		"", // priorityFee
 		fireblocks.FeeLevelHigh,
 	)
 	resp, err := c.ContractCall(context.Background(), req)

--- a/chainio/clients/fireblocks/contract_call.go
+++ b/chainio/clients/fireblocks/contract_call.go
@@ -43,11 +43,20 @@ type ContractCallRequest struct {
 	// In case a transaction is stuck, specify the hash of the stuck transaction to replace it
 	// by this transaction with a higher fee, or to replace it with this transaction with a zero fee and drop it from the blockchain.
 	ReplaceTxByHash string `json:"replaceTxByHash"`
+	// GasPrice and GasLimit are the gas price and gas limit for the transaction.
+	// If GasPrice is specified (non-1559), MaxFee and PriorityFee are not required.
+	GasPrice string `json:"gasPrice"`
+	GasLimit string `json:"gasLimit"`
+	// MaxFee and PriorityFee are the maximum and priority fees for the transaction.
+	// If the transaction is stuck, the Fireblocks platform will replace the transaction with a new one with a higher fee.
+	// These fields are required if FeeLevel is not specified.
+	MaxFee      string `json:"maxFee"`
+	PriorityFee string `json:"priorityFee"`
 	// FeeLevel is the fee level for the transaction which Fireblocks estimates based on the current network conditions.
 	// The fee level can be HIGH, MEDIUM, or LOW.
+	// If MaxFee and PriorityFee are not specified, the Fireblocks platform will use the default fee level MEDIUM.
 	// Ref: https://developers.fireblocks.com/docs/gas-estimation#estimated-network-fee
 	FeeLevel FeeLevel `json:"feeLevel"`
-	// TODO: add maxFee and priorityFee
 }
 
 type ContractCallResponse struct {
@@ -63,6 +72,10 @@ func NewContractCallRequest(
 	amount string,
 	calldata string,
 	replaceTxByHash string,
+	gasPrice string,
+	gasLimit string,
+	maxFee string,
+	priorityFee string,
 	feeLevel FeeLevel,
 ) *ContractCallRequest {
 	return &ContractCallRequest{
@@ -83,6 +96,10 @@ func NewContractCallRequest(
 			Calldata: calldata,
 		},
 		ReplaceTxByHash: replaceTxByHash,
+		GasPrice:        gasPrice,
+		GasLimit:        gasLimit,
+		MaxFee:          maxFee,
+		PriorityFee:     priorityFee,
 		FeeLevel:        feeLevel,
 	}
 }


### PR DESCRIPTION
It used to rely on Fireblocks' gas estimation by passing in `HIGH` as `feeLevel` parameter when creating a transaction.
However, this estimation doesn't guarantee that replacement (boosting) transaction increases the gas cost by > 15% than the previous transaction, which is a requirement for replacing a pending transaction. 
We need to explicitly pass in the gas fee cap and priority fee cap instead of passing in `feeLevel` in this case. 