### PR TITLE
separate operator details and metadata uri update

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -21,7 +21,8 @@ import (
 	stakeregistry "github.com/Layr-Labs/eigensdk-go/contracts/bindings/StakeRegistry"
 )
 
-// different node providers have different eth_getLogs range limits. 10k is an arbitrary choice that should work for most
+// different node providers have different eth_getLogs range limits. 10k is an arbitrary choice that should work for
+// most
 var DefaultQueryBlockRange = big.NewInt(10_000)
 
 type AvsRegistryReader interface {

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -21,8 +21,8 @@ import (
 	stakeregistry "github.com/Layr-Labs/eigensdk-go/contracts/bindings/StakeRegistry"
 )
 
-// different node providers have different eth_getLogs range limits. 10k is an arbitrary choice that should work for
-// most
+// DefaultQueryBlockRange different node providers have different eth_getLogs range limits.
+// 10k is an arbitrary choice that should work for most
 var DefaultQueryBlockRange = big.NewInt(10_000)
 
 type AvsRegistryReader interface {

--- a/chainio/mocks/elContractsWriter.go
+++ b/chainio/mocks/elContractsWriter.go
@@ -73,6 +73,21 @@ func (mr *MockELWriterMockRecorder) RegisterAsOperator(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterAsOperator", reflect.TypeOf((*MockELWriter)(nil).RegisterAsOperator), arg0, arg1)
 }
 
+// UpdateMetadataURI mocks base method.
+func (m *MockELWriter) UpdateMetadataURI(arg0 context.Context, arg1 string) (*types0.Receipt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMetadataURI", arg0, arg1)
+	ret0, _ := ret[0].(*types0.Receipt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateMetadataURI indicates an expected call of UpdateMetadataURI.
+func (mr *MockELWriterMockRecorder) UpdateMetadataURI(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetadataURI", reflect.TypeOf((*MockELWriter)(nil).UpdateMetadataURI), arg0, arg1)
+}
+
 // UpdateOperatorDetails mocks base method.
 func (m *MockELWriter) UpdateOperatorDetails(arg0 context.Context, arg1 types.Operator) (*types0.Receipt, error) {
 	m.ctrl.T.Helper()

--- a/cmd/egnkey/main.go
+++ b/cmd/egnkey/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/operatorid"
 	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/generate"
+	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/operatorid"
 	"github.com/Layr-Labs/eigensdk-go/cmd/egnkey/store"
 	"github.com/urfave/cli/v2"
 )

--- a/signerv2/kms_signer.go
+++ b/signerv2/kms_signer.go
@@ -28,11 +28,18 @@ func NewKMSSigner(ctx context.Context, svc *kms.Client, pk *ecdsa.PublicKey, key
 
 // KMSSignerFn returns a SignerFn that uses a KMS key to sign transactions
 // Heavily taken from https://github.com/welthee/go-ethereum-aws-kms-tx-signer
-// It constructs R and S values from KMS, and constructs the recovery id (V) by trying to recover with both 0 and 1 values:
+// It constructs R and S values from KMS, and constructs the recovery id (V) by trying to recover with both 0 and 1
+// values:
 // ref: https://github.com/aws-samples/aws-kms-ethereum-accounts?tab=readme-ov-file#the-recovery-identifier-v
 //
 // Its V value is 0/1 instead of 27/28 because `types.LatestSignerForChainID` expects 0/1 which turns it into 27/28
-func KMSSignerFn(ctx context.Context, svc *kms.Client, pk *ecdsa.PublicKey, keyId string, chainID *big.Int) (bind.SignerFn, error) {
+func KMSSignerFn(
+	ctx context.Context,
+	svc *kms.Client,
+	pk *ecdsa.PublicKey,
+	keyId string,
+	chainID *big.Int,
+) (bind.SignerFn, error) {
 	if chainID == nil {
 		return nil, errors.New("chainID is required")
 	}


### PR DESCRIPTION
Fixes # .

### What Changed?
- Separate 2 different actions so client can only have dedicated tx and save on gas. Earlier this method used to send 2 transactions so I separated them
- formatting
- logging fixes

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it