### PR TITLE
feat: make wait for receipt adjustable

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -272,7 +273,7 @@ func (w *ChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -392,7 +393,7 @@ func (w *ChainWriter) RegisterOperator(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -434,7 +435,7 @@ func (w *ChainWriter) UpdateStakesOfEntireOperatorSetForQuorums(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -463,7 +464,7 @@ func (w *ChainWriter) UpdateStakesOfOperatorSubsetForAllQuorums(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -492,7 +493,7 @@ func (w *ChainWriter) DeregisterOperator(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -517,7 +518,7 @@ func (w *ChainWriter) UpdateSocket(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send UpdateSocket tx with err: " + err.Error())
 	}

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -3,6 +3,7 @@ package elcontracts
 import (
 	"context"
 	"errors"
+	"time"
 
 	"math/big"
 
@@ -181,7 +182,7 @@ func (w *ChainWriter) RegisterAsOperator(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -217,7 +218,7 @@ func (w *ChainWriter) UpdateOperatorDetails(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -247,7 +248,7 @@ func (w *ChainWriter) UpdateMetadataURI(ctx context.Context, uri string, waitFor
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -287,7 +288,7 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to approve token transfer"), err)
 	}
-	_, err = w.txMgr.Send(ctx, tx, waitForReceipt)
+	_, err = w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -296,7 +297,7 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -323,7 +324,7 @@ func (w *ChainWriter) SetClaimerFor(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -350,7 +351,7 @@ func (w *ChainWriter) ProcessClaim(
 	if err != nil {
 		return nil, utils.WrapError("failed to create ProcessClaim tx", err)
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -387,7 +388,7 @@ func (w *ChainWriter) ForceDeregisterFromOperatorSets(
 		return nil, utils.WrapError("failed to create ForceDeregisterFromOperatorSets tx", err)
 	}
 
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -416,7 +417,7 @@ func (w *ChainWriter) SetOperatorCommissionBips(
 		return nil, utils.WrapError("failed to create SetOperatorCommissionBips tx", err)
 	}
 
-	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt, 2*time.Second)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}

--- a/chainio/txmgr/geometric/geometric.go
+++ b/chainio/txmgr/geometric/geometric.go
@@ -173,6 +173,7 @@ func (t *GeometricTxManager) Send(
 	ctx context.Context,
 	tx *types.Transaction,
 	waitForReceipt bool,
+	waitForDuration time.Duration,
 ) (*types.Receipt, error) {
 	return t.processTransaction(ctx, newTxnRequest(tx))
 }

--- a/chainio/txmgr/geometric/geometric_example_test.go
+++ b/chainio/txmgr/geometric/geometric_example_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"time"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
@@ -43,7 +44,7 @@ func ExampleGeometricTxManager() {
 	client, txmgr := createTxMgr(anvilUrl, ecdsaPrivateKey)
 
 	tx := createTx(client, address)
-	_, err = txmgr.Send(context.TODO(), tx, true)
+	_, err = txmgr.Send(context.TODO(), tx, true, 2*time.Second)
 	if err != nil {
 		panic(err)
 	}

--- a/chainio/txmgr/geometric/geometric_test.go
+++ b/chainio/txmgr/geometric/geometric_test.go
@@ -76,7 +76,7 @@ func TestGeometricTxManager(t *testing.T) {
 		unsignedTx := newUnsignedEthTransferTx(0, nil)
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		txReceipt, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true)
+		txReceipt, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true, 2*time.Second)
 		require.NoError(t, err)
 
 		h.validateTxReceipt(t, txReceipt)
@@ -90,7 +90,7 @@ func TestGeometricTxManager(t *testing.T) {
 		unsignedTx := newUnsignedEthTransferTx(0, nil)
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		txReceipt, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true)
+		txReceipt, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true, 2*time.Second)
 		require.NoError(t, err)
 
 		h.validateTxReceipt(t, txReceipt)
@@ -102,7 +102,7 @@ func TestGeometricTxManager(t *testing.T) {
 		unsignedTx := newUnsignedEthTransferTx(0, big.NewInt(1))
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		txReceipt, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true)
+		txReceipt, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true, 2*time.Second)
 		// ethBackend returns an error if the tx's gasFeeCap is less than the baseFeePerGas
 		// this test makes sure that even setting a gasFeeCap less than the baseFeePerGas in the tx (1 above) still
 		// works,
@@ -128,7 +128,7 @@ func TestGeometricTxManager(t *testing.T) {
 			g.Go(func() error {
 				ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
-				txReceipt, err := h.txmgr.Send(ctxWithTimeout, tx, true)
+				txReceipt, err := h.txmgr.Send(ctxWithTimeout, tx, true, 2*time.Second)
 				if err == nil {
 					txReceipts[nonce] = txReceipt
 				}
@@ -157,7 +157,7 @@ func TestGeometricTxManager(t *testing.T) {
 			g.Go(func() error {
 				ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
-				txReceipt, err := h.txmgr.Send(ctxWithTimeout, tx, true)
+				txReceipt, err := h.txmgr.Send(ctxWithTimeout, tx, true, 2*time.Second)
 				if err == nil {
 					txReceipts[nonce] = txReceipt
 				}
@@ -179,7 +179,7 @@ func TestGeometricTxManager(t *testing.T) {
 			tx := newUnsignedEthTransferTx(nonce, nil)
 			ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			_, err := h.txmgr.Send(ctxWithTimeout, tx, true)
+			_, err := h.txmgr.Send(ctxWithTimeout, tx, true, 2*time.Second)
 			require.NoError(t, err)
 		}
 
@@ -191,7 +191,7 @@ func TestGeometricTxManager(t *testing.T) {
 		tx := newUnsignedEthTransferTx(uint64(100), nil)
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
-		_, err := h.txmgr.Send(ctxWithTimeout, tx, true)
+		_, err := h.txmgr.Send(ctxWithTimeout, tx, true, 2*time.Second)
 		require.Equal(t, context.DeadlineExceeded, err)
 
 	})
@@ -202,11 +202,11 @@ func TestGeometricTxManager(t *testing.T) {
 		unsignedTx := newUnsignedEthTransferTx(0, nil)
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true)
+		_, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true, 2*time.Second)
 		require.NoError(t, err)
 
 		unsignedTx = newUnsignedEthTransferTx(0, nil)
-		_, err = h.txmgr.Send(ctxWithTimeout, unsignedTx, true)
+		_, err = h.txmgr.Send(ctxWithTimeout, unsignedTx, true, 2*time.Second)
 		require.Error(t, err)
 	})
 }
@@ -409,7 +409,7 @@ func TestGeometricTxManagerIntegration(t *testing.T) {
 		unsignedTx := newUnsignedEthTransferTx(0, nil)
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		txReceipt, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true)
+		txReceipt, err := h.txmgr.Send(ctxWithTimeout, unsignedTx, true, 2*time.Second)
 		require.NoError(t, err)
 
 		h.validateTxReceipt(t, txReceipt)

--- a/chainio/txmgr/txmgr.go
+++ b/chainio/txmgr/txmgr.go
@@ -2,6 +2,7 @@ package txmgr
 
 import (
 	"context"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -11,7 +12,7 @@ type TxManager interface {
 	// Send is used to sign and send a transaction to an evm chain
 	// It takes an unsigned transaction and then signs it before sending
 	// It might also take care of nonce management and gas estimation, depending on the implementation
-	Send(ctx context.Context, tx *types.Transaction, waitForReceipt bool) (*types.Receipt, error)
+	Send(ctx context.Context, tx *types.Transaction, waitForReceipt bool, waitForDuration time.Duration) (*types.Receipt, error)
 
 	// GetNoSendTxOpts generates a TransactOpts with
 	// - NoSend=true: b/c we want to manage the sending ourselves

--- a/signerv2/kms_signer_test.go
+++ b/signerv2/kms_signer_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	eigenkms "github.com/Layr-Labs/eigensdk-go/aws/kms"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
@@ -116,7 +117,7 @@ func TestSendTransaction(t *testing.T) {
 		Nonce:   0,
 		To:      &zeroAddr,
 		Value:   big.NewInt(1_000_000_000_000_000_000),
-	}), true)
+	}), true, 2*time.Second)
 	assert.Nil(t, err)
 	assert.NotNil(t, receipt)
 	balance, err := ethClient.BalanceAt(context.Background(), keyAddr, nil)


### PR DESCRIPTION
Found this todo and just quickly coded it up. I assume the intention to make the ticker adjustable is to make it configurable when sending a tx. Groups pretty nicely together with `waitForReceipt`.