### PR TITLE
AVS-259: Subgraph test

### DIFF
--- a/services/operatorsinfo/operatorsinfo_subgraph.go
+++ b/services/operatorsinfo/operatorsinfo_subgraph.go
@@ -15,8 +15,8 @@ import (
 )
 
 type (
-	QueryOperatorByIdGql struct {
-		Operator IndexedOperatorInfoGql `graphql:"operator(id: $id)"`
+	QueryOperatorByAddressGql struct {
+		Operator IndexedOperatorInfoGql `graphql:"operator(address: $address)"`
 	}
 	OperatorsInfoServiceSubgraph struct {
 		logger logging.Logger
@@ -26,7 +26,7 @@ type (
 		Socket graphql.String
 	}
 	IndexedOperatorInfoGql struct {
-		Id         graphql.String
+		Address    graphql.String
 		PubkeyG1_X graphql.String   `graphql:"pubkeyG1_X"`
 		PubkeyG1_Y graphql.String   `graphql:"pubkeyG1_Y"`
 		PubkeyG2_X []graphql.String `graphql:"pubkeyG2_X"`
@@ -80,7 +80,7 @@ func (ops *OperatorsInfoServiceSubgraph) GetOperatorInfo(ctx context.Context, op
 
 func (ops *OperatorsInfoServiceSubgraph) getIndexedOperatorInfoByOperatorId(ctx context.Context, operator common.Address) (*types.OperatorInfo, error) {
 	var (
-		query     QueryOperatorByIdGql
+		query     QueryOperatorByAddressGql
 		variables = map[string]any{
 			"id": graphql.String(fmt.Sprintf("0x%s", hex.EncodeToString(operator[:]))),
 		}

--- a/services/operatorsinfo/operatorsinfo_subgraph.go
+++ b/services/operatorsinfo/operatorsinfo_subgraph.go
@@ -85,7 +85,7 @@ func (ops *OperatorsInfoServiceSubgraph) getIndexedOperatorInfoByOperatorId(ctx 
 			"id": graphql.String(fmt.Sprintf("0x%s", hex.EncodeToString(operator[:]))),
 		}
 	)
-	err := ops.client.Query(context.Background(), &query, variables)
+	err := ops.client.Query(ctx, &query, variables)
 	if err != nil {
 		ops.logger.Error("Error requesting info for operator", "err", err, "operator", hex.EncodeToString(operator[:]))
 		return nil, err

--- a/services/operatorsinfo/operatorsinfo_subgraph.go
+++ b/services/operatorsinfo/operatorsinfo_subgraph.go
@@ -20,7 +20,8 @@ type (
 	}
 	OperatorsInfoServiceSubgraph struct {
 		logger logging.Logger
-		client *graphql.Client
+		client GraphQLQuerier
+		name   string
 	}
 	SocketUpdates struct {
 		Socket graphql.String
@@ -47,6 +48,9 @@ type (
 	G1Point struct {
 		*bn254.G1Affine
 	}
+	GraphQLQuerier interface {
+		Query(ctx context.Context, q any, variables map[string]any) error
+	}
 )
 
 var _ OperatorsInfoService = (*OperatorsInfoServiceSubgraph)(nil)
@@ -58,14 +62,13 @@ var _ OperatorsInfoService = (*OperatorsInfoServiceSubgraph)(nil)
 // Using a separate initialize() function might lead to some users forgetting to call it and the service not behaving properly.
 func NewOperatorsInfoServiceSubgraph(
 	ctx context.Context,
-	url string,
+	client GraphQLQuerier,
 	logger logging.Logger,
 ) *OperatorsInfoServiceSubgraph {
-	client := graphql.NewClient(url, nil)
-
 	return &OperatorsInfoServiceSubgraph{
 		logger: logger,
 		client: client,
+		name:   "OperatorsInfoServiceSubgraph",
 	}
 }
 
@@ -85,6 +88,8 @@ func (ops *OperatorsInfoServiceSubgraph) getIndexedOperatorInfoByOperatorId(ctx 
 			"id": graphql.String(fmt.Sprintf("0x%s", hex.EncodeToString(operator[:]))),
 		}
 	)
+	fmt.Print("NAME OF SUBRAPH", ops.name)
+	fmt.Print("NAME OF SUBRAPH: ", ops.client)
 	err := ops.client.Query(ctx, &query, variables)
 	if err != nil {
 		ops.logger.Error("Error requesting info for operator", "err", err, "operator", hex.EncodeToString(operator[:]))

--- a/services/operatorsinfo/operatorsinfo_subgraph_test.go
+++ b/services/operatorsinfo/operatorsinfo_subgraph_test.go
@@ -1,0 +1,59 @@
+package operatorsinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/shurcooL/graphql"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockGraphQLQuerier struct {
+	QueryFn func(ctx context.Context, q any, variables map[string]any) error
+}
+
+func (m mockGraphQLQuerier) Query(ctx context.Context, q any, variables map[string]any) error {
+	return m.QueryFn(ctx, q, variables)
+}
+
+func TestIndexedChainState_GetIndexedOperatorState(t *testing.T) {
+	logger := logging.NewNoopLogger()
+
+	operatorAddress := common.Address{0x1}
+
+	operatorsQueryCalled := false
+	querier := &mockGraphQLQuerier{}
+	querier.QueryFn = func(ctx context.Context, q any, variables map[string]any) error {
+		switch res := q.(type) {
+		case *QueryOperatorByAddressGql:
+			if operatorsQueryCalled {
+				return nil
+			}
+			res.Operator = IndexedOperatorInfoGql{
+				Address:    graphql.String(operatorAddress.String()),
+				PubkeyG1_X: "3336192159512049190945679273141887248666932624338963482128432381981287252980",
+				PubkeyG1_Y: "15195175002875833468883745675063986308012687914999552116603423331534089122704",
+				PubkeyG2_X: []graphql.String{
+					"21597023645215426396093421944506635812143308313031252511177204078669540440732",
+					"11405255666568400552575831267661419473985517916677491029848981743882451844775",
+				},
+				PubkeyG2_Y: []graphql.String{
+					"9416989242565286095121881312760798075882411191579108217086927390793923664442",
+					"13612061731370453436662267863740141021994163834412349567410746669651828926551",
+				},
+				SocketUpdates: []SocketUpdates{{Socket: "localhost:32006;32007"}},
+			}
+			operatorsQueryCalled = true
+			return nil
+		default:
+			return nil
+		}
+	}
+
+	cs := NewOperatorsInfoServiceSubgraph(context.Background(), operatorAddress.String(), logger)
+	operatorPubkeys, err := cs.GetOperatorInfo(context.Background(), operatorAddress)
+	assert.True(t, err)
+	assert.Equal(t, operatorPubkeys.Socket, "localhost:32006;32007")
+}

--- a/services/operatorsinfo/operatorsinfo_subgraph_test.go
+++ b/services/operatorsinfo/operatorsinfo_subgraph_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/shurcooL/graphql"
 	"github.com/stretchr/testify/assert"
@@ -52,8 +53,8 @@ func TestIndexedChainState_GetIndexedOperatorState(t *testing.T) {
 		}
 	}
 
-	cs := NewOperatorsInfoServiceSubgraph(context.Background(), operatorAddress.String(), logger)
+	cs := NewOperatorsInfoServiceSubgraph(context.Background(), querier, logger)
 	operatorPubkeys, err := cs.GetOperatorInfo(context.Background(), operatorAddress)
 	assert.True(t, err)
-	assert.Equal(t, operatorPubkeys.Socket, "localhost:32006;32007")
+	assert.Equal(t, operatorPubkeys.Socket, types.Socket("localhost:32006;32007"))
 }


### PR DESCRIPTION
Fixes # .

### What Changed?
Adds unit + integration tests for operatorInfo subgraph
### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it