### PR TITLE
chore: clean up elcontracts to take context

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -29,7 +29,7 @@ import (
 
 type eLReader interface {
 	CalculateOperatorAVSRegistrationDigestHash(
-		opts *bind.CallOpts,
+		ctx context.Context,
 		operatorAddr gethcommon.Address,
 		serviceManagerAddr gethcommon.Address,
 		operatorToAvsRegistrationSigSalt [32]byte,
@@ -233,7 +233,7 @@ func (w *ChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(
 
 	// params to register operator in delegation manager's operator-avs mapping
 	msgToSign, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
-		&bind.CallOpts{},
+		ctx,
 		operatorAddr,
 		w.serviceManagerAddr,
 		operatorToAvsRegistrationSigSalt,
@@ -355,7 +355,7 @@ func (w *ChainWriter) RegisterOperator(
 
 	// params to register operator in delegation manager's operator-avs mapping
 	msgToSign, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
-		&bind.CallOpts{},
+		ctx,
 		operatorAddr,
 		w.serviceManagerAddr,
 		operatorToAvsRegistrationSigSalt,

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -1,6 +1,7 @@
 package elcontracts_test
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 
 func TestChainReader(t *testing.T) {
 	clients, anvilHttpEndpoint := testclients.BuildTestClients(t)
+	ctx := context.Background()
 
 	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
 	operator := types.Operator{
@@ -22,13 +24,13 @@ func TestChainReader(t *testing.T) {
 	}
 
 	t.Run("is operator registered", func(t *testing.T) {
-		isOperator, err := clients.ElChainReader.IsOperatorRegistered(&bind.CallOpts{}, operator)
+		isOperator, err := clients.ElChainReader.IsOperatorRegistered(ctx, operator)
 		assert.NoError(t, err)
 		assert.Equal(t, isOperator, true)
 	})
 
 	t.Run("get operator details", func(t *testing.T) {
-		operatorDetails, err := clients.ElChainReader.GetOperatorDetails(&bind.CallOpts{}, operator)
+		operatorDetails, err := clients.ElChainReader.GetOperatorDetails(ctx, operator)
 		assert.NoError(t, err)
 		assert.NotNil(t, operatorDetails)
 		assert.Equal(t, operator.Address, operatorDetails.Address)
@@ -37,7 +39,7 @@ func TestChainReader(t *testing.T) {
 	t.Run("get strategy and underlying token", func(t *testing.T) {
 		strategyAddr := contractAddrs.Erc20MockStrategy
 		strategy, underlyingTokenAddr, err := clients.ElChainReader.GetStrategyAndUnderlyingToken(
-			&bind.CallOpts{},
+			ctx,
 			strategyAddr,
 		)
 		assert.NoError(t, err)
@@ -55,7 +57,7 @@ func TestChainReader(t *testing.T) {
 	t.Run("get strategy and underlying ERC20 token", func(t *testing.T) {
 		strategyAddr := contractAddrs.Erc20MockStrategy
 		strategy, contractUnderlyingToken, underlyingTokenAddr, err := clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
-			&bind.CallOpts{},
+			ctx,
 			strategyAddr,
 		)
 		assert.NoError(t, err)
@@ -70,7 +72,7 @@ func TestChainReader(t *testing.T) {
 
 	t.Run("service manager can slash operator until block", func(t *testing.T) {
 		_, err := clients.ElChainReader.ServiceManagerCanSlashOperatorUntilBlock(
-			&bind.CallOpts{},
+			ctx,
 			common.HexToAddress(operator.Address),
 			contractAddrs.ServiceManager,
 		)
@@ -79,7 +81,7 @@ func TestChainReader(t *testing.T) {
 
 	t.Run("operator is frozen", func(t *testing.T) {
 		isFrozen, err := clients.ElChainReader.OperatorIsFrozen(
-			&bind.CallOpts{},
+			ctx,
 			common.HexToAddress(operator.Address),
 		)
 		assert.NoError(t, err)
@@ -88,7 +90,7 @@ func TestChainReader(t *testing.T) {
 
 	t.Run("get operator shares in strategy", func(t *testing.T) {
 		shares, err := clients.ElChainReader.GetOperatorSharesInStrategy(
-			&bind.CallOpts{},
+			ctx,
 			common.HexToAddress(operator.Address),
 			contractAddrs.Erc20MockStrategy,
 		)
@@ -102,7 +104,7 @@ func TestChainReader(t *testing.T) {
 		approverSalt := [32]byte{}
 		expiry := big.NewInt(0)
 		digest, err := clients.ElChainReader.CalculateDelegationApprovalDigestHash(
-			&bind.CallOpts{},
+			ctx,
 			staker,
 			common.HexToAddress(operator.Address),
 			delegationApprover,
@@ -118,7 +120,7 @@ func TestChainReader(t *testing.T) {
 		salt := [32]byte{}
 		expiry := big.NewInt(0)
 		digest, err := clients.ElChainReader.CalculateOperatorAVSRegistrationDigestHash(
-			&bind.CallOpts{},
+			ctx,
 			common.HexToAddress(operator.Address),
 			avs,
 			salt,

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -6,7 +6,6 @@ import (
 
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
@@ -27,7 +26,7 @@ import (
 
 type Reader interface {
 	GetStrategyAndUnderlyingERC20Token(
-		opts *bind.CallOpts, strategyAddr gethcommon.Address,
+		ctx context.Context, strategyAddr gethcommon.Address,
 	) (*strategy.ContractIStrategy, erc20.ContractIERC20Methods, gethcommon.Address, error)
 }
 
@@ -276,7 +275,7 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 		return nil, err
 	}
 	_, underlyingTokenContract, underlyingTokenAddr, err := w.elChainReader.GetStrategyAndUnderlyingERC20Token(
-		&bind.CallOpts{Context: ctx},
+		ctx,
 		strategyAddr,
 	)
 	if err != nil {

--- a/metrics/collectors/economic/economic.go
+++ b/metrics/collectors/economic/economic.go
@@ -2,6 +2,7 @@
 package economic
 
 import (
+	"context"
 	"errors"
 	"strconv"
 
@@ -14,7 +15,7 @@ import (
 )
 
 type eLReader interface {
-	OperatorIsFrozen(opts *bind.CallOpts, operatorAddr common.Address) (bool, error)
+	OperatorIsFrozen(ctx context.Context, operatorAddr common.Address) (bool, error)
 }
 
 type avsRegistryReader interface {
@@ -153,7 +154,7 @@ func (ec *Collector) Collect(ch chan<- prometheus.Metric) {
 	// 1. keep this collector format but query the OperatorFrozen event from a subgraph
 	// 2. subscribe to the event and keep a local state of whether the operator has been slashed, exporting it via
 	// normal prometheus instrumentation
-	operatorIsFrozen, err := ec.elReader.OperatorIsFrozen(nil, ec.operatorAddr)
+	operatorIsFrozen, err := ec.elReader.OperatorIsFrozen(context.Background(), ec.operatorAddr)
 	if err != nil {
 		ec.logger.Error("Failed to get slashing incurred", "err", err)
 	} else {

--- a/metrics/collectors/economic/economic_test.go
+++ b/metrics/collectors/economic/economic_test.go
@@ -1,6 +1,7 @@
 package economic
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -29,7 +30,7 @@ func newFakeELReader() *fakeELReader {
 	}
 }
 
-func (f *fakeELReader) OperatorIsFrozen(opts *bind.CallOpts, operatorAddr common.Address) (bool, error) {
+func (f *fakeELReader) OperatorIsFrozen(ctx context.Context, operatorAddr common.Address) (bool, error) {
 	return f.registeredOperators[operatorAddr], nil
 }
 


### PR DESCRIPTION
Fixes # .

### What Changed?
- All read call in elcontracts take context as first input
- This is in consistency with write

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it