### PR TITLE
[fireblocks] Leave `externalTxID` empty

### DIFF
--- a/chainio/clients/fireblocks/contract_call.go
+++ b/chainio/clients/fireblocks/contract_call.go
@@ -33,13 +33,14 @@ type extraParams struct {
 }
 
 type ContractCallRequest struct {
-	Operation       TransactionOperation `json:"operation"`
-	ExternalTxID    string               `json:"externalTxId"`
-	AssetID         AssetID              `json:"assetId"`
-	Source          account              `json:"source"`
-	Destination     account              `json:"destination"`
-	Amount          string               `json:"amount,omitempty"`
-	ExtraParameters extraParams          `json:"extraParameters"`
+	Operation TransactionOperation `json:"operation"`
+	// ExternalTxID is an optional field that can be used as an idempotency key.
+	ExternalTxID    string      `json:"externalTxId,omitempty"`
+	AssetID         AssetID     `json:"assetId"`
+	Source          account     `json:"source"`
+	Destination     account     `json:"destination"`
+	Amount          string      `json:"amount,omitempty"`
+	ExtraParameters extraParams `json:"extraParameters"`
 	// In case a transaction is stuck, specify the hash of the stuck transaction to replace it
 	// by this transaction with a higher fee, or to replace it with this transaction with a zero fee and drop it from the blockchain.
 	ReplaceTxByHash string `json:"replaceTxByHash,omitempty"`

--- a/chainio/clients/wallet/fireblocks_wallet.go
+++ b/chainio/clients/wallet/fireblocks_wallet.go
@@ -182,7 +182,7 @@ func (t *fireblocksWallet) SendTransaction(ctx context.Context, tx *types.Transa
 	}
 
 	req := fireblocks.NewContractCallRequest(
-		tx.Hash().Hex(),
+		"", // externalTxID
 		assetID,
 		account.ID,                // source account ID
 		contract.ID,               // destination account ID

--- a/chainio/clients/wallet/fireblocks_wallet_test.go
+++ b/chainio/clients/wallet/fireblocks_wallet_test.go
@@ -254,7 +254,7 @@ func TestSendTransactionReplaceTx(t *testing.T) {
 		TxHash: expectedTxHash,
 	}, nil)
 	fireblocksClient.EXPECT().ContractCall(gomock.Any(), fireblocks.NewContractCallRequest(
-		replacementTx.Hash().Hex(),
+		"",
 		"ETH_TEST3",
 		"vaultAccountID",
 		"contractID",


### PR DESCRIPTION
`externalTxID` serves as an idempotency key.
An issue with Fireblocks `externalTxID` is that even when the `ContractCall` request fails (i.e. due to timeout) their DB still saves the `externalTxID`, which invalidates any further retries with the same `externalTxID`. With the information available in `types.Transaction`, there isn't reliable way to determine if the request is a retry or not.