### PR TITLE
move some warn to debug

### DIFF
--- a/chainio/clients/avsregistry/bindings.go
+++ b/chainio/clients/avsregistry/bindings.go
@@ -146,7 +146,7 @@ func NewBindingsFromConfig(
 	)
 
 	if isZeroAddress(cfg.RegistryCoordinatorAddress) {
-		logger.Warn("RegistryCoordinator address not provided, the calls to the contract will not work")
+		logger.Debug("RegistryCoordinator address not provided, the calls to the contract will not work")
 	} else {
 		contractBlsRegistryCoordinator, err = regcoordinator.NewContractRegistryCoordinator(
 			cfg.RegistryCoordinatorAddress,
@@ -212,7 +212,7 @@ func NewBindingsFromConfig(
 	}
 
 	if isZeroAddress(cfg.OperatorStateRetrieverAddress) {
-		logger.Warn("OperatorStateRetriever address not provided, the calls to the contract will not work")
+		logger.Debug("OperatorStateRetriever address not provided, the calls to the contract will not work")
 	} else {
 		contractOperatorStateRetriever, err = opstateretriever.NewContractOperatorStateRetriever(
 			cfg.OperatorStateRetrieverAddress,

--- a/chainio/clients/elcontracts/bindings.go
+++ b/chainio/clients/elcontracts/bindings.go
@@ -51,7 +51,7 @@ func NewBindingsFromConfig(
 	)
 
 	if isZeroAddress(cfg.DelegationManagerAddress) {
-		logger.Warn("DelegationManager address not provided, the calls to the contract will not work")
+		logger.Debug("DelegationManager address not provided, the calls to the contract will not work")
 	} else {
 		contractDelegationManager, err = delegationmanager.NewContractDelegationManager(cfg.DelegationManagerAddress, client)
 		if err != nil {
@@ -78,7 +78,7 @@ func NewBindingsFromConfig(
 	}
 
 	if isZeroAddress(cfg.AvsDirectoryAddress) {
-		logger.Warn("AVSDirectory address not provided, the calls to the contract will not work")
+		logger.Debug("AVSDirectory address not provided, the calls to the contract will not work")
 	} else {
 		avsDirectory, err = avsdirectory.NewContractAVSDirectory(cfg.AvsDirectoryAddress, client)
 		if err != nil {
@@ -87,7 +87,7 @@ func NewBindingsFromConfig(
 	}
 
 	if isZeroAddress(cfg.RewardsCoordinatorAddress) {
-		logger.Warn("RewardsCoordinator address not provided, the calls to the contract will not work")
+		logger.Debug("RewardsCoordinator address not provided, the calls to the contract will not work")
 	} else {
 		rewardsCoordinator, err = rewardscoordinator.NewContractIRewardsCoordinator(cfg.RewardsCoordinatorAddress, client)
 		if err != nil {


### PR DESCRIPTION
Fixes # .

### What Changed?
- Making that warn to debug to not alarm users that something is wrong. If they call the methods of contract which they did not provide, they will get error anyway. 

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it