### PR TITLE
minimal diff to be able to return the task response bytes instead of just the task response digest

### DIFF
--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -274,6 +274,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 		select {
 		case signedTaskResponseDigest := <-signedTaskRespsC:
 			a.logger.Debug("Task goroutine received new signed task response digest", "taskIndex", taskIndex, "signedTaskResponseDigest", signedTaskResponseDigest)
+			// Retrieve the TaskResponse from the map
+			taskResponse := a.taskResponseMap[signedTaskResponseDigest.TaskResponseDigest]
 
 			err := a.verifySignature(taskIndex, signedTaskResponseDigest, operatorsAvsStateDict)
 			signedTaskResponseDigest.SignatureVerificationErrorC <- err

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -136,9 +136,6 @@ type BlsAggregatorService struct {
 	avsRegistryService avsregistry.AvsRegistryService
 	logger             logging.Logger
 
-	// taskResponseMap is a map of taskResponseDigest to taskResponse
-	taskResponseMap map[types.TaskResponseDigest]types.TaskResponse
-
 	hashFunction types.TaskResponseHashFunction
 }
 
@@ -151,7 +148,6 @@ func NewBlsAggregatorService(avsRegistryService avsregistry.AvsRegistryService, 
 		taskChansMutex:       sync.RWMutex{},
 		avsRegistryService:   avsRegistryService,
 		logger:               logger,
-		taskResponseMap:      make(map[types.TaskResponseDigest]types.TaskResponse),
 		hashFunction:         hashFunction,
 	}
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -186,7 +186,6 @@ func (a *BlsAggregatorService) ProcessNewSignature(
 	ctx context.Context,
 	taskIndex types.TaskIndex,
 	taskResponse types.TaskResponse,
-	//taskResponseDigest types.TaskResponseDigest,
 	blsSignature *bls.Signature,
 	operatorId types.OperatorId,
 ) error {
@@ -199,8 +198,12 @@ func (a *BlsAggregatorService) ProcessNewSignature(
 	// compute the taskResponseDigest, note that this is now enforcing a specific encoding for the taskResponse
 	taskResponseDigest := types.TaskResponseDigest(sha256.Sum256(taskResponse))
 
-	// Store the TaskResponse in our mapping
-	a.taskResponseMap[taskResponseDigest] = taskResponse
+	// check if the taskResponseDigest is already in the map
+	_, taskResponseExists := a.taskResponseMap[taskResponseDigest]
+	if !taskResponseExists {
+		// Store the TaskResponse in our mapping
+		a.taskResponseMap[taskResponseDigest] = taskResponse
+	}
 
 	signatureVerificationErrorC := make(chan error)
 	// send the task to the goroutine processing this task

--- a/types/avs.go
+++ b/types/avs.go
@@ -8,6 +8,7 @@ import (
 
 type TaskIndex = uint32
 type TaskResponseDigest = Bytes32
+type TaskResponse = []byte
 
 type SignedTaskResponseDigest struct {
 	TaskResponseDigest          TaskResponseDigest

--- a/types/avs.go
+++ b/types/avs.go
@@ -8,7 +8,9 @@ import (
 
 type TaskIndex = uint32
 type TaskResponseDigest = Bytes32
-type TaskResponse = []byte
+type TaskResponse = interface{}
+
+type TaskResponseHashFunction func(taskResponse TaskResponse) TaskResponseDigest
 
 type SignedTaskResponseDigest struct {
 	TaskResponseDigest          TaskResponseDigest

--- a/types/avs.go
+++ b/types/avs.go
@@ -13,7 +13,7 @@ type TaskResponse = interface{}
 type TaskResponseHashFunction func(taskResponse TaskResponse) TaskResponseDigest
 
 type SignedTaskResponseDigest struct {
-	TaskResponseDigest          TaskResponseDigest
+	TaskResponse                TaskResponse
 	BlsSignature                *bls.Signature
 	OperatorId                  OperatorId
 	SignatureVerificationErrorC chan error `json:"-"` // removed from json because channels are not marshallable
@@ -21,7 +21,7 @@ type SignedTaskResponseDigest struct {
 
 func (strd SignedTaskResponseDigest) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.Any("taskResponseDigest", strd.TaskResponseDigest),
+		slog.Any("taskResponse", strd.TaskResponse),
 		slog.Any("blsSignature", strd.BlsSignature),
 		slog.Any("operatorId", strd.OperatorId),
 	)


### PR DESCRIPTION
Fixes [AVS-218](https://linear.app/eigenlabs/issue/AVS-218/fix-blsagg-service-to-store-and-return-msgs-not-their-hash)

Update `bls_aggregation` service to return the Task Response bytes 

### What Changed?

- Added the type `TaskResponse` to the avs types and include it in the `BlsAggregationServiceResponse`
- Update `ProcessNewSignature` to take in the `TaskResponse` as a parameter instead of the `TaskReponseDigest` 
- Update `SignedTaskResponseDigest` to return the `TaskResponse` rather than the `TaskResponseDigest`
    - Compute the `TaskResponseDigest` to be signed in the function as the hashFunction of the `TaskResponse` bytes

TODO: update comments


### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it 