### PR TITLE
Cleaning file path before using it

### DIFF
--- a/crypto/bls/attestation.go
+++ b/crypto/bls/attestation.go
@@ -232,7 +232,7 @@ func (k *KeyPair) EncryptedString(path string, password string) ([]byte, error) 
 }
 
 func ReadPrivateKeyFromFile(path string, password string) (*KeyPair, error) {
-	keyStoreContents, err := os.ReadFile(path)
+	keyStoreContents, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/ecdsa/utils.go
+++ b/crypto/ecdsa/utils.go
@@ -81,7 +81,7 @@ func writeBytesToFile(path string, data []byte) error {
 }
 
 func ReadKey(keyStoreFile string, password string) (*ecdsa.PrivateKey, error) {
-	keyStoreContents, err := os.ReadFile(keyStoreFile)
+	keyStoreContents, err := os.ReadFile(filepath.Clean(keyStoreFile))
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func ReadKey(keyStoreFile string, password string) (*ecdsa.PrivateKey, error) {
 // GetAddressFromKeyStoreFile We are using Web3 format defined by
 // https://ethereum.org/en/developers/docs/data-structures-and-encoding/web3-secret-storage/
 func GetAddressFromKeyStoreFile(keyStoreFile string) (gethcommon.Address, error) {
-	keyJson, err := os.ReadFile(keyStoreFile)
+	keyJson, err := os.ReadFile(filepath.Clean(keyStoreFile))
 	if err != nil {
 		return gethcommon.Address{}, err
 	}

--- a/signer/privatekey_signer.go
+++ b/signer/privatekey_signer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math/big"
 	"os"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -56,7 +57,7 @@ func (p *PrivateKeySigner) SendToExternal(ctx context.Context, tx *types.Transac
 }
 
 func getECDSAPrivateKey(keyStoreFile string, password string) (*ecdsa.PrivateKey, error) {
-	keyStoreContents, err := os.ReadFile(keyStoreFile)
+	keyStoreContents, err := os.ReadFile(filepath.Clean(keyStoreFile))
 	if err != nil {
 		return nil, err
 	}

--- a/testutils/test_data.go
+++ b/testutils/test_data.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"path/filepath"
 )
 
 // Test data for generic loading of JSON data files.
@@ -15,7 +16,7 @@ type TestData[T any] struct {
 func NewTestData[T any](defaultInput T) TestData[T] {
 	path, exists := os.LookupEnv("TEST_DATA_PATH")
 	if exists {
-		file, err := os.ReadFile(path)
+		file, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			log.Fatalf("Failed to open file: %v", err)
 		}


### PR DESCRIPTION
### What Changed?
Before using the path variables, this PR calls filepath.Clean on it to prevent:
`G304 (CWE-22): Potential file inclusion via variable`

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it