### PR TITLE
Change the way exec.Command is called to sanitize parameters

### DIFF
--- a/testutils/anvil.go
+++ b/testutils/anvil.go
@@ -131,6 +131,7 @@ func GetContractAddressesFromContractRegistry(ethHttpUrl string) (mockAvsContrac
 }
 
 func AdvanceChainByNBlocks(n int, anvilEndpoint string) {
+	// see https://book.getfoundry.sh/reference/anvil/#custom-methods
 	cmd := exec.Command("cast", "rpc", "anvil_mine", fmt.Sprintf("%d", n), "--rpc-url", anvilEndpoint)
 	err := cmd.Run()
 	if err != nil {

--- a/testutils/anvil.go
+++ b/testutils/anvil.go
@@ -131,12 +131,7 @@ func GetContractAddressesFromContractRegistry(ethHttpUrl string) (mockAvsContrac
 }
 
 func AdvanceChainByNBlocks(n int, anvilEndpoint string) {
-	cmd := exec.Command("bash", "-c",
-		fmt.Sprintf(
-			// see https://book.getfoundry.sh/reference/anvil/#custom-methods
-			`cast rpc anvil_mine %d --rpc-url %s`,
-			n, anvilEndpoint),
-	)
+	cmd := exec.Command("cast", "rpc", "anvil_mine", fmt.Sprintf("%d", n), "--rpc-url", anvilEndpoint)
 	err := cmd.Run()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes # .

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it