### PR TITLE
add % to regex

### DIFF
--- a/types/operator_metadata_test.go
+++ b/types/operator_metadata_test.go
@@ -18,7 +18,7 @@ func TestOperatorMetadata(t *testing.T) {
 			name: "Valid metadata with twitter.com url",
 			metadata: OperatorMetadata{
 				Name:        "Ethereum Utopia",
-				Description: "Madhur's first operator is best in this world+&~#$—",
+				Description: "Madhur's first operator is best in this world+&~#$—%",
 				Logo:        "https://goerli-operator-metadata.s3.amazonaws.com/eigenlayer.png",
 				Twitter:     "https://twitter.com/test",
 				Website:     "https://test.com",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,7 +26,7 @@ import (
 const (
 	PngMimeType = "image/png"
 
-	TextRegex = `^[a-zA-Z0-9 +.,;:?!'"\-_/()\[\]~&#$—]+$`
+	TextRegex = `^[a-zA-Z0-9 +.,;:?!'"\-_/()\[\]~&#$—%]+$`
 
 	// Limit Http response to 1 MB
 	httpResponseLimitBytes = 1 * 1024 * 1024


### PR DESCRIPTION
Fixes # .

### What Changed?
- Add `%` to the text regex

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it