### PR TITLE
Test with race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ mocks: ## generates mocks
 	go generate ./...
 
 tests: ## runs all tests
-	go test -race ./... -timeout=30s
+	go test -race ./... -timeout=1m
 
 tests-cover: ## run all tests with test coverge
 	go test -race ./... -coverprofile=coverage.out -covermode=atomic -v -count=1

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ mocks: ## generates mocks
 	go generate ./...
 
 tests: ## runs all tests
-	go test ./... -timeout=30s
+	go test -race ./... -timeout=30s
 
 tests-cover: ## run all tests with test coverge
-	go test ./... -coverprofile=coverage.out -covermode=atomic -v -count=1
+	go test -race ./... -coverprofile=coverage.out -covermode=atomic -v -count=1
 	go tool cover -html=coverage.out -o coverage.html
 	open coverage.html
 


### PR DESCRIPTION
Would have prevented https://github.com/Layr-Labs/eigensdk-go/issues/79 from being introduced.

Tested locally.

Will make running tests slower, but tests can be made faster by running them in parallel (check `golangci-lint run -E paralleltest`)