### PR TITLE
fix: race condition when querying registered operators data

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -426,11 +426,10 @@ func (r *ChainReader) QueryExistingRegisteredOperatorPubKeys(
 	if blockRange == nil {
 		blockRange = DefaultQueryBlockRange
 	}
-	startBlock = new(big.Int).Set(startBlock)
 
 	operatorAddresses := make([]types.OperatorAddr, 0)
 	operatorPubkeys := make([]types.OperatorPubkeys, 0)
-	for i := startBlock; i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
+	for i := new(big.Int).Set(startBlock); i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
 		// Subtract 1 since FilterQuery is inclusive
 		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(blockRange, big.NewInt(1)))
 		if toBlock.Cmp(stopBlock) > 0 {
@@ -520,10 +519,9 @@ func (r *ChainReader) QueryExistingRegisteredOperatorSockets(
 	if blockRange == nil {
 		blockRange = DefaultQueryBlockRange
 	}
-	startBlock = new(big.Int).Set(startBlock)
 
 	operatorIdToSocketMap := make(map[types.OperatorId]types.Socket)
-	for i := startBlock; i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
+	for i := new(big.Int).Set(startBlock); i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
 		// Subtract 1 since FilterQuery is inclusive
 		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(blockRange, big.NewInt(1)))
 		if toBlock.Cmp(stopBlock) > 0 {

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -432,7 +432,8 @@ func (r *ChainReader) QueryExistingRegisteredOperatorPubKeys(
 	// QueryExistingRegisteredOperatorPubKeys and QueryExistingRegisteredOperatorSockets
 	// both run in parallel and they read and mutate the same variable startBlock,
 	// so we clone it to prevent the race condition.
-	// TODO: we might want to eventually change the function signature to pass a uint, but that would be a breaking change
+	// TODO: we might want to eventually change the function signature to pass a uint,
+	// but that would be a breaking change
 	for i := new(big.Int).Set(startBlock); i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
 		// Subtract 1 since FilterQuery is inclusive
 		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(blockRange, big.NewInt(1)))
@@ -528,7 +529,8 @@ func (r *ChainReader) QueryExistingRegisteredOperatorSockets(
 	// QueryExistingRegisteredOperatorPubKeys and QueryExistingRegisteredOperatorSockets
 	// both run in parallel and they read and mutate the same variable startBlock,
 	// so we clone it to prevent the race condition.
-	// TODO: we might want to eventually change the function signature to pass a uint, but that would be a breaking change
+	// TODO: we might want to eventually change the function signature to pass a uint,
+	// but that would be a breaking change
 	for i := new(big.Int).Set(startBlock); i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
 		// Subtract 1 since FilterQuery is inclusive
 		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(blockRange, big.NewInt(1)))

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -429,6 +429,10 @@ func (r *ChainReader) QueryExistingRegisteredOperatorPubKeys(
 
 	operatorAddresses := make([]types.OperatorAddr, 0)
 	operatorPubkeys := make([]types.OperatorPubkeys, 0)
+	// QueryExistingRegisteredOperatorPubKeys and QueryExistingRegisteredOperatorSockets
+	// both run in parallel and they read and mutate the same variable startBlock,
+	// so we clone it to prevent the race condition.
+	// TODO: we might want to eventually change the function signature to pass a uint, but that would be a breaking change
 	for i := new(big.Int).Set(startBlock); i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
 		// Subtract 1 since FilterQuery is inclusive
 		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(blockRange, big.NewInt(1)))
@@ -521,6 +525,10 @@ func (r *ChainReader) QueryExistingRegisteredOperatorSockets(
 	}
 
 	operatorIdToSocketMap := make(map[types.OperatorId]types.Socket)
+	// QueryExistingRegisteredOperatorPubKeys and QueryExistingRegisteredOperatorSockets
+	// both run in parallel and they read and mutate the same variable startBlock,
+	// so we clone it to prevent the race condition.
+	// TODO: we might want to eventually change the function signature to pass a uint, but that would be a breaking change
 	for i := new(big.Int).Set(startBlock); i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {
 		// Subtract 1 since FilterQuery is inclusive
 		toBlock := big.NewInt(0).Add(i, big.NewInt(0).Sub(blockRange, big.NewInt(1)))

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -426,6 +426,7 @@ func (r *ChainReader) QueryExistingRegisteredOperatorPubKeys(
 	if blockRange == nil {
 		blockRange = DefaultQueryBlockRange
 	}
+	startBlock = new(big.Int).Set(startBlock)
 
 	operatorAddresses := make([]types.OperatorAddr, 0)
 	operatorPubkeys := make([]types.OperatorPubkeys, 0)
@@ -519,6 +520,7 @@ func (r *ChainReader) QueryExistingRegisteredOperatorSockets(
 	if blockRange == nil {
 		blockRange = DefaultQueryBlockRange
 	}
+	startBlock = new(big.Int).Set(startBlock)
 
 	operatorIdToSocketMap := make(map[types.OperatorId]types.Socket)
 	for i := startBlock; i.Cmp(stopBlock) <= 0; i.Add(i, blockRange) {

--- a/services/operatorsinfo/operatorsinfo_inmemory.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory.go
@@ -298,10 +298,12 @@ func (ops *OperatorsInfoServiceInMemory) queryPastRegisteredOperatorEventsAndFil
 	// starting the other
 	wg.Add(2)
 	go func() {
+		startBlock := new(big.Int).Set(opts.StartBlock)
+		stopBlock := new(big.Int).Set(opts.StopBlock)
 		alreadyRegisteredOperatorAddrs, alreadyRegisteredOperatorPubkeys, pubkeysErr = ops.avsRegistryReader.QueryExistingRegisteredOperatorPubKeys(
 			ctx,
-			opts.StartBlock,
-			opts.StopBlock,
+			startBlock,
+			stopBlock,
 			ops.logFilterQueryBlockRange,
 		)
 		wg.Done()
@@ -309,10 +311,12 @@ func (ops *OperatorsInfoServiceInMemory) queryPastRegisteredOperatorEventsAndFil
 	var socketsMap map[types.OperatorId]types.Socket
 	var socketsErr error
 	go func() {
+		startBlock := new(big.Int).Set(opts.StartBlock)
+		stopBlock := new(big.Int).Set(opts.StopBlock)
 		socketsMap, socketsErr = ops.avsRegistryReader.QueryExistingRegisteredOperatorSockets(
 			ctx,
-			opts.StartBlock,
-			opts.StopBlock,
+			startBlock,
+			stopBlock,
 			ops.logFilterQueryBlockRange,
 		)
 		wg.Done()

--- a/services/operatorsinfo/operatorsinfo_inmemory.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory.go
@@ -298,12 +298,10 @@ func (ops *OperatorsInfoServiceInMemory) queryPastRegisteredOperatorEventsAndFil
 	// starting the other
 	wg.Add(2)
 	go func() {
-		startBlock := new(big.Int).Set(opts.StartBlock)
-		stopBlock := new(big.Int).Set(opts.StopBlock)
 		alreadyRegisteredOperatorAddrs, alreadyRegisteredOperatorPubkeys, pubkeysErr = ops.avsRegistryReader.QueryExistingRegisteredOperatorPubKeys(
 			ctx,
-			startBlock,
-			stopBlock,
+			opts.StartBlock,
+			opts.StopBlock,
 			ops.logFilterQueryBlockRange,
 		)
 		wg.Done()
@@ -311,12 +309,10 @@ func (ops *OperatorsInfoServiceInMemory) queryPastRegisteredOperatorEventsAndFil
 	var socketsMap map[types.OperatorId]types.Socket
 	var socketsErr error
 	go func() {
-		startBlock := new(big.Int).Set(opts.StartBlock)
-		stopBlock := new(big.Int).Set(opts.StopBlock)
 		socketsMap, socketsErr = ops.avsRegistryReader.QueryExistingRegisteredOperatorSockets(
 			ctx,
-			startBlock,
-			stopBlock,
+			opts.StartBlock,
+			opts.StopBlock,
 			ops.logFilterQueryBlockRange,
 		)
 		wg.Done()


### PR DESCRIPTION
### What Changed?
This PR adds a small fix for a race condition found when querying registered operators data.

The functions `QueryExistingRegisteredOperatorPubKeys` and `QueryExistingRegisteredOperatorSockets` both run in parallel and they read and mutate the same variable `startBlock`. This causes a race condition because `startBlock` is a `*big.Int`.

The solution is to clone the `startBlock` into a new variable for each function.

A better solution would be to change `QueryExistingRegisteredOperatorPubKeys` and `QueryExistingRegisteredOperatorSockets` function signatures to receive `startBlock` as primitive `int64` variable instead of `*big.Int` and do the conversion to `*big.Int` inside of the functions.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it