### PR TITLE
Add missing fields in fireblocks AssetAddress struct

### DIFF
--- a/chainio/clients/fireblocks/get_asset_addresses.go
+++ b/chainio/clients/fireblocks/get_asset_addresses.go
@@ -11,11 +11,14 @@ import (
 type AssetAddress struct {
 	AssetID           AssetID `json:"assetId"`
 	Address           string  `json:"address"`
-	Tag               string  `json:"tag"`
 	Description       string  `json:"description"`
+	Tag               string  `json:"tag"`
 	Type              string  `json:"type"`
+	CustomerRefID     string  `json:"customerRefId"`
+	AddressFormat     string  `json:"addressFormat"`
 	LegacyAddress     string  `json:"legacyAddress"`
 	EnterpriseAddress string  `json:"enterpriseAddress"`
+	BIP44AddressIndex int     `json:"bip44AddressIndex"`
 	UserDefined       bool    `json:"userDefined"`
 }
 


### PR DESCRIPTION
Adds missing fields in `AssetAddress` struct according to the [API response](https://developers.fireblocks.com/reference/getvaultaccountassetaddressespaginated)

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it