### PR TITLE
Fix:  Error wrap may panic by nil error

### DIFF
--- a/services/avsregistry/avsregistry_chaincaller.go
+++ b/services/avsregistry/avsregistry_chaincaller.go
@@ -109,7 +109,7 @@ func (ar *AvsRegistryServiceChainCaller) getOperatorPubkeys(ctx context.Context,
 	}
 	pubkeys, ok := ar.operatorPubkeysService.GetOperatorPubkeys(ctx, operatorAddr)
 	if !ok {
-		return types.OperatorPubkeys{}, types.WrapError(fmt.Errorf("Failed to get operator pubkeys from pubkey compendium service (operatorAddr: %v, operatorId: %v)", operatorAddr, operatorId), err)
+		return types.OperatorPubkeys{}, fmt.Errorf("Failed to get operator pubkeys from pubkey compendium service (operatorAddr: %v, operatorId: %v)", operatorAddr, operatorId)
 	}
 	return pubkeys, nil
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -38,5 +38,18 @@ var (
 )
 
 func WrapError(mainErr error, subErr error) error {
+	// Some times the wrap will wrap a nil error
+	if mainErr == nil && subErr == nil {
+		return nil
+	}
+
+	if mainErr == nil && subErr != nil {
+		return fmt.Errorf("sub error: %s", subErr.Error())
+	}
+
+	if mainErr != nil && subErr == nil {
+		return fmt.Errorf("%s: unknown sub error", mainErr.Error())
+	}
+
 	return fmt.Errorf("%s: %s", mainErr.Error(), subErr.Error())
 }


### PR DESCRIPTION
### Motivation

Note in:

```go
func (ar *AvsRegistryServiceChainCaller) getOperatorPubkeys(ctx context.Context, operatorId types.OperatorId) (types.OperatorPubkeys, error) {
	operatorAddr, err := ar.AvsRegistryReader.GetOperatorFromId(&bind.CallOpts{Context: ctx}, operatorId)
	if err != nil {
		return types.OperatorPubkeys{}, types.WrapError(errors.New("Failed to get operator address from pubkey hash"), err)
	}
	pubkeys, ok := ar.operatorPubkeysService.GetOperatorPubkeys(ctx, operatorAddr)
	if !ok {
		return types.OperatorPubkeys{}, fmt.Errorf("Failed to get operator pubkeys from pubkey compendium service (operatorAddr: %v, operatorId: %v)", operatorAddr, operatorId)
	}
	return pubkeys, nil
}

```

if `operatorPubkeysService` not found the key, it will return false but the `err` is nil, it will cause a panic by read nil point by wrapper:

```go
fmt.Errorf("%s: %s", mainErr.Error(), subErr.Error())
```

### Solution

- we need add checks in wrapper, even use nil error, will not cause a panic
- fix the operatorPubkeysService error wrapper, the wrap is useless by the err will always nil

