### PR TITLE
feat: modularize bindings generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ lint: ## runs all linters
 	golangci-lint run ./...
 
 
-___BINDINGS___: ##
+___BINDINGS___: ## 
 
 core_default := "DelegationManager IRewardsCoordinator ISlasher StrategyManager EigenPod EigenPodManager IStrategy IAVSDirectory"
 core_location := "./lib/eigenlayer-middleware/lib/eigenlayer-contracts"
@@ -71,7 +71,7 @@ sdk_default := "MockAvsServiceManager ContractsRegistry"
 sdk_location := "."
 sdk_bindings_location := "./bindings"
 
-.PHONY: core-bindings
+.PHONY: core-bindings ## generates core contracts bindings
 core-bindings: ## generates core bindings
 	@echo "Starting core bindings generation"
 ifneq ($(contracts),)
@@ -83,7 +83,7 @@ else
 endif
 
 
-.PHONY: middleware-bindings
+.PHONY: middleware-bindings ## generates middleware contracts bindings
 middleware-bindings: ## generates middleware bindings
 	@echo "Starting middleware bindings generation"
 ifneq ($(contracts),)
@@ -94,7 +94,7 @@ else
 	cd contracts && ./generate-bindings.sh $(middleware_location) $(middleware_default) $(middleware_bindings_location)
 endif
 
-.PHONY: sdk-bindings
+.PHONY: sdk-bindings ## generates sdk contracts bindings
 sdk-bindings: ## generates sdk bindings
 	@echo "Starting sdk bindings generation"
 ifneq ($(contracts),)
@@ -106,7 +106,7 @@ else
 endif
 
 .PHONY: bindings
-bindings: ## generates contract bindings
+bindings: ## generates all contract bindings
 	rm -rf bindings/* && make core-bindings middleware-bindings sdk-bindings
 
 .PHONY: eigenpod-bindings

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ sdk_default := "MockAvsServiceManager ContractsRegistry"
 sdk_location := "."
 sdk_bindings_location := "./bindings"
 
+# To generate bindings for specific contracts, run `make core-bindings contracts="DelegationManager IRewardsCoordinator"`
 .PHONY: core-bindings ## generates core contracts bindings
 core-bindings: ## generates core bindings
 	@echo "Starting core bindings generation"
@@ -82,7 +83,7 @@ else
 	cd contracts && ./generate-bindings.sh $(core_location) $(core_default) $(core_bindings_location)
 endif
 
-
+# To generate bindings for specific contracts, run `make middleware-bindings contracts="RegistryCoordinator"`
 .PHONY: middleware-bindings ## generates middleware contracts bindings
 middleware-bindings: ## generates middleware bindings
 	@echo "Starting middleware bindings generation"
@@ -94,6 +95,7 @@ else
 	cd contracts && ./generate-bindings.sh $(middleware_location) $(middleware_default) $(middleware_bindings_location)
 endif
 
+# To generate bindings for specific contracts, run `make sdk-bindings contracts="MockAvsServiceManager"`
 .PHONY: sdk-bindings ## generates sdk contracts bindings
 sdk-bindings: ## generates sdk bindings
 	@echo "Starting sdk bindings generation"
@@ -105,13 +107,13 @@ else
 	cd contracts && ./generate-bindings.sh $(sdk_location) $(sdk_default) $(sdk_bindings_location)
 endif
 
-.PHONY: bindings
-bindings: ## generates all contract bindings
-	rm -rf bindings/* && make core-bindings middleware-bindings sdk-bindings
-
 .PHONY: eigenpod-bindings
 eigenpod-bindings: ## generates contract bindings for eigenpod
 	cd chainio/clients/eigenpod && ./generate.sh
+
+.PHONY: bindings
+bindings: ## generates all contract bindings
+	rm -rf bindings/* && make core-bindings middleware-bindings sdk-bindings eigenpod-bindings
 
 
 ___CONTRACTS___: ## 

--- a/contracts/generate-bindings.sh
+++ b/contracts/generate-bindings.sh
@@ -33,33 +33,17 @@ function create_binding {
     rm -rf data/tmp.abi data/tmp.bin
 }
 
-cd $script_path
+path=$1
+echo "Generating bindings for contracts in path: $path"
+cd "$path"
+pwd
+
+contracts=$2
+bindings_path=$3
+
 forge build
-sdk_contracts="MockAvsServiceManager ContractsRegistry"
-for contract in $sdk_contracts; do
+echo "Generating bindings for contracts: $contracts"
+for contract in $contracts; do
     sleep 1 # this is a hack to fix the issue with abigen randomly failing for some contracts
-    create_binding . $contract ./bindings
-done
-
-EIGENLAYER_MIDDLEWARE_PATH=$script_path/lib/eigenlayer-middleware
-cd $EIGENLAYER_MIDDLEWARE_PATH
-# you might want to run forge clean if the contracts have changed
-forge build
-
-# No idea why but ordering of the contracts matters here... when I move them around sometimes bindings fail
-avs_contracts="RegistryCoordinator IndexRegistry OperatorStateRetriever StakeRegistry BLSApkRegistry IBLSSignatureChecker ServiceManagerBase IERC20"
-for contract in $avs_contracts; do
-    sleep 1 # this is a hack to fix the issue with abigen randomly failing for some contracts
-    create_binding . $contract ../../bindings
-done
-
-EIGENLAYER_CONTRACT_PATH=$EIGENLAYER_MIDDLEWARE_PATH/lib/eigenlayer-contracts
-cd $EIGENLAYER_CONTRACT_PATH
-forge build
-
-# No idea why but the ordering of the contracts matters, and for some orderings abigen fails...
-el_contracts="DelegationManager IRewardsCoordinator ISlasher StrategyManager EigenPod EigenPodManager IStrategy IAVSDirectory"
-for contract in $el_contracts; do
-    sleep 1 # this is a hack to fix the issue with abigen randomly failing for some contracts
-    create_binding . $contract ../../../../bindings
+    create_binding . "$contract" "$bindings_path"
 done


### PR DESCRIPTION
Fixes # .

### What Changed?
- Break bindings generation into sdk, middleware and core contracts
- This helps a dev to only generate either core, middleware or sdk bindings for testing changes due to branching issues which comes with core and middleware contracts
- It keep the middleware bindings untouched if you want to test core bindings and middleware has not updated their contracts yet
- I have run make bindings before pushing this which validates the new command is working as expected 


## Future improvement 
- Delete the respective bindings when running subcommands like if generating core bindings just delete all core bindings to have clean bindings
- Add eigenpod

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it