### PR TITLE
feat: use new NewServeMux instead of Default and ctx for running metrics server

### DIFF
--- a/metrics/eigenmetrics.go
+++ b/metrics/eigenmetrics.go
@@ -107,10 +107,10 @@ func (m *EigenMetrics) Start(ctx context.Context, reg prometheus.Gatherer) <-cha
 
 	go func() {
 		err := httpServer.ListenAndServe()
-		if err != nil {
-			errChan <- utils.WrapError("Prometheus server failed", err)
+		if err == http.ErrServerClosed {
+			m.logger.Info("server closed")
 		} else {
-			errChan <- nil
+			errChan <- utils.WrapError("Prometheus server failed", err)
 		}
 	}()
 	return errChan

--- a/metrics/eigenmetrics.go
+++ b/metrics/eigenmetrics.go
@@ -80,12 +80,17 @@ func (m *EigenMetrics) SetPerformanceScore(score float64) {
 func (m *EigenMetrics) Start(ctx context.Context, reg prometheus.Gatherer) <-chan error {
 	m.logger.Infof("Starting metrics server at port %v", m.ipPortAddress)
 	errC := make(chan error, 1)
+	mux := http.NewServeMux()
+	httpServer := http.Server{
+		Addr:    m.ipPortAddress,
+		Handler: mux,
+	}
 	go func() {
-		http.Handle("/metrics", promhttp.HandlerFor(
+		mux.Handle("/metrics", promhttp.HandlerFor(
 			reg,
 			promhttp.HandlerOpts{},
 		))
-		err := http.ListenAndServe(m.ipPortAddress, nil)
+		err := httpServer.ListenAndServe()
 		if err != nil {
 			errC <- utils.WrapError("Prometheus server failed", err)
 		} else {

--- a/metrics/eigenmetrics.go
+++ b/metrics/eigenmetrics.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/Layr-Labs/eigensdk-go/utils"
-	"gorm.io/gorm/logger"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -102,7 +101,7 @@ func (m *EigenMetrics) Start(ctx context.Context, reg prometheus.Gatherer) <-cha
 		if err := httpServer.Shutdown(context.Background()); err != nil {
 			errChan <- err
 		}
-		logger.Info("shutdown completed")
+		m.logger.Info("shutdown completed")
 	}()
 
 	go func() {


### PR DESCRIPTION
### What Changed?
This PR does following:

- introduces new server mux instead of default
- uses context from `Start` to be able to stop server// context handling

### Why this PR?
- `context` arg was currently not being used
- in our e2e tests, we create multiple metric servers (for different services/components/multiple operators). We couldn't register different prometheus registries because of the `DefaultServeMux` coming from `http` package. This change could enable that

### Reviewer Checklist
- [x] Code is well-documented
- [x] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [x] Code deprecates any old functionality before removing it