### PR TITLE
Avoid panic in ReadStringFromSecretManager in secretmanager.go

### DIFF
--- a/aws/secretmanager/secretmanager.go
+++ b/aws/secretmanager/secretmanager.go
@@ -3,6 +3,7 @@ package secretmanager
 import (
 	"context"
 
+	"github.com/Layr-Labs/eigensdk-go/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
@@ -11,7 +12,7 @@ import (
 func ReadStringFromSecretManager(ctx context.Context, secretName, region string) (string, error) {
 	config, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
-		return "", err
+		return "", utils.WrapError("error while loading default config", err)
 	}
 
 	// Create Secrets Manager client
@@ -26,7 +27,7 @@ func ReadStringFromSecretManager(ctx context.Context, secretName, region string)
 	if err != nil {
 		// For a list of exceptions thrown, see
 		// https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-		return "", err
+		return "", utils.WrapError("error while loading default config", err)
 	}
 
 	// Decrypts secret using the associated KMS key.

--- a/aws/secretmanager/secretmanager.go
+++ b/aws/secretmanager/secretmanager.go
@@ -2,7 +2,6 @@ package secretmanager
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -12,7 +11,7 @@ import (
 func ReadStringFromSecretManager(ctx context.Context, secretName, region string) (string, error) {
 	config, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 
 	// Create Secrets Manager client


### PR DESCRIPTION
Fixes # .

### What Changed?
Avoid panicking in secretmanager.go, returning the error instead of doing a `Fatal`.


### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it