### PR TITLE
Fix: Not panic when call checkIfStakeThresholdsMet for operator which not stake all quorum

### DIFF
--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -370,11 +370,25 @@ func checkIfStakeThresholdsMet(
 	quorumThresholdPercentagesMap map[types.QuorumNum]types.QuorumThresholdPercentage,
 ) bool {
 	for quorumNum, quorumThresholdPercentage := range quorumThresholdPercentagesMap {
+		signedStakeByQuorum, ok := signedStakePerQuorum[quorumNum]
+		if !ok {
+			// signedStakePerQuorum not contain the quorum,
+			// this case means signedStakePerQuorum has not signed for each quorum.
+			return false
+		}
+
+		totalStakeByQuorum, ok := totalStakePerQuorum[quorumNum]
+		if !ok {
+			// Note this case should not happend, if not found in totalStakePerQuorum
+			// We can just think is zero
+			totalStakeByQuorum = big.NewInt(0)
+		}
+
 		// we check that signedStake >= totalStake * quorumThresholdPercentage / 100
 		// to be exact (and do like the contracts), we actually check that
 		// signedStake * 100 >= totalStake * quorumThresholdPercentage
-		signedStake := big.NewInt(0).Mul(signedStakePerQuorum[quorumNum], big.NewInt(100))
-		thresholdStake := big.NewInt(0).Mul(totalStakePerQuorum[quorumNum], big.NewInt(int64(quorumThresholdPercentage)))
+		signedStake := big.NewInt(0).Mul(signedStakeByQuorum, big.NewInt(100))
+		thresholdStake := big.NewInt(0).Mul(totalStakeByQuorum, big.NewInt(int64(quorumThresholdPercentage)))
 		if signedStake.Cmp(thresholdStake) < 0 {
 			return false
 		}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -374,6 +374,7 @@ func checkIfStakeThresholdsMet(
 		if !ok {
 			// signedStakePerQuorum not contain the quorum,
 			// this case means signedStakePerQuorum has not signed for each quorum.
+			// even the total stake for this quorum is zero.
 			return false
 		}
 

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -337,7 +337,7 @@ func TestBlsAgg(t *testing.T) {
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
-	t.Run("2 quorums 2 operators which just stake 1 quorum; 2 correct signature - verified", func(t *testing.T) {
+	t.Run("2 quorums 2 operators which just stake one quorum; 2 correct signature - verified", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId: types.OperatorId{1},
 			// Note the quorums is {0, 1}, but operator id 1 just stake 0.
@@ -385,7 +385,7 @@ func TestBlsAgg(t *testing.T) {
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
-	t.Run("2 quorum 3 operator which just stake 1 quorum; 2 correct signature quorumThreshold 50% - verified", func(t *testing.T) {
+	t.Run("2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 50% - verified", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId: types.OperatorId{1},
 			// Note the quorums is {0, 1}, but operator id 1 just stake 0.
@@ -440,7 +440,7 @@ func TestBlsAgg(t *testing.T) {
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
-	t.Run("2 quorum 3 operator which just stake 1 quorum; 2 correct signature quorumThreshold 60% - task expired", func(t *testing.T) {
+	t.Run("2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 60% - task expired", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId: types.OperatorId{1},
 			// Note the quorums is {0, 1}, but operator id 1 just stake 0.
@@ -484,7 +484,7 @@ func TestBlsAgg(t *testing.T) {
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
-	t.Run("2 quorums 1 operators which just stake 0; 1 signatures - task expired", func(t *testing.T) {
+	t.Run("2 quorums 1 operators which just stake one quorum; 1 signatures - task expired", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId: types.OperatorId{1},
 			// Note the quorums is {0, 1}, but operator id 1 just stake 0.
@@ -514,7 +514,7 @@ func TestBlsAgg(t *testing.T) {
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
-	t.Run("2 quorums 2 operators, 1 operator which just stake 0; 1 signatures - task expired", func(t *testing.T) {
+	t.Run("2 quorums 2 operators, 1 operator which just stake one quorum; 1 signatures - task expired", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId: types.OperatorId{1},
 			// Note the quorums is {0, 1}, but operator id 1 just stake 0.


### PR DESCRIPTION
### Motivation

An AVS can have multi-quorum, but if one operator not stake in all quorums, the `checkIfStakeThresholdsMet` will panic by not check if operator stake for a quorum.

In Code:

```golang
// checkIfStakeThresholdsMet checks at least quorumThresholdPercentage of stake
// has signed for each quorum.
func checkIfStakeThresholdsMet(
	signedStakePerQuorum map[types.QuorumNum]*big.Int,
	totalStakePerQuorum map[types.QuorumNum]*big.Int,
	quorumThresholdPercentagesMap map[types.QuorumNum]types.QuorumThresholdPercentage,
) bool {
        // Just for show case
	fmt.Printf("signedStakePerQuorum %v\n", signedStakePerQuorum)
	fmt.Printf("totalStakePerQuorum %v\n", totalStakePerQuorum)
	fmt.Printf("quorumThresholdPercentagesMap %v\n", quorumThresholdPercentagesMap)

	for quorumNum, quorumThresholdPercentage := range quorumThresholdPercentagesMap {
		// we check that signedStake >= totalStake * quorumThresholdPercentage / 100
		// to be exact (and do like the contracts), we actually check that
		// signedStake * 100 >= totalStake * quorumThresholdPercentage

		fmt.Printf("quorumNum %v\n", quorumNum.UnderlyingType())
		fmt.Printf("quorumThresholdPercentage %v\n", quorumThresholdPercentage)

		signedStake := big.NewInt(0).Mul(signedStakePerQuorum[quorumNum], big.NewInt(100))
		thresholdStake := big.NewInt(0).Mul(totalStakePerQuorum[quorumNum], big.NewInt(int64(quorumThresholdPercentage)))
		if signedStake.Cmp(thresholdStake) < 0 {
			return false
		}
	}
	return true
}
``` 

Note, if a operator just stake 0 quorum, then the log will be:

```log
signedStakePerQuorum map[0:0]
totalStakePerQuorum map[0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 8:0 9:0 10:0]
quorumThresholdPercentagesMap map[0:66 1:66 2:66 3:66 4:66 5:66 6:66 7:66 8:66 9:66 10:66]
quorumNum 3
quorumThresholdPercentage 66
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x5a5f8b]

goroutine 46 [running]:
math/big.(*Int).Mul(0xc0004d95b8, 0x0, 0xc0004d9598)
        /home/fy/.gvm/gos/go1.21.1/src/math/big/int.go:194 +0x8b
github.com/Layr-Labs/eigensdk-go/services/bls_aggregation.checkIfStakeThresholdsMet(0xc00059a090, 0xc0002ca6c0, 0xc0003b5110)
        /home/fy/.gvm/pkgsets/go1.21.1/global/pkg/mod/github.com/!layr-!labs/eigensdk-go@v0.1.4-0.20240404055221-7d329c19d777/services/bls_aggregation/blsagg.go:384 +0x325
github.com/Layr-Labs/eigensdk-go/services/bls_aggregation.(*BlsAggregatorService).singleTaskAggregatorGoroutineFunc(0xc0000d3f90, 0x0, 0x1b?, {0xc0003ae310?, 0xb, 0xb}, {0xc0001367d0, 0xb, 0xb?}, 0x1176592e000, ...)
        /home/fy/.gvm/pkgsets/go1.21.1/global/pkg/mod/github.com/!layr-!labs/eigensdk-go@v0.1.4-0.20240404055221-7d329c19d777/services/bls_aggregation/blsagg.go:277 +0xb0c
created by github.com/Layr-Labs/eigensdk-go/services/bls_aggregation.(*BlsAggregatorService).InitializeNewTask in goroutine 13
        /home/fy/.gvm/pkgsets/go1.21.1/global/pkg/mod/github.com/!layr-!labs/eigensdk-go@v0.1.4-0.20240404055221-7d329c19d777/services/bls_aggregation/blsagg.go:166 +0x419
```

Note for golang the iter for map will random, so `signedStakePerQuorum[quorumNum]` will return a nil, but no zero for `*big.Int`, so it will panic.

### Solution

We need add a check to avoid panic, if a quorum not in `signedStakePerQuorum`, just return false, even the total stake for this quorum is zero.

More details can see the tests:

- 2 quorums 2 operators which just stake one quorum; 2 correct signature - verified
- 2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 50% - verified
- 2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 60% - task expired
- 2 quorums 1 operator which just stake one quorum; 1 signatures - task expired
- 2 quorums 2 operators, 1 operator which just stake 0; 1 signatures - task expired
