### PR TITLE
Add compliance tests

### DIFF
--- a/cmd/egnaddrs/main_test.go
+++ b/cmd/egnaddrs/main_test.go
@@ -26,14 +26,16 @@ func TestEgnAddrsWithServiceManagerFlag(t *testing.T) {
 	// read input from JSON if available, otherwise use default values
 	var defaultInput = struct {
 		ServiceManagerAddress common.Address `json:"service_manager_address"`
+		RpcUrl                string         `json:"rpc_url"`
 	}{
 		ServiceManagerAddress: testutils.GetContractAddressesFromContractRegistry(anvilEndpoint).ServiceManager,
+		RpcUrl:                anvilEndpoint,
 	}
 	testData := testutils.NewTestData(defaultInput)
 
 	args := []string{"egnaddrs"}
 	args = append(args, "--service-manager", testData.Input.ServiceManagerAddress.Hex())
-	args = append(args, "--rpc-url", anvilEndpoint)
+	args = append(args, "--rpc-url", testData.Input.RpcUrl)
 	// we just make sure it doesn't crash
 	run(args)
 }

--- a/services/avsregistry/avsregistry_chaincaller_test.go
+++ b/services/avsregistry/avsregistry_chaincaller_test.go
@@ -36,8 +36,8 @@ func (f *fakeOperatorInfoService) GetOperatorInfo(
 func TestAvsRegistryServiceChainCaller_GetOperatorPubkeys(t *testing.T) {
 	logger := testutils.GetTestLogger()
 	var defaultInput = struct {
-		OperatorAddr common.Address   `json:"private_key_decimal"`
-		OperatorId   types.OperatorId `json:"operator_id"`
+		OperatorAddr types.OperatorAddr `json:"operator_address"`
+		OperatorId   types.OperatorId   `json:"operator_id"`
 	}{
 		OperatorAddr: common.HexToAddress("0x1"),
 		OperatorId:   types.OperatorId{1},

--- a/services/avsregistry/avsregistry_chaincaller_test.go
+++ b/services/avsregistry/avsregistry_chaincaller_test.go
@@ -33,7 +33,7 @@ func (f *fakeOperatorInfoService) GetOperatorInfo(
 	return f.operatorInfo, true
 }
 
-func TestAvsRegistryServiceChainCaller_getOperatorPubkeys(t *testing.T) {
+func TestAvsRegistryServiceChainCaller_GetOperatorPubkeys(t *testing.T) {
 	logger := testutils.GetTestLogger()
 	testOperator1 := fakes.TestOperator{
 		OperatorAddr: common.HexToAddress("0x1"),

--- a/services/avsregistry/avsregistry_chaincaller_test.go
+++ b/services/avsregistry/avsregistry_chaincaller_test.go
@@ -35,9 +35,18 @@ func (f *fakeOperatorInfoService) GetOperatorInfo(
 
 func TestAvsRegistryServiceChainCaller_GetOperatorPubkeys(t *testing.T) {
 	logger := testutils.GetTestLogger()
-	testOperator1 := fakes.TestOperator{
+	var defaultInput = struct {
+		OperatorAddr common.Address   `json:"private_key_decimal"`
+		OperatorId   types.OperatorId `json:"operator_id"`
+	}{
 		OperatorAddr: common.HexToAddress("0x1"),
 		OperatorId:   types.OperatorId{1},
+	}
+	testData := testutils.NewTestData(defaultInput)
+
+	testOperator1 := fakes.TestOperator{
+		OperatorAddr: testData.Input.OperatorAddr,
+		OperatorId:   testData.Input.OperatorId,
 		OperatorInfo: types.OperatorInfo{
 			Pubkeys: types.OperatorPubkeys{
 				G1Pubkey: bls.NewG1Point(big.NewInt(1), big.NewInt(1)),

--- a/services/avsregistry/avsregistry_chaincaller_test.go
+++ b/services/avsregistry/avsregistry_chaincaller_test.go
@@ -2,6 +2,7 @@ package avsregistry
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 
 	"math/big"
@@ -37,16 +38,20 @@ func TestAvsRegistryServiceChainCaller_GetOperatorPubkeys(t *testing.T) {
 	logger := testutils.GetTestLogger()
 	var defaultInput = struct {
 		OperatorAddr types.OperatorAddr `json:"operator_address"`
-		OperatorId   types.OperatorId   `json:"operator_id"`
+		OperatorId   string             `json:"operator_id"`
 	}{
 		OperatorAddr: common.HexToAddress("0x1"),
-		OperatorId:   types.OperatorId{1},
+		OperatorId:   "1",
 	}
 	testData := testutils.NewTestData(defaultInput)
 
+	opid, err := hex.DecodeString(testData.Input.OperatorId)
+	if err != nil {
+		t.Fatalf("failed to decode operator id: %v", err)
+	}
 	testOperator1 := fakes.TestOperator{
 		OperatorAddr: testData.Input.OperatorAddr,
-		OperatorId:   testData.Input.OperatorId,
+		OperatorId:   types.OperatorId(opid),
 		OperatorInfo: types.OperatorInfo{
 			Pubkeys: types.OperatorPubkeys{
 				G1Pubkey: bls.NewG1Point(big.NewInt(1), big.NewInt(1)),

--- a/services/avsregistry/avsregistry_chaincaller_test.go
+++ b/services/avsregistry/avsregistry_chaincaller_test.go
@@ -41,7 +41,7 @@ func TestAvsRegistryServiceChainCaller_GetOperatorPubkeys(t *testing.T) {
 		OperatorId   string             `json:"operator_id"`
 	}{
 		OperatorAddr: common.HexToAddress("0x1"),
-		OperatorId:   "1",
+		OperatorId:   "0000000000000000000000000000000000000000000000000000000000000001",
 	}
 	testData := testutils.NewTestData(defaultInput)
 


### PR DESCRIPTION
We add TestsOperatorPubkeys and TestSignTransactionWithKmsSigner tests in this PR to match the compliance tests automation and TestEgnAddrsWithServiceManagerFlag was modified.

Fixes # .

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it