### PR TITLE
Wrap error properly

### DIFF
--- a/types/errors.go
+++ b/types/errors.go
@@ -31,12 +31,12 @@ func WrapError(mainErr error, subErr error) error {
 	}
 
 	if mainErr == nil && subErr != nil {
-		return fmt.Errorf("sub error: %s", subErr.Error())
+		return fmt.Errorf("sub error: %w", subErr)
 	}
 
 	if mainErr != nil && subErr == nil {
-		return fmt.Errorf("%s: unknown sub error", mainErr.Error())
+		return fmt.Errorf("%w: unknown sub error", mainErr)
 	}
 
-	return fmt.Errorf("%s: %s", mainErr.Error(), subErr.Error())
+	return fmt.Errorf("%w: %w", mainErr, subErr)
 }


### PR DESCRIPTION
Wrapping errors using `%s` formats the error message, but does not wrap the error in a way that can be unwrapped by `errors` library. Using `%w` allows child errors to be unwrapped properly.