### PR TITLE
Prevent Duplicate Signature Processing in BLS Aggregator

### DIFF
--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -336,29 +336,12 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 				signedTaskResponseDigest,
 			)
 
-			err := a.verifySignature(taskIndex, signedTaskResponseDigest, operatorsAvsStateDict)
-			if err != nil {
-				a.logger.Info(
-					"Signature verification failed",
-					"taskIndex", taskIndex,
-					"operatorId", fmt.Sprintf("%x", signedTaskResponseDigest.OperatorId),
-					"error", err,
-				)
-				signedTaskResponseDigest.SignatureVerificationErrorC <- err
-				continue
-			}
-
 			// compute the taskResponseDigest using the hash function
 			taskResponseDigest, err := a.hashFunction(signedTaskResponseDigest.TaskResponse)
 			if err != nil {
 				// this error should never happen, because we've already hashed the taskResponse in verifySignature,
 				// but keeping here in case the verifySignature implementation ever changes or some catastrophic bug
 				// happens..
-				a.logger.Warn(
-					"Failed to hash task response",
-					"taskIndex", taskIndex,
-					"error", err,
-				)
 				continue
 			}
 
@@ -374,6 +357,14 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 					signedTaskResponseDigest.SignatureVerificationErrorC <- fmt.Errorf("duplicate signature from operator %x for task %d", signedTaskResponseDigest.OperatorId, taskIndex)
 					continue
 				}
+			}
+
+			err = a.verifySignature(taskIndex, signedTaskResponseDigest, operatorsAvsStateDict)
+			// return the err (or nil) to the operator, and then proceed to do aggregation logic asynchronously (when no
+			// error)
+			signedTaskResponseDigest.SignatureVerificationErrorC <- err
+			if err != nil {
+				continue
 			}
 
 			// after verifying signature we aggregate its sig and pubkey, and update the signed stake amount

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -349,6 +349,11 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			digestAggregatedOperators, ok := aggregatedOperatorsDict[taskResponseDigest]
 			if ok {
 				if digestAggregatedOperators.signersOperatorIdsSet[signedTaskResponseDigest.OperatorId] {
+					a.logger.Warn(
+						"Duplicate signature received",
+						"operatorId", fmt.Sprintf("%x", signedTaskResponseDigest.OperatorId),
+						"taskIndex", taskIndex,
+					)
 					signedTaskResponseDigest.SignatureVerificationErrorC <- fmt.Errorf("duplicate signature from operator %x for task %d", signedTaskResponseDigest.OperatorId, taskIndex)
 					continue
 				}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -360,6 +360,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			}
 
 			err = a.verifySignature(taskIndex, signedTaskResponseDigest, operatorsAvsStateDict)
+                         // return the err (or nil) to the operator, and then proceed to do aggregation logic asynchronously (when no error)
 			signedTaskResponseDigest.SignatureVerificationErrorC <- err
 			if err != nil {
 				continue

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -349,7 +349,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			digestAggregatedOperators, ok := aggregatedOperatorsDict[taskResponseDigest]
 			if ok {
 				if digestAggregatedOperators.signersOperatorIdsSet[signedTaskResponseDigest.OperatorId] {
-					a.logger.Warn(
+					a.logger.Info(
 						"Duplicate signature received",
 						"operatorId", fmt.Sprintf("%x", signedTaskResponseDigest.OperatorId),
 						"taskIndex", taskIndex,

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -360,7 +360,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			}
 
 			err = a.verifySignature(taskIndex, signedTaskResponseDigest, operatorsAvsStateDict)
-                         // return the err (or nil) to the operator, and then proceed to do aggregation logic asynchronously (when no error)
+			// return the err (or nil) to the operator, and then proceed to do aggregation logic asynchronously (when no
+			// error)
 			signedTaskResponseDigest.SignatureVerificationErrorC <- err
 			if err != nil {
 				continue


### PR DESCRIPTION
Fixes [AVS-1053]( https://linear.app/eigenlabs/issue/AVS-1053/avs-devex-prevent-duplicate-signature-processing-in-bls-aggregator)

### What Changed?
Modified `singleTaskAggregatorGoroutineFunc` in blsagg/bls_aggregator_service.go
- Added explicit duplicate signature check before signature verification
- Moved task response hashing earlier in the processing flow
- Added unit test 

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it