### PR TITLE
refactor: handle zero bitmap

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -361,16 +361,25 @@ func (r *ChainReader) QueryRegistrationDetail(
 ) ([]bool, error) {
 	operatorId, err := r.GetOperatorId(opts, operatorAddress)
 	if err != nil {
-		return nil, err
+		return nil, utils.WrapError("Failed to get operator id", err)
 	}
 	value, err := r.registryCoordinator.GetCurrentQuorumBitmap(opts, operatorId)
 	if err != nil {
-		return nil, err
+		return nil, utils.WrapError("Failed to get operator quorums", err)
 	}
 	numBits := value.BitLen()
 	var quorums []bool
 	for i := 0; i < numBits; i++ {
 		quorums = append(quorums, value.Int64()&(1<<i) != 0)
+	}
+	if len(quorums) == 0 {
+		numQuorums, err := r.GetQuorumCount(opts)
+		if err != nil {
+			return nil, utils.WrapError("Failed to get quorum count", err)
+		}
+		for i := uint8(0); i < numQuorums; i++ {
+			quorums = append(quorums, false)
+		}
 	}
 	return quorums, nil
 }


### PR DESCRIPTION
A followup PR of https://github.com/Layr-Labs/eigensdk-go/pull/331. The functions works well with our system internally, but i just realized that if the bitmap is 0, the result array would be empty too. So is it better that we populate all existing quorums with default value (which is false in this case) to the result to be more consistent. Also wrap some errors this time.

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it