### PR TITLE
make queryBlockRangea an argument to query log functions

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -395,7 +395,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorPubKeys(
 	operatorPubkeys := make([]types.OperatorPubkeys, 0)
 	for i := startBlock; i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
 		// Subtract 1 since FilterQuery is inclusive
-		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(DefaultQueryBlockRange, big.NewInt(1)))
+		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(blockRange, big.NewInt(1)))
 		if toBlock.Cmp(stopBlock) > 0 {
 			toBlock = stopBlock
 		}
@@ -484,7 +484,7 @@ func (r *AvsRegistryChainReader) QueryExistingRegisteredOperatorSockets(
 	operatorIdToSocketMap := make(map[types.OperatorId]types.Socket)
 	for i := startBlock; i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
 		// Subtract 1 since FilterQuery is inclusive
-		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(DefaultQueryBlockRange, big.NewInt(1)))
+		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(blockRange, big.NewInt(1)))
 		if toBlock.Cmp(stopBlock) > 0 {
 			toBlock = stopBlock
 		}

--- a/chainio/mocks/avsRegistryContractsReader.go
+++ b/chainio/mocks/avsRegistryContractsReader.go
@@ -212,9 +212,9 @@ func (mr *MockAvsRegistryReaderMockRecorder) IsOperatorRegistered(arg0, arg1 any
 }
 
 // QueryExistingRegisteredOperatorPubKeys mocks base method.
-func (m *MockAvsRegistryReader) QueryExistingRegisteredOperatorPubKeys(arg0 context.Context, arg1, arg2 *big.Int) ([]common.Address, []types.OperatorPubkeys, error) {
+func (m *MockAvsRegistryReader) QueryExistingRegisteredOperatorPubKeys(arg0 context.Context, arg1, arg2, arg3 *big.Int) ([]common.Address, []types.OperatorPubkeys, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryExistingRegisteredOperatorPubKeys", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "QueryExistingRegisteredOperatorPubKeys", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]common.Address)
 	ret1, _ := ret[1].([]types.OperatorPubkeys)
 	ret2, _ := ret[2].(error)
@@ -222,22 +222,22 @@ func (m *MockAvsRegistryReader) QueryExistingRegisteredOperatorPubKeys(arg0 cont
 }
 
 // QueryExistingRegisteredOperatorPubKeys indicates an expected call of QueryExistingRegisteredOperatorPubKeys.
-func (mr *MockAvsRegistryReaderMockRecorder) QueryExistingRegisteredOperatorPubKeys(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAvsRegistryReaderMockRecorder) QueryExistingRegisteredOperatorPubKeys(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryExistingRegisteredOperatorPubKeys", reflect.TypeOf((*MockAvsRegistryReader)(nil).QueryExistingRegisteredOperatorPubKeys), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryExistingRegisteredOperatorPubKeys", reflect.TypeOf((*MockAvsRegistryReader)(nil).QueryExistingRegisteredOperatorPubKeys), arg0, arg1, arg2, arg3)
 }
 
 // QueryExistingRegisteredOperatorSockets mocks base method.
-func (m *MockAvsRegistryReader) QueryExistingRegisteredOperatorSockets(arg0 context.Context, arg1, arg2 *big.Int) (map[types.Bytes32]types.Socket, error) {
+func (m *MockAvsRegistryReader) QueryExistingRegisteredOperatorSockets(arg0 context.Context, arg1, arg2, arg3 *big.Int) (map[types.Bytes32]types.Socket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryExistingRegisteredOperatorSockets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "QueryExistingRegisteredOperatorSockets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(map[types.Bytes32]types.Socket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // QueryExistingRegisteredOperatorSockets indicates an expected call of QueryExistingRegisteredOperatorSockets.
-func (mr *MockAvsRegistryReaderMockRecorder) QueryExistingRegisteredOperatorSockets(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAvsRegistryReaderMockRecorder) QueryExistingRegisteredOperatorSockets(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryExistingRegisteredOperatorSockets", reflect.TypeOf((*MockAvsRegistryReader)(nil).QueryExistingRegisteredOperatorSockets), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryExistingRegisteredOperatorSockets", reflect.TypeOf((*MockAvsRegistryReader)(nil).QueryExistingRegisteredOperatorSockets), arg0, arg1, arg2, arg3)
 }

--- a/services/operatorsinfo/operatorsinfo_inmemory_test.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory_test.go
@@ -59,9 +59,9 @@ func TestGetOperatorInfo(t *testing.T) {
 				errC := make(chan error)
 				mockSubscription.EXPECT().Err().AnyTimes().Return(errC)
 				mockAvsRegistrySubscriber.EXPECT().SubscribeToNewPubkeyRegistrations().Return(nil, mockSubscription, nil)
-				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorPubKeys(gomock.Any(), nil, nil).Return(nil, nil, nil)
+				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorPubKeys(gomock.Any(), nil, nil, defaultLogFilterQueryBlockRange).Return(nil, nil, nil)
 				mockAvsRegistrySubscriber.EXPECT().SubscribeToOperatorSocketUpdates().Return(nil, mockSubscription, nil)
-				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorSockets(gomock.Any(), nil, nil).Return(nil, nil)
+				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorSockets(gomock.Any(), nil, nil, defaultLogFilterQueryBlockRange).Return(nil, nil)
 			},
 			queryOperatorAddr: testOperator1.operatorAddr,
 			wantOperatorFound: false,
@@ -73,10 +73,10 @@ func TestGetOperatorInfo(t *testing.T) {
 				errC := make(chan error)
 				mockSubscription.EXPECT().Err().AnyTimes().Return(errC)
 				mockAvsRegistrySubscriber.EXPECT().SubscribeToNewPubkeyRegistrations().Return(nil, mockSubscription, nil)
-				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorPubKeys(gomock.Any(), nil, nil).
+				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorPubKeys(gomock.Any(), nil, nil, defaultLogFilterQueryBlockRange).
 					Return([]common.Address{testOperator1.operatorAddr}, []types.OperatorPubkeys{testOperator1.operatorInfo.Pubkeys}, nil)
 				mockAvsRegistrySubscriber.EXPECT().SubscribeToOperatorSocketUpdates().Return(nil, mockSubscription, nil)
-				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorSockets(gomock.Any(), nil, nil).
+				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorSockets(gomock.Any(), nil, nil, defaultLogFilterQueryBlockRange).
 					Return(map[types.OperatorId]types.Socket{
 						types.OperatorIdFromG1Pubkey(testOperator1.operatorInfo.Pubkeys.G1Pubkey): testOperator1.operatorInfo.Socket,
 					}, nil)
@@ -106,10 +106,10 @@ func TestGetOperatorInfo(t *testing.T) {
 				operatorSocketUpdateEventC <- operatorSocketUpdateEvent
 				mockSubscription.EXPECT().Err().AnyTimes().Return(errC)
 				mockAvsRegistrySubscriber.EXPECT().SubscribeToNewPubkeyRegistrations().Return(pubkeyRegistrationEventC, mockSubscription, nil)
-				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorPubKeys(gomock.Any(), nil, nil).
+				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorPubKeys(gomock.Any(), nil, nil, defaultLogFilterQueryBlockRange).
 					Return([]common.Address{}, []types.OperatorPubkeys{}, nil)
 				mockAvsRegistrySubscriber.EXPECT().SubscribeToOperatorSocketUpdates().Return(operatorSocketUpdateEventC, mockSubscription, nil)
-				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorSockets(gomock.Any(), nil, nil).Return(nil, nil)
+				mockAvsReader.EXPECT().QueryExistingRegisteredOperatorSockets(gomock.Any(), nil, nil, defaultLogFilterQueryBlockRange).Return(nil, nil)
 			},
 			queryOperatorAddr: testOperator1.operatorAddr,
 			wantOperatorFound: true,
@@ -129,7 +129,7 @@ func TestGetOperatorInfo(t *testing.T) {
 				tt.mocksInitializationFunc(mockAvsRegistrySubscriber, mockAvsReader, mockSubscription)
 			}
 			// Create a new instance of the operatorpubkeys service
-			service := NewOperatorsInfoServiceInMemory(context.Background(), mockAvsRegistrySubscriber, mockAvsReader, logger)
+			service := NewOperatorsInfoServiceInMemory(context.Background(), mockAvsRegistrySubscriber, mockAvsReader, nil, logger)
 			time.Sleep(2 * time.Second) // need to give it time to process the subscription events.. not sure if there's a better way to do this.
 
 			// Call the GetOperatorPubkeys method with the test operator address


### PR DESCRIPTION


### What Changed?
<!-- Describe the changes made in this pull request -->
Realized some node providers don't even allow the 10k query range, so had to make it passed as an argument, with default fallback to 10_000.
This is another breaking change for the interface though :\

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it