### PR TITLE
add set claimer for to EL writer

### DIFF
--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -175,11 +175,11 @@ func (config *BuildAllConfig) BuildELClients(
 
 	delegationManagerAddr, err := avsRegistryContractBindings.StakeRegistry.Delegation(&bind.CallOpts{})
 	if err != nil {
-		logger.Fatal("Failed to fetch Slasher contract", "err", err)
+		logger.Fatal("Failed to fetch DelegationManager contract", "err", err)
 	}
 	avsDirectoryAddr, err := avsRegistryContractBindings.ServiceManager.AvsDirectory(&bind.CallOpts{})
 	if err != nil {
-		logger.Fatal("Failed to fetch Slasher contract", "err", err)
+		logger.Fatal("Failed to fetch AVSDirectory contract", "err", err)
 	}
 
 	elContractBindings, err := config.buildEigenLayerContractBindings(
@@ -206,6 +206,7 @@ func (config *BuildAllConfig) BuildELClients(
 		elContractBindings.Slasher,
 		elContractBindings.DelegationManager,
 		elContractBindings.StrategyManager,
+		nil,
 		elContractBindings.StrategyManagerAddr,
 		elChainReader,
 		ethHttpClient,

--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -206,7 +206,7 @@ func (config *BuildAllConfig) BuildELClients(
 		elContractBindings.Slasher,
 		elContractBindings.DelegationManager,
 		elContractBindings.StrategyManager,
-		nil,
+		nil, // this is nil because we don't have access to the rewards coordinator contract right now. we are going to refactor this method later
 		elContractBindings.StrategyManagerAddr,
 		elChainReader,
 		ethHttpClient,

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -9,16 +9,15 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
-	"github.com/Layr-Labs/eigensdk-go/logging"
-	"github.com/Layr-Labs/eigensdk-go/types"
-	"github.com/Layr-Labs/eigensdk-go/utils"
-
 	avsdirectory "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AVSDirectory"
 	delegationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/DelegationManager"
 	erc20 "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IERC20"
 	slasher "github.com/Layr-Labs/eigensdk-go/contracts/bindings/ISlasher"
 	strategy "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IStrategy"
 	strategymanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/StrategyManager"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/Layr-Labs/eigensdk-go/types"
+	"github.com/Layr-Labs/eigensdk-go/utils"
 )
 
 type ELReader interface {
@@ -62,16 +61,17 @@ type ELReader interface {
 }
 
 type Config struct {
-	DelegationManagerAddress common.Address
-	AvsDirectoryAddress      common.Address
+	DelegationManagerAddress  common.Address
+	AvsDirectoryAddress       common.Address
+	RewardsCoordinatorAddress common.Address
 }
 
 type ELChainReader struct {
 	logger            logging.Logger
 	slasher           slasher.ContractISlasherCalls
-	delegationManager delegationmanager.ContractDelegationManagerCalls
-	strategyManager   strategymanager.ContractStrategyManagerCalls
-	avsDirectory      avsdirectory.ContractAVSDirectoryCalls
+	delegationManager *delegationmanager.ContractDelegationManager
+	strategyManager   *strategymanager.ContractStrategyManager
+	avsDirectory      *avsdirectory.ContractAVSDirectory
 	ethClient         eth.Client
 }
 
@@ -80,9 +80,9 @@ var _ ELReader = (*ELChainReader)(nil)
 
 func NewELChainReader(
 	slasher slasher.ContractISlasherCalls,
-	delegationManager delegationmanager.ContractDelegationManagerCalls,
-	strategyManager strategymanager.ContractStrategyManagerCalls,
-	avsDirectory avsdirectory.ContractAVSDirectoryCalls,
+	delegationManager *delegationmanager.ContractDelegationManager,
+	strategyManager *strategymanager.ContractStrategyManager,
+	avsDirectory *avsdirectory.ContractAVSDirectory,
 	logger logging.Logger,
 	ethClient eth.Client,
 ) *ELChainReader {

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -3,6 +3,7 @@ package elcontracts
 import (
 	"context"
 	"errors"
+
 	"github.com/Layr-Labs/eigensdk-go/utils"
 
 	"math/big"

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -3,6 +3,7 @@ package elcontracts
 import (
 	"context"
 	"errors"
+	"github.com/Layr-Labs/eigensdk-go/utils"
 
 	"math/big"
 
@@ -311,7 +312,6 @@ func (w *ELChainWriter) SetClaimerFor(
 		return nil, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	w.logger.Infof("setting claimer %s", claimer)
 	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
 	if err != nil {
 		return nil, err
@@ -323,9 +323,8 @@ func (w *ELChainWriter) SetClaimerFor(
 	}
 	receipt, err := w.txMgr.Send(ctx, tx)
 	if err != nil {
-		return nil, errors.New("failed to send tx with err: " + err.Error())
+		return nil, utils.WrapError("failed to send tx", err)
 	}
 
-	w.logger.Infof("set claimer %s successful", claimer)
 	return receipt, nil
 }

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -3,6 +3,7 @@ package elcontracts
 import (
 	"context"
 	"errors"
+
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -12,6 +13,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	"github.com/Layr-Labs/eigensdk-go/chainio/txmgr"
 	delegationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/DelegationManager"
+	rewardscoordinator "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IRewardsCoordinator"
 	slasher "github.com/Layr-Labs/eigensdk-go/contracts/bindings/ISlasher"
 	strategymanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/StrategyManager"
 	"github.com/Layr-Labs/eigensdk-go/logging"
@@ -36,12 +38,18 @@ type ELWriter interface {
 		strategyAddr gethcommon.Address,
 		amount *big.Int,
 	) (*gethtypes.Receipt, error)
+
+	SetClaimerFor(
+		ctx context.Context,
+		claimer gethcommon.Address,
+	) (*gethtypes.Receipt, error)
 }
 
 type ELChainWriter struct {
-	slasher             slasher.ContractISlasherTransacts
-	delegationManager   delegationmanager.ContractDelegationManagerTransacts
-	strategyManager     strategymanager.ContractStrategyManagerTransacts
+	slasher             *slasher.ContractISlasher
+	delegationManager   *delegationmanager.ContractDelegationManager
+	strategyManager     *strategymanager.ContractStrategyManager
+	rewardsCoordinator  *rewardscoordinator.ContractIRewardsCoordinator
 	strategyManagerAddr gethcommon.Address
 	elChainReader       ELReader
 	ethClient           eth.Client
@@ -52,9 +60,10 @@ type ELChainWriter struct {
 var _ ELWriter = (*ELChainWriter)(nil)
 
 func NewELChainWriter(
-	slasher slasher.ContractISlasherTransacts,
-	delegationManager delegationmanager.ContractDelegationManagerTransacts,
-	strategyManager strategymanager.ContractStrategyManagerTransacts,
+	slasher *slasher.ContractISlasher,
+	delegationManager *delegationmanager.ContractDelegationManager,
+	strategyManager *strategymanager.ContractStrategyManager,
+	rewardsCoordinator *rewardscoordinator.ContractIRewardsCoordinator,
 	strategyManagerAddr gethcommon.Address,
 	elChainReader ELReader,
 	ethClient eth.Client,
@@ -69,6 +78,7 @@ func NewELChainWriter(
 		delegationManager:   delegationManager,
 		strategyManager:     strategyManager,
 		strategyManagerAddr: strategyManagerAddr,
+		rewardsCoordinator:  rewardsCoordinator,
 		elChainReader:       elChainReader,
 		logger:              logger,
 		ethClient:           ethClient,
@@ -107,6 +117,7 @@ func BuildELChainWriter(
 		elContractBindings.Slasher,
 		elContractBindings.DelegationManager,
 		elContractBindings.StrategyManager,
+		nil,
 		elContractBindings.StrategyManagerAddr,
 		elChainReader,
 		ethClient,
@@ -143,6 +154,7 @@ func NewWriterFromConfig(
 		elContractBindings.Slasher,
 		elContractBindings.DelegationManager,
 		elContractBindings.StrategyManager,
+		elContractBindings.RewardsCoordinator,
 		elContractBindings.StrategyManagerAddr,
 		elChainReader,
 		ethClient,
@@ -288,5 +300,32 @@ func (w *ELChainWriter) DepositERC20IntoStrategy(
 	}
 
 	w.logger.Infof("deposited %s into strategy %s", amount.String(), strategyAddr)
+	return receipt, nil
+}
+
+func (w *ELChainWriter) SetClaimerFor(
+	ctx context.Context,
+	claimer gethcommon.Address,
+) (*gethtypes.Receipt, error) {
+	if w.rewardsCoordinator == nil {
+		return nil, errors.New("RewardsCoordinator contract not provided")
+	}
+
+	w.logger.Infof("setting claimer %s", claimer)
+	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := w.rewardsCoordinator.SetClaimerFor(noSendTxOpts, claimer)
+	if err != nil {
+		return nil, err
+	}
+	receipt, err := w.txMgr.Send(ctx, tx)
+	if err != nil {
+		return nil, errors.New("failed to send tx with err: " + err.Error())
+	}
+
+	w.logger.Infof("set claimer %s successful", claimer)
 	return receipt, nil
 }

--- a/chainio/mocks/elContractsWriter.go
+++ b/chainio/mocks/elContractsWriter.go
@@ -73,6 +73,21 @@ func (mr *MockELWriterMockRecorder) RegisterAsOperator(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterAsOperator", reflect.TypeOf((*MockELWriter)(nil).RegisterAsOperator), arg0, arg1)
 }
 
+// SetClaimerFor mocks base method.
+func (m *MockELWriter) SetClaimerFor(arg0 context.Context, arg1 common.Address) (*types0.Receipt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetClaimerFor", arg0, arg1)
+	ret0, _ := ret[0].(*types0.Receipt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetClaimerFor indicates an expected call of SetClaimerFor.
+func (mr *MockELWriterMockRecorder) SetClaimerFor(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClaimerFor", reflect.TypeOf((*MockELWriter)(nil).SetClaimerFor), arg0, arg1)
+}
+
 // UpdateMetadataURI mocks base method.
 func (m *MockELWriter) UpdateMetadataURI(arg0 context.Context, arg1 string) (*types0.Receipt, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Fixes # .

### What Changed?
- Add SetClaimerFor function in SDK
- Changing the contracts argument reader and writer struct back to struct instead of interface due to usage restriction for nil checks. We are not using mocks for testing for those so it doesn't make sense to use to interface

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it