### PR TITLE
fix task expiration timer: was not being stopped on task completion

### DIFF
--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -20,7 +20,9 @@ var (
 	TaskAlreadyInitializedErrorFn = func(taskIndex types.TaskIndex) error {
 		return fmt.Errorf("task %d already initialized", taskIndex)
 	}
-	TaskExpiredError    = fmt.Errorf("task expired")
+	TaskExpiredErrorFn = func(taskIndex types.TaskIndex) error {
+		return fmt.Errorf("task %d expired", taskIndex)
+	}
 	TaskNotFoundErrorFn = func(taskIndex types.TaskIndex) error {
 		return fmt.Errorf("task %d not initialized or already completed", taskIndex)
 	}
@@ -317,11 +319,12 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 					NonSignerStakeIndices:        indices.NonSignerStakeIndices,
 				}
 				a.aggregatedResponsesC <- blsAggregationServiceResponse
+				taskExpiredTimer.Stop()
 				return
 			}
 		case <-taskExpiredTimer.C:
 			a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-				Err: TaskExpiredError,
+				Err: TaskExpiredErrorFn(taskIndex),
 			}
 			return
 		}

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -259,7 +259,7 @@ func TestBlsAgg(t *testing.T) {
 		err := blsAggServ.InitializeNewTask(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
-			Err: TaskExpiredError,
+			Err: TaskExpiredErrorFn(taskIndex),
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
@@ -331,7 +331,7 @@ func TestBlsAgg(t *testing.T) {
 		err = blsAggServ.ProcessNewSignature(context.Background(), taskIndex, taskResponseDigest, blsSig, testOperator1.OperatorId)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
-			Err: TaskExpiredError,
+			Err: TaskExpiredErrorFn(taskIndex),
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
@@ -478,7 +478,7 @@ func TestBlsAgg(t *testing.T) {
 		require.Nil(t, err)
 
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
-			Err: TaskExpiredError,
+			Err: TaskExpiredErrorFn(taskIndex),
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
@@ -508,7 +508,7 @@ func TestBlsAgg(t *testing.T) {
 		require.Nil(t, err)
 
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
-			Err: TaskExpiredError,
+			Err: TaskExpiredErrorFn(taskIndex),
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
@@ -543,7 +543,7 @@ func TestBlsAgg(t *testing.T) {
 		require.Nil(t, err)
 
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
-			Err: TaskExpiredError,
+			Err: TaskExpiredErrorFn(taskIndex),
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
@@ -649,7 +649,7 @@ func TestBlsAgg(t *testing.T) {
 		err = blsAggServ.ProcessNewSignature(context.Background(), taskIndex, taskResponseDigest2, blsSigOp2, testOperator2.OperatorId)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
-			Err: TaskExpiredError,
+			Err: TaskExpiredErrorFn(taskIndex),
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)


### PR DESCRIPTION
task expiration timer was not being stopped upon task completion, so was returning unwanted errors.
Also error was not tagged with taskIndex so was impossible to know which taskId had expired.