### PR TITLE
Remove panic in BuildAll

### DIFF
--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -152,7 +152,7 @@ func BuildAll(
 	}
 	signerV2, addr, err := signerv2.SignerFromConfig(signerv2.Config{PrivateKey: ecdsaPrivateKey}, chainid)
 	if err != nil {
-		panic(err)
+		return nil, utils.WrapError("Failed to create the signer from the given config", err)
 	}
 
 	pkWallet, err := wallet.NewPrivateKeyWallet(ethHttpClient, signerV2, addr, logger)


### PR DESCRIPTION
I think it's better to return an err instead of panicking in `BuildAll` in `chainio/clients/builder.go`.

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it