### PR TITLE
feat: return metadata logo fetch error

### DIFF
--- a/types/errors.go
+++ b/types/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrInvalidUrlLength         = errors.New("url length should be no larger than 1024 character")
 	ErrInvalidUrl               = errors.New("invalid url")
 
+	ErrImageFetchFailed      = errors.New("error fetching operator logo")
 	ErrInvalidImageMimeType  = errors.New("invalid image mime-type. only png is supported")
 	ErrInvalidImageExtension = errors.New(
 		"invalid image extension. only " + strings.Join(ImageExtensions, ",") + " is supported",

--- a/types/operator_metadata.go
+++ b/types/operator_metadata.go
@@ -139,6 +139,12 @@ func isImageURL(urlString string) error {
 			if err != nil {
 				return err
 			}
+
+			// Check if the response status was an error
+			if imageResponse.StatusCode >= 400 {
+				return ErrImageFetchFailed
+			}
+
 			imageBytes, err := io.ReadAll(imageResponse.Body)
 			if err != nil {
 				return err


### PR DESCRIPTION
Adds proper error message if operator logo from metadata could not be fetched (404 error for example). 

### Motivation
Previously if logo could not be fetched user would receive mime type error that only pngs are supported

### Solution
Check for http response status and throw self explanatory error