### PR TITLE
better error returned

### DIFF
--- a/utils/errors.go
+++ b/utils/errors.go
@@ -22,6 +22,7 @@ var (
 	ErrInvalidTwitterUrlRegex   = errors.New(
 		"invalid twitter url, it should be of the format https://twitter.com/<username> or https://x.com/<username>",
 	)
+	ErrResponseTooLarge = errors.New("response too large, allowed size is 1 MB")
 )
 
 func TypedErr(e interface{}) error {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,6 +27,9 @@ const (
 	PngMimeType = "image/png"
 
 	TextRegex = `^[a-zA-Z0-9 +.,;:?!'"\-_/()\[\]~&#$—]+$`
+
+	// Limit Http response to 1 MB
+	httpResponseLimit = 1 * 1024 * 1024
 )
 
 var (
@@ -124,7 +127,18 @@ func ReadPublicURL(url string) ([]byte, error) {
 	}(resp.Body)
 
 	// allow images of up to 1 MiB
-	return io.ReadAll(http.MaxBytesReader(nil, resp.Body, 1*1024*1024))
+	response, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, httpResponseLimit))
+	if err != nil {
+		// We are doing this because errors.Is(err) check doesn't work for this
+		// since MaxBytesError has pointer receiver. Not sure what is the correct
+		// way to do this.
+		maxByteErr := http.MaxBytesError{}
+		if err.Error() == maxByteErr.Error() {
+			return nil, ErrResponseTooLarge
+		}
+		return nil, err
+	}
+	return response, nil
 }
 
 func CheckIfValidTwitterURL(twitterURL string) error {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -29,7 +29,7 @@ const (
 	TextRegex = `^[a-zA-Z0-9 +.,;:?!'"\-_/()\[\]~&#$—]+$`
 
 	// Limit Http response to 1 MB
-	httpResponseLimit = 1 * 1024 * 1024
+	httpResponseLimitBytes = 1 * 1024 * 1024
 )
 
 var (
@@ -127,7 +127,7 @@ func ReadPublicURL(url string) ([]byte, error) {
 	}(resp.Body)
 
 	// allow images of up to 1 MiB
-	response, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, httpResponseLimit))
+	response, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, httpResponseLimitBytes))
 	if err != nil {
 		// We are doing this because errors.Is(err) check doesn't work for this
 		// since MaxBytesError has pointer receiver. Not sure what is the correct

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateRawGithubUrl(t *testing.T) {
@@ -24,6 +25,32 @@ func TestValidateRawGithubUrl(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateRawGithubUrl(tt.url)
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestReadPublicURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		expectedErr error
+	}{
+		{
+			name:        "request < 1mb",
+			url:         "https://raw.githubusercontent.com/shrimalmadhur/metadata/main/logo.png",
+			expectedErr: nil,
+		},
+		{
+			name:        "request too large",
+			url:         "https://raw.githubusercontent.com/shrimalmadhur/metadata/main/2mb.png",
+			expectedErr: ErrResponseTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ReadPublicURL(tt.url)
 			assert.Equal(t, tt.expectedErr, err)
 		})
 	}


### PR DESCRIPTION
Fixes # .

### What Changed?
- Return better error to user
- `make fmt`

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it