### PR TITLE
added derive_operatorid command to egnkey

### DIFF
--- a/cmd/egnkey/derive_operatorid/derive_operatorid.go
+++ b/cmd/egnkey/derive_operatorid/derive_operatorid.go
@@ -1,0 +1,39 @@
+package derive_operatorid
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	"github.com/Layr-Labs/eigensdk-go/types"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	PrivateKey = &cli.StringFlag{
+		Name:     "private-key",
+		Usage:    "(bn254) private key from which to derive operatorId from",
+		Required: true,
+	}
+)
+
+var Command = &cli.Command{
+	Name:        "derive-operator-id",
+	Aliases:     []string{"d"},
+	Description: `Given a private key, output its associated operatorId (hash of bn254 G1 pubkey).`,
+	Action:      derive,
+	Flags: []cli.Flag{
+		PrivateKey,
+	},
+}
+
+func derive(c *cli.Context) error {
+	sk := c.String(PrivateKey.Name)
+	keypair, err := bls.NewKeyPairFromString(sk)
+	if err != nil {
+		return err
+	}
+	operatorId := types.OperatorIdFromKeyPair(keypair)
+	fmt.Println("0x" + hex.EncodeToString(operatorId[:]))
+	return nil
+}

--- a/cmd/egnkey/generate/generate.go
+++ b/cmd/egnkey/generate/generate.go
@@ -1,4 +1,4 @@
-package main
+package generate
 
 import (
 	"encoding/hex"
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-var commandGenerate = &cli.Command{
+var Command = &cli.Command{
 	Name:    "generate",
 	Aliases: []string{"g"},
 	Description: `Generate keys for testing purpose.

--- a/cmd/egnkey/main.go
+++ b/cmd/egnkey/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/derive_operatorid"
+	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/operatorid"
 	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/generate"
 	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/store"
 	"github.com/urfave/cli/v2"
@@ -17,7 +17,7 @@ func main() {
 	app.Commands = []*cli.Command{
 		generate.Command,
 		store.Command,
-		derive_operatorid.Command,
+		operatorid.Command,
 	}
 
 	app.Usage = "Used to manage batch keys for testing"

--- a/cmd/egnkey/main.go
+++ b/cmd/egnkey/main.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/derive_operatorid"
+	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/generate"
+	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/store"
 	"github.com/urfave/cli/v2"
 )
 
@@ -12,8 +15,9 @@ func main() {
 	app.Name = "egnkey"
 	app.Description = "Eigenlayer batch keys manager"
 	app.Commands = []*cli.Command{
-		commandGenerate,
-		commandStore,
+		generate.Command,
+		store.Command,
+		derive_operatorid.Command,
 	}
 
 	app.Usage = "Used to manage batch keys for testing"

--- a/cmd/egnkey/operatorid/operatorid.go
+++ b/cmd/egnkey/operatorid/operatorid.go
@@ -1,4 +1,4 @@
-package derive_operatorid
+package operatorid
 
 import (
 	"encoding/hex"

--- a/cmd/egnkey/store/store.go
+++ b/cmd/egnkey/store/store.go
@@ -1,4 +1,4 @@
-package main
+package store
 
 import (
 	"github.com/Layr-Labs/eigensdk-go/crypto/ecdsa"
@@ -25,7 +25,7 @@ var (
 	}
 )
 
-var commandStore = &cli.Command{
+var Command = &cli.Command{
 	Name:        "convert",
 	Aliases:     []string{"c"},
 	Description: `Stores an ecdsa key to a file, in web3 secret storage format.`,


### PR DESCRIPTION
Not sure if this is the best place to have this but I really need something like this to help me debug wrong operator registration scenarios for tests and local devnets.

Typically generate a bunch of keys from some mnemonic, and want to quickly see their associated operatorId (hash of G1 pubkey associated with that private key). So with this command I'll just be able to pipe the private keys through this to also print their operatorId

### What Changed?
<!-- Describe the changes made in this pull request -->

also refactored commands to be in their own packages to prevent var/flag conflicts

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it