### PR TITLE
fest: support start/stop blocks for querying operator info(pubkey and socket)

### DIFF
--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -1150,6 +1150,8 @@ func TestIntegrationBlsAgg(t *testing.T) {
 			avsClients.AvsRegistryChainSubscriber,
 			avsClients.AvsRegistryChainReader,
 			nil,
+			nil,
+			nil,
 			logger,
 		)
 		avsRegistryService := avsregistry.NewAvsRegistryServiceChainCaller(

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -1150,7 +1150,7 @@ func TestIntegrationBlsAgg(t *testing.T) {
 			avsClients.AvsRegistryChainSubscriber,
 			avsClients.AvsRegistryChainReader,
 			nil,
-			&operatorsinfo.Opts{},
+			operatorsinfo.Opts{},
 			logger,
 		)
 		avsRegistryService := avsregistry.NewAvsRegistryServiceChainCaller(

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -1150,8 +1150,7 @@ func TestIntegrationBlsAgg(t *testing.T) {
 			avsClients.AvsRegistryChainSubscriber,
 			avsClients.AvsRegistryChainReader,
 			nil,
-			nil,
-			nil,
+			&operatorsinfo.Opts{},
 			logger,
 		)
 		avsRegistryService := avsregistry.NewAvsRegistryServiceChainCaller(

--- a/services/operatorsinfo/operatorsinfo_inmemory.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory.go
@@ -97,7 +97,7 @@ func NewOperatorsInfoServiceInMemory(
 	avsRegistrySubscriber avsRegistrySubscriber,
 	avsRegistryReader avsRegistryReader,
 	logFilterQueryBlockRange *big.Int,
-	opts *Opts,
+	opts Opts,
 	logger logging.Logger,
 ) *OperatorsInfoServiceInMemory {
 	queryC := make(chan query)
@@ -127,7 +127,7 @@ func (ops *OperatorsInfoServiceInMemory) startServiceInGoroutine(
 	ctx context.Context,
 	queryC <-chan query,
 	wg *sync.WaitGroup,
-	opts *Opts,
+	opts Opts,
 ) {
 	go func() {
 
@@ -284,7 +284,7 @@ func (ops *OperatorsInfoServiceInMemory) startServiceInGoroutine(
 
 func (ops *OperatorsInfoServiceInMemory) queryPastRegisteredOperatorEventsAndFillDb(
 	ctx context.Context,
-	opts *Opts,
+	opts Opts,
 ) error {
 	// Querying with nil startBlock and stopBlock will return all events. It doesn't matter if we query some events that
 	// we will receive again in the websocket,
@@ -338,7 +338,7 @@ func (ops *OperatorsInfoServiceInMemory) queryPastRegisteredOperatorEventsAndFil
 		// we print each socket info on a separate line because slog for some reason doesn't pass map keys via their
 		// LogValue() function, so operatorId (of custom type Bytes32) prints as a byte array instead of its hex
 		// representation from LogValue()
-		// passing the Bytes32 directly to an slog log statements does call LogValue() and prints the hex representation
+		// passing the Bytes32 directly to a slog log statements does call LogValue() and prints the hex representation
 		ops.logger.Debug(
 			"operator socket returned from registration events query",
 			"operatorId",

--- a/services/operatorsinfo/operatorsinfo_inmemory_test.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory_test.go
@@ -153,6 +153,8 @@ func TestGetOperatorInfo(t *testing.T) {
 				mockAvsRegistrySubscriber,
 				mockAvsReader,
 				nil,
+				nil,
+				nil,
 				logger,
 			)
 			time.Sleep(

--- a/services/operatorsinfo/operatorsinfo_inmemory_test.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory_test.go
@@ -153,8 +153,7 @@ func TestGetOperatorInfo(t *testing.T) {
 				mockAvsRegistrySubscriber,
 				mockAvsReader,
 				nil,
-				nil,
-				nil,
+				&Opts{},
 				logger,
 			)
 			time.Sleep(

--- a/services/operatorsinfo/operatorsinfo_inmemory_test.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory_test.go
@@ -153,7 +153,7 @@ func TestGetOperatorInfo(t *testing.T) {
 				mockAvsRegistrySubscriber,
 				mockAvsReader,
 				nil,
-				&Opts{},
+				Opts{},
 				logger,
 			)
 			time.Sleep(


### PR DESCRIPTION
Fixes #259 and #312.

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it