### PR TITLE
add gasLimitMultiplier to fireblocks and privatekey wallets

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 
@@ -212,7 +213,8 @@ func (r *AvsRegistryChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 		uint32(curBlock),
 	)
 	if err != nil {
-		return nil, types.WrapError(errors.New("Failed to get operators state"), err)
+		return nil, types.WrapError(fmt.Errorf("Failed to get operators state at block %d, quorums %v and registryCoordinatorAddr %v",
+			curBlock, quorumNumbers, r.registryCoordinatorAddr), err)
 	}
 	var quorumOperatorAddrs [][]common.Address
 	for _, quorum := range operatorStakes {


### PR DESCRIPTION
Fixes errors we were getting on avs-sync with txs reverting due to running out of gas.

@ian-shim this is a super simple gasLimitMultiplier parameter that the user can set (so we can test whether 1.1, 1.2, etc works best for different cases). hardcoded the default as 1.1