### PR TITLE
add context to the error returned by waitForReceipt when context is d…

### DIFF
--- a/chainio/txmgr/txmgr.go
+++ b/chainio/txmgr/txmgr.go
@@ -129,7 +129,7 @@ func (m *SimpleTxManager) waitForReceipt(ctx context.Context, txID wallet.TxID) 
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Join(errors.New("Context done before tx was mined"), ctx.Err())
 		case <-queryTicker.C:
 			if receipt := m.queryReceipt(ctx, txID); receipt != nil {
 				return receipt, nil


### PR DESCRIPTION
…one before tx is mined

Fixes # .

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it