### PR TITLE
Update fireblocks get asset addresses endpoint

### DIFF
--- a/chainio/clients/fireblocks/get_asset_addresses.go
+++ b/chainio/clients/fireblocks/get_asset_addresses.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -20,15 +21,44 @@ type AssetAddress struct {
 
 func (f *client) GetAssetAddresses(ctx context.Context, vaultID string, assetID AssetID) ([]AssetAddress, error) {
 	f.logger.Debug("Fireblocks get asset addressees", "vaultID", vaultID, "assetID", assetID)
-	path := fmt.Sprintf("/v1/vault/accounts/%s/%s/addresses", vaultID, assetID)
-	res, err := f.makeRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error making request: %w", err)
-	}
 	var addresses []AssetAddress
-	err = json.NewDecoder(strings.NewReader(string(res))).Decode(&addresses)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing response body: %w", err)
+	type paging struct {
+		Before string `json:"before"`
+		After  string `json:"after"`
+	}
+	var response struct {
+		Addresses []AssetAddress `json:"addresses"`
+		Paging    paging         `json:"paging"`
+	}
+
+	p := paging{}
+	next := true
+	for next {
+		path := fmt.Sprintf("/v1/vault/accounts/%s/%s/addresses_paginated", vaultID, assetID)
+		u, err := url.Parse(path)
+		if err != nil {
+			return addresses, fmt.Errorf("error parsing URL: %w", err)
+		}
+		q := u.Query()
+		q.Set("before", p.Before)
+		q.Set("after", p.After)
+		u.RawQuery = q.Encode()
+
+		res, err := f.makeRequest(ctx, "GET", u.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("error making request: %w", err)
+		}
+		body := string(res)
+		err = json.NewDecoder(strings.NewReader(body)).Decode(&response)
+		if err != nil {
+			return addresses, fmt.Errorf("error parsing response body: %s: %w", body, err)
+		}
+
+		addresses = append(addresses, response.Addresses...)
+		p = response.Paging
+		if p.After == "" {
+			next = false
+		}
 	}
 
 	return addresses, nil

--- a/chainio/clients/fireblocks/list_vault_accounts.go
+++ b/chainio/clients/fireblocks/list_vault_accounts.go
@@ -42,7 +42,6 @@ func (f *client) ListVaultAccounts(ctx context.Context) ([]VaultAccount, error) 
 		q.Set("before", p.Before)
 		q.Set("after", p.After)
 		u.RawQuery = q.Encode()
-		fmt.Println("URL: ", u.String())
 		res, err := f.makeRequest(ctx, "GET", u.String(), nil)
 		if err != nil {
 			return accounts, fmt.Errorf("error making request: %w", err)


### PR DESCRIPTION
Updated the deprecated [endpoint](https://developers.fireblocks.com/reference/getvaultaccountassetaddresses) with new [endpoint](https://developers.fireblocks.com/reference/getvaultaccountassetaddressespaginated). 
Tested that the response from this test before and after this change are identical: `go test ./chainio/clients/... -v -run TestGetAssetAddresses`

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it