### PR TITLE
feat: check quorums registered detail

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -358,18 +358,24 @@ func (r *ChainReader) GetOperatorFromId(
 func (r *ChainReader) QueryRegistrationDetail(
 	opts *bind.CallOpts,
 	operatorAddress common.Address,
-) (map[int]bool, error) {
+) ([]bool, error) {
 	operatorId, err := r.GetOperatorId(opts, operatorAddress)
 	if err != nil {
 		return nil, err
 	}
-	bitmap, err := r.registryCoordinator.GetCurrentQuorumBitmap(opts, operatorId)
+	value, err := r.registryCoordinator.GetCurrentQuorumBitmap(opts, operatorId)
 	if err != nil {
 		return nil, err
 	}
-	quorums := make(map[int]bool)
-	for i, b := range bitmap.Bits() {
-		quorums[i] = b == 1
+	numBits := value.BitLen()
+	quorums := make([]bool, numBits)
+	for i := 0; i < numBits; i++ {
+		// Check if the ith bit is set
+		if value.Int64()&(1<<i) != 0 {
+			quorums[i] = true
+		} else {
+			quorums[i] = false
+		}
 	}
 	return quorums, nil
 }

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -358,7 +358,7 @@ func (r *ChainReader) GetOperatorFromId(
 func (r *ChainReader) QueryRegistrationDetail(
 	opts *bind.CallOpts,
 	operatorAddress common.Address,
-) (map[int]bool, error) {
+) ([]bool, error) {
 	operatorId, err := r.GetOperatorId(opts, operatorAddress)
 	if err != nil {
 		return nil, err
@@ -368,9 +368,9 @@ func (r *ChainReader) QueryRegistrationDetail(
 		return nil, err
 	}
 	numBits := value.BitLen()
-	quorums := make(map[int]bool, numBits)
+	var quorums []bool
 	for i := 0; i < numBits; i++ {
-		quorums[i] = value.Int64()&(1<<i) != 0
+		quorums = append(quorums, value.Int64()&(1<<i) != 0)
 	}
 	return quorums, nil
 }

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -355,6 +355,25 @@ func (r *ChainReader) GetOperatorFromId(
 	return operatorAddress, nil
 }
 
+func (r *ChainReader) QueryRegistrationDetail(
+	opts *bind.CallOpts,
+	operatorAddress common.Address,
+) (map[int]bool, error) {
+	operatorId, err := r.GetOperatorId(opts, operatorAddress)
+	if err != nil {
+		return nil, err
+	}
+	bitmap, err := r.registryCoordinator.GetCurrentQuorumBitmap(opts, operatorId)
+	if err != nil {
+		return nil, err
+	}
+	quorums := make(map[int]bool)
+	for i, b := range bitmap.Bits() {
+		quorums[i] = b == 1
+	}
+	return quorums, nil
+}
+
 func (r *ChainReader) IsOperatorRegistered(
 	opts *bind.CallOpts,
 	operatorAddress common.Address,

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -358,7 +358,7 @@ func (r *ChainReader) GetOperatorFromId(
 func (r *ChainReader) QueryRegistrationDetail(
 	opts *bind.CallOpts,
 	operatorAddress common.Address,
-) ([]bool, error) {
+) (map[int]bool, error) {
 	operatorId, err := r.GetOperatorId(opts, operatorAddress)
 	if err != nil {
 		return nil, err
@@ -368,14 +368,9 @@ func (r *ChainReader) QueryRegistrationDetail(
 		return nil, err
 	}
 	numBits := value.BitLen()
-	quorums := make([]bool, numBits)
+	quorums := make(map[int]bool, numBits)
 	for i := 0; i < numBits; i++ {
-		// Check if the ith bit is set
-		if value.Int64()&(1<<i) != 0 {
-			quorums[i] = true
-		} else {
-			quorums[i] = false
-		}
+		quorums[i] = value.Int64()&(1<<i) != 0
 	}
 	return quorums, nil
 }


### PR DESCRIPTION
 Add a function to query bitmap of quorums and convert it into human-readable format which is boolean array.
### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it