### PR TITLE
feat: Add task index in the BlsAggregationServiceResponse when error

### DIFF
--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -235,14 +235,16 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	operatorsAvsStateDict, err := a.avsRegistryService.GetOperatorsAvsStateAtBlock(context.Background(), quorumNumbers, taskCreatedBlock)
 	if err != nil {
 		a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-			Err: TaskInitializationErrorFn(fmt.Errorf("AggregatorService failed to get operators state from avs registry at blockNum %d: %w", taskCreatedBlock, err), taskIndex),
+			Err:       TaskInitializationErrorFn(fmt.Errorf("AggregatorService failed to get operators state from avs registry at blockNum %d: %w", taskCreatedBlock, err), taskIndex),
+			TaskIndex: taskIndex,
 		}
 		return
 	}
 	quorumsAvsStakeDict, err := a.avsRegistryService.GetQuorumsAvsStateAtBlock(context.Background(), quorumNumbers, taskCreatedBlock)
 	if err != nil {
 		a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-			Err: TaskInitializationErrorFn(fmt.Errorf("Aggregator failed to get quorums state from avs registry: %w", err), taskIndex),
+			Err:       TaskInitializationErrorFn(fmt.Errorf("Aggregator failed to get quorums state from avs registry: %w", err), taskIndex),
+			TaskIndex: taskIndex,
 		}
 		return
 	}
@@ -330,7 +332,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 				indices, err := a.avsRegistryService.GetCheckSignaturesIndices(&bind.CallOpts{}, taskCreatedBlock, quorumNumbers, nonSignersOperatorIds)
 				if err != nil {
 					a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-						Err: utils.WrapError(errors.New("Failed to get check signatures indices"), err),
+						Err:       utils.WrapError(errors.New("Failed to get check signatures indices"), err),
+						TaskIndex: taskIndex,
 					}
 					return
 				}
@@ -355,7 +358,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			}
 		case <-taskExpiredTimer.C:
 			a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-				Err: TaskExpiredErrorFn(taskIndex),
+				Err:       TaskExpiredErrorFn(taskIndex),
+				TaskIndex: taskIndex,
 			}
 			return
 		}

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -85,6 +85,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
 	t.Run("1 quorum 3 operator 3 correct signatures", func(t *testing.T) {
@@ -147,6 +148,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
 	t.Run("2 quorums 2 operators 2 correct signatures", func(t *testing.T) {
@@ -538,6 +540,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
 	t.Run("2 quorums 1 operators which just stake one quorum; 1 signatures - task expired", func(t *testing.T) {
@@ -570,6 +573,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
 	t.Run("2 quorums 2 operators, 1 operator which just stake one quorum; 1 signatures - task expired", func(t *testing.T) {
@@ -607,6 +611,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
 	t.Run("send signature of task that isn't initialized - task not found error", func(t *testing.T) {
@@ -683,6 +688,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
 	t.Run("1 quorum 2 operator 2 signatures on 2 different msgs - task expired", func(t *testing.T) {
@@ -724,6 +730,7 @@ func TestBlsAgg(t *testing.T) {
 		}
 		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
 	t.Run("1 quorum 1 operator 1 invalid signature (TaskResponseDigest does not match TaskResponse)", func(t *testing.T) {


### PR DESCRIPTION
### What Changed?

Add task index in the BlsAggregationServiceResponse when error

When develop aggregator by eigensdk-go, some bls sig task may failed or expired, when this happend, 
the caller will got a err from `blsAggServ.aggregatedResponsesC`.

But this responses will just contain a err by:

```go
	TaskExpiredErrorFn = func(taskIndex types.TaskIndex) error {
		return fmt.Errorf("task %d expired", taskIndex)
	}
```

if the caller should process which task is failed, only can write this code:

```go
	var taskIndex uint32
	if blsAggServiceResp.Err != nil {
		errString := blsAggServiceResp.Err.Error()
		if strings.Contains(errString, "expired") {
			fmt.Sscanf(errString, "task %d expired", &taskIndex)
			t.logger.Debug("expired index", "index", taskIndex)
		}
	} else {
		taskIndex = blsAggServiceResp.TaskIndex
	}

       // process taskIndex ...
```

So we can just put the `taskIndex` into the resp when error, then the caller can not use `Sscanf` which depend by error.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it