### PR TITLE
fix the way operator sockets are printed in operatorsinfo srvc

### DIFF
--- a/services/operatorsinfo/operatorsinfo_inmemory.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory.go
@@ -195,7 +195,12 @@ func (ops *OperatorsInfoServiceInMemory) queryPastRegisteredOperatorEventsAndFil
 		return utils.WrapError(errors.New("error querying existing registered operator sockets"), socketsErr)
 	}
 	ops.logger.Debug("List of queried operator registration events in blsApkRegistry", "alreadyRegisteredOperatorAddr", alreadyRegisteredOperatorAddrs, "alreadyRegisteredOperatorPubkeys", alreadyRegisteredOperatorPubkeys, "service", "OperatorPubkeysServiceInMemory")
-	ops.logger.Debug("List of queried operator socket registration events", "socketsMap", socketsMap, "service", "OperatorPubkeysServiceInMemory")
+	for operatorId, socket := range socketsMap {
+		// we print each socket info on a separate line because slog for some reason doesn't pass map keys via their LogValue() function,
+		// so operatorId (of custom type Bytes32) prints as a byte array instead of its hex representation from LogValue()
+		// passing the Bytes32 directly to an slog log statements does call LogValue() and prints the hex representation
+		ops.logger.Debug("operator socket returned from registration events query", "operatorId", operatorId, "socket", socket, "service", "OperatorPubkeysServiceInMemory")
+	}
 
 	// Fill the pubkeydict db with the operators and pubkeys found
 	for i, operatorAddr := range alreadyRegisteredOperatorAddrs {


### PR DESCRIPTION


### What Changed?
<!-- Describe the changes made in this pull request -->
Simple change. Tried to find a way to get slog to pass map keys through their LogValue function, but couldn't find anything.
Another option would be to define a custom type for each map we have and define a LogValue on each, but that seems tiresome...

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it