### PR TITLE
#79: fix data race for blsagg AVS-44

### DIFF
--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -291,7 +291,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 					signersApkG2:               bls.NewZeroG2Point().Add(operatorsAvsStateDict[signedTaskResponseDigest.OperatorId].OperatorInfo.Pubkeys.G2Pubkey),
 					signersAggSigG1:            signedTaskResponseDigest.BlsSignature,
 					signersOperatorIdsSet:      map[types.OperatorId]bool{signedTaskResponseDigest.OperatorId: true},
-					signersTotalStakePerQuorum: operatorsAvsStateDict[signedTaskResponseDigest.OperatorId].StakePerQuorum,
+					signersTotalStakePerQuorum: cloneStakePerQuorumMap(operatorsAvsStateDict[signedTaskResponseDigest.OperatorId].StakePerQuorum),
 				}
 			} else {
 				digestAggregatedOperators.signersAggSigG1.Add(signedTaskResponseDigest.BlsSignature)
@@ -463,4 +463,12 @@ func checkIfStakeThresholdsMet(
 		}
 	}
 	return true
+}
+
+func cloneStakePerQuorumMap(stakes map[types.QuorumNum]types.StakeAmount) map[types.QuorumNum]types.StakeAmount {
+	out := make(map[types.QuorumNum]types.StakeAmount, len(stakes))
+	for k, v := range stakes {
+		out[k] = new(big.Int).Set(v)
+	}
+	return out
 }


### PR DESCRIPTION
Fixes #79.

### What Changed?

```
==================
WARNING: DATA RACE
Write at 0x00c000189980 by goroutine 17:
  runtime.mapassign()
      /usr/local/go/src/runtime/map.go:579 +0x0
  github.com/Layr-Labs/eigensdk-go/services/bls_aggregation.(*BlsAggregatorService).singleTaskAggregatorGoroutineFunc()
      /Users/cheney/ata/eigensdk-go/services/bls_aggregation/blsagg.go:307 +0x2139
  github.com/Layr-Labs/eigensdk-go/services/bls_aggregation.(*BlsAggregatorService).InitializeNewTask.gowrap2()
      /Users/cheney/ata/eigensdk-go/services/bls_aggregation/blsagg.go:184 +0xf3

Previous read at 0x00c000189980 by goroutine 18:
  runtime.mapaccess2()
      /usr/local/go/src/runtime/map.go:457 +0x0
  github.com/Layr-Labs/eigensdk-go/services/bls_aggregation.checkIfStakeThresholdsMet()
      /Users/cheney/ata/eigensdk-go/services/bls_aggregation/blsagg.go:440 +0x116
  github.com/Layr-Labs/eigensdk-go/services/bls_aggregation.(*BlsAggregatorService).singleTaskAggregatorGoroutineFunc()
      /Users/cheney/ata/eigensdk-go/services/bls_aggregation/blsagg.go:314 +0x1464
  github.com/Layr-Labs/eigensdk-go/services/bls_aggregation.(*BlsAggregatorService).InitializeNewTask.gowrap2()
      /Users/cheney/ata/eigensdk-go/services/bls_aggregation/blsagg.go:184 +0xf3
```


This data race is caused by reading and writing the same map `operatorsAvsStateDict[].StakePerQuorum`, which is returned by `avsRegistryService.GetOperatorsAvsStateAtBlock` in multiple goroutines.  

In the test case, the implementation of `avsRegistryService` is `FakeAvsRegistryService`, and it always returns the same map for [`GetOperatorsAvsStateAtBlock`](https://github.com/Layr-Labs/eigensdk-go/blob/1ac246a1b715cf2d0ee5fc23612f4cacd7248db8/services/avsregistry/avsregistry_fake.go#L41).

We can fix this by cloning a new map for [`StakePerQuorum`](https://github.com/Layr-Labs/eigensdk-go/blob/1ac246a1b715cf2d0ee5fc23612f4cacd7248db8/services/bls_aggregation/blsagg.go#L292).

In the production environment, we can’t ensure that `avsRegistryService.GetOperatorsAvsStateAtBlock` always returns a new map that is safe to modify since `avsRegistryService` is an interface. For example, we have implemented a cache wrapper for `avsRegistryService`.

In conclusion, I think it’s worth cloning the `StakePerQuorum` map for safety since the overhead is low.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it