### PR TITLE
Simplify register operator avswriter fn

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -336,16 +336,16 @@ func (w *AvsRegistryChainWriter) RegisterOperator(
 	var operatorToAvsRegistrationSigSalt [32]byte
 	_, err = rand.Read(operatorToAvsRegistrationSigSalt[:])
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	curBlockNum, err := w.ethClient.BlockNumber(context.Background())
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	curBlock, err := w.ethClient.BlockByNumber(context.Background(), big.NewInt(int64(curBlockNum)))
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	sigValidForSeconds := int64(60 * 60) // 1 hour
 	operatorToAvsRegistrationSigExpiry := big.NewInt(int64(curBlock.Time()) + sigValidForSeconds)

--- a/chainio/mocks/avsRegistryContractsWriter.go
+++ b/chainio/mocks/avsRegistryContractsWriter.go
@@ -61,6 +61,21 @@ func (mr *MockAvsRegistryWriterMockRecorder) DeregisterOperator(arg0, arg1, arg2
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterOperator", reflect.TypeOf((*MockAvsRegistryWriter)(nil).DeregisterOperator), arg0, arg1, arg2)
 }
 
+// RegisterOperator mocks base method.
+func (m *MockAvsRegistryWriter) RegisterOperator(arg0 context.Context, arg1 *ecdsa.PrivateKey, arg2 *bls.KeyPair, arg3 types.QuorumNums, arg4 string) (*types0.Receipt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterOperator", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*types0.Receipt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegisterOperator indicates an expected call of RegisterOperator.
+func (mr *MockAvsRegistryWriterMockRecorder) RegisterOperator(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterOperator", reflect.TypeOf((*MockAvsRegistryWriter)(nil).RegisterOperator), arg0, arg1, arg2, arg3, arg4)
+}
+
 // RegisterOperatorInQuorumWithAVSRegistryCoordinator mocks base method.
 func (m *MockAvsRegistryWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(arg0 context.Context, arg1 *ecdsa.PrivateKey, arg2 [32]byte, arg3 *big.Int, arg4 *bls.KeyPair, arg5 types.QuorumNums, arg6 string) (*types0.Receipt, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Fixes # .

### What Changed?
Simplify this function which was needlessly complicated. If users need the low level granularity than they can just use the bindings directly is what Im thinking. Most users of the high level writer client probably just want this to happen and not ask too many questions. That's also my case when writing test cases that use this function.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it