### PR TITLE
Update blsagg service hash fn to return error

### DIFF
--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -274,7 +274,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			// compute the taskResponseDigest using the hash function
 			taskResponseDigest, err := a.hashFunction(signedTaskResponseDigest.TaskResponse)
 			if err != nil {
-				a.logger.Error("Failed to hash task response, skipping.", "taskIndex", taskIndex, "signedTaskResponseDigest", signedTaskResponseDigest, "err", err)
+				// this error should never happen, because we've already hashed the taskResponse in verifySignature,
+				// but keeping here in case the verifySignature implementation ever changes or some catastrophic bug happens..
 				continue
 			}
 			// after verifying signature we aggregate its sig and pubkey, and update the signed stake amount
@@ -392,6 +393,7 @@ func (a *BlsAggregatorService) verifySignature(
 
 	taskResponseDigest, err := a.hashFunction(signedTaskResponseDigest.TaskResponse)
 	if err != nil {
+		a.logger.Error("Failed to hash task response, skipping.", "taskIndex", taskIndex, "signedTaskResponseDigest", signedTaskResponseDigest, "err", err)
 		return HashFunctionError(err)
 	}
 

--- a/services/mocks/blsagg/blsaggregation.go
+++ b/services/mocks/blsagg/blsaggregation.go
@@ -72,7 +72,7 @@ func (mr *MockBlsAggregationServiceMockRecorder) InitializeNewTask(arg0, arg1, a
 }
 
 // ProcessNewSignature mocks base method.
-func (m *MockBlsAggregationService) ProcessNewSignature(arg0 context.Context, arg1 uint32, arg2 types.Bytes32, arg3 *bls.Signature, arg4 types.Bytes32) error {
+func (m *MockBlsAggregationService) ProcessNewSignature(arg0 context.Context, arg1 uint32, arg2 any, arg3 *bls.Signature, arg4 types.Bytes32) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessNewSignature", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)

--- a/types/avs.go
+++ b/types/avs.go
@@ -10,7 +10,7 @@ type TaskIndex = uint32
 type TaskResponseDigest = Bytes32
 type TaskResponse = interface{}
 
-type TaskResponseHashFunction func(taskResponse TaskResponse) TaskResponseDigest
+type TaskResponseHashFunction func(taskResponse TaskResponse) (TaskResponseDigest, error)
 
 type SignedTaskResponseDigest struct {
 	TaskResponse                TaskResponse


### PR DESCRIPTION
the hashfn type in blsagg was not returning error, which was forcing implementations to panic.

### What Changed?
<!-- Describe the changes made in this pull request -->

Updated to also return error so client can decide what to do on error

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it