### PR TITLE
Fix: Add AddCallerSkip for zap to show real caller

### DIFF
--- a/logging/zap_logger.go
+++ b/logging/zap_logger.go
@@ -19,28 +19,32 @@ type ZapLogger struct {
 
 var _ Logger = (*ZapLogger)(nil)
 
+// NewZapLogger creates a new logger wrapped the zap.Logger
 func NewZapLogger(env LogLevel) (Logger, error) {
-	callerSkip := zap.AddCallerSkip(1)
+	var config zap.Config
 
 	if env == Production {
-		logger, err := zap.NewProduction(callerSkip)
-		if err != nil {
-			panic(err)
-		}
-		return &ZapLogger{
-			logger: logger,
-		}, nil
+		config = zap.NewProductionConfig()
 	} else if env == Development {
-		logger, err := zap.NewDevelopment(callerSkip)
-		if err != nil {
-			panic(err)
-		}
-		return &ZapLogger{
-			logger: logger,
-		}, nil
+		config = zap.NewDevelopmentConfig()
 	} else {
 		panic(fmt.Sprintf("Unknown environment. Expected %s or %s. Received %s.", Development, Production, env))
 	}
+
+	return NewZapLoggerByConfig(config, zap.AddCallerSkip(1))
+}
+
+// NewZapLoggerByConfig creates a logger wrapped the zap.Logger
+// Note if the logger need to show the caller, need use `zap.AddCallerSkip(1)` ad options
+func NewZapLoggerByConfig(config zap.Config, options ...zap.Option) (Logger, error) {
+	logger, err := config.Build(options...)
+	if err != nil {
+		panic(err)
+	}
+
+	return &ZapLogger{
+		logger: logger,
+	}, nil
 }
 
 func (z *ZapLogger) Debug(msg string, tags ...any) {

--- a/logging/zap_logger.go
+++ b/logging/zap_logger.go
@@ -20,8 +20,10 @@ type ZapLogger struct {
 var _ Logger = (*ZapLogger)(nil)
 
 func NewZapLogger(env LogLevel) (Logger, error) {
+	callerSkip := zap.AddCallerSkip(1)
+
 	if env == Production {
-		logger, err := zap.NewProduction()
+		logger, err := zap.NewProduction(callerSkip)
 		if err != nil {
 			panic(err)
 		}
@@ -29,7 +31,7 @@ func NewZapLogger(env LogLevel) (Logger, error) {
 			logger: logger,
 		}, nil
 	} else if env == Development {
-		logger, err := zap.NewDevelopment()
+		logger, err := zap.NewDevelopment(callerSkip)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
### Motivation

For a zap logger wrapper, if not contain the `AddCallerSkip`, it 's caller will be the log func 's pos:

```log
2024-04-04T15:59:14.151+0800    DEBUG   logging/zap_logger.go:45        List of queried operator registration events in blsApkRegistry{"alreadyRegisteredOperatorAddr": ["0xe9a7669ac9ebe9b7e21e0a323fc3a6f34ce744eb"], "service": "OperatorPubkeysServiceInMemory"}
2024-04-04T15:59:14.151+0800    INFO    logging/zap_logger.go:69        Starting aggregator.
2024-04-04T15:59:14.151+0800    INFO    logging/zap_logger.go:69        Starting aggregator rpc server.
2024-04-04T15:59:14.151+0800    INFO    logging/zap_logger.go:49        Aggregator set to send new task every 10 seconds...
2024-04-04T15:59:14.151+0800    INFO    logging/zap_logger.go:49        Start LegacyRpcServer   {"addr": "localhost:8090"}
```

Note all log 's caller is the logging wrapper, which is:

```go
func (z *ZapLogger) Infof(template string, args ...interface{}) {
	z.logger.Sugar().Infof(template, args...)
}
```

### Solution

So we need add `AddCallerSkip(1)`, then we will got:

```log
2024-04-04T16:03:43.217+0800    INFO    aggregator/aggregator.go:120    Starting aggregator.
2024-04-04T16:03:43.217+0800    INFO    aggregator/aggregator.go:121    Starting aggregator rpc server.
2024-04-04T16:03:43.217+0800    INFO    aggregator/aggregator.go:125    Aggregator set to send new task every 10 seconds...
2024-04-04T16:03:43.217+0800    INFO    rpc/legacy.go:34        Start LegacyRpcServer   {"addr": "localhost:8090"}
```

Note the user may define the zap logger by spec configs, so we add a new func to create:

```go
// NewZapLoggerByConfig creates a logger wrapped the zap.Logger
// Note if the logger need to show the caller, need use `zap.AddCallerSkip(1)` ad options
func NewZapLoggerByConfig(config zap.Config, options ...zap.Option) (Logger, error) 
```