### PR TITLE
Add BLS Aggregation window waiting after quorum

### DIFF
--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -197,6 +197,24 @@ func (a *BlsAggregatorService) InitializeNewTask(
 	quorumThresholdPercentages types.QuorumThresholdPercentages,
 	timeToExpiry time.Duration,
 ) error {
+	return a.InitializeNewTaskWithWindow(
+		taskIndex,
+		taskCreatedBlock,
+		quorumNumbers,
+		quorumThresholdPercentages,
+		timeToExpiry,
+		0,
+	)
+}
+
+func (a *BlsAggregatorService) InitializeNewTaskWithWindow(
+	taskIndex types.TaskIndex,
+	taskCreatedBlock uint32,
+	quorumNumbers types.QuorumNums,
+	quorumThresholdPercentages types.QuorumThresholdPercentages,
+	timeToExpiry time.Duration,
+	windowTime time.Duration,
+) error {
 	a.logger.Debug(
 		"AggregatorService initializing new task",
 		"taskIndex",
@@ -225,6 +243,7 @@ func (a *BlsAggregatorService) InitializeNewTask(
 		quorumNumbers,
 		quorumThresholdPercentages,
 		timeToExpiry,
+		windowTime,
 		signedTaskRespsC,
 	)
 	return nil
@@ -265,12 +284,14 @@ func (a *BlsAggregatorService) ProcessNewSignature(
 	}
 }
 
+// TODO: document this
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	taskIndex types.TaskIndex,
 	taskCreatedBlock uint32,
 	quorumNumbers types.QuorumNums,
 	quorumThresholdPercentages []types.QuorumThresholdPercentage,
 	timeToExpiry time.Duration,
+	windowTime time.Duration,
 	signedTaskRespsC <-chan types.SignedTaskResponseDigest,
 ) {
 	a.logger.Debug("AggregatorService goroutine processing new task",
@@ -438,25 +459,13 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			) {
 				if !openWindow {
 					openWindow = true
-					windowTimer = time.NewTimer(2 * time.Second)
-					a.logger.Info("Window timer started")
+					windowTimer = time.NewTimer(windowTime * time.Second)
+					a.logger.Debug("Window timer started")
 					continue
 				}
 				a.logger.Debug("Task goroutine stake threshold reached",
 					"taskIndex", taskIndex,
 					"taskResponseDigest", taskResponseDigest)
-
-				a.sendAggregatedResponse(
-					operatorsAvsStateDict,
-					taskIndex,
-					taskCreatedBlock,
-					signedTaskResponseDigest,
-					digestAggregatedOperators,
-					quorumNumbers,
-					taskResponseDigest,
-					quorumApksG1,
-				)
-				taskExpiredTimer.Stop()
 				return
 			}
 		case <-taskExpiredTimer.C:
@@ -479,7 +488,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			}
 			return
 		case <-windowTimer.C:
-			a.logger.Info("Window timer expired")
+			a.logger.Debug("Window timer expired")
 			a.sendAggregatedResponse(
 				operatorsAvsStateDict,
 				taskIndex,

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -344,6 +344,9 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	aggregatedOperatorsDict := map[types.TaskResponseDigest]aggregatedOperators{}
 	windowTimer := time.NewTimer(timeToExpiry + 1)
 	openWindow := false
+	var lastSignedTaskResponseDigest types.SignedTaskResponseDigest
+	var lastDigestAggregatedOperators aggregatedOperators
+	var lastTaskResponseDigest types.TaskResponseDigest
 	for {
 		select {
 		case signedTaskResponseDigest := <-signedTaskRespsC:
@@ -417,6 +420,12 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 					digestAggregatedOperators.signersTotalStakePerQuorum[quorumNum].Add(digestAggregatedOperators.signersTotalStakePerQuorum[quorumNum], stake)
 				}
 			}
+
+			// update the buffer variables to be used when the window timer fires
+			lastDigestAggregatedOperators = digestAggregatedOperators
+			lastTaskResponseDigest = taskResponseDigest
+			lastSignedTaskResponseDigest = signedTaskResponseDigest
+
 			// update the aggregatedOperatorsDict. Note that we need to assign the whole struct value at once,
 			// because of https://github.com/golang/go/issues/3117
 			aggregatedOperatorsDict[taskResponseDigest] = digestAggregatedOperators
@@ -448,11 +457,20 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 					quorumApksG1,
 				)
 				taskExpiredTimer.Stop()
-
+				return
 			}
 		case <-taskExpiredTimer.C:
 			if openWindow {
-				// send the aggregated response
+				a.sendAggregatedResponse(
+					operatorsAvsStateDict,
+					taskIndex,
+					taskCreatedBlock,
+					lastSignedTaskResponseDigest,
+					lastDigestAggregatedOperators,
+					quorumNumbers,
+					lastTaskResponseDigest,
+					quorumApksG1,
+				)
 			}
 
 			a.aggregatedResponsesC <- BlsAggregationServiceResponse{
@@ -462,7 +480,16 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			return
 		case <-windowTimer.C:
 			a.logger.Info("Window timer expired")
-			// a.sendAggregatedResponse()
+			a.sendAggregatedResponse(
+				operatorsAvsStateDict,
+				taskIndex,
+				taskCreatedBlock,
+				lastSignedTaskResponseDigest,
+				lastDigestAggregatedOperators,
+				quorumNumbers,
+				lastTaskResponseDigest,
+				quorumApksG1,
+			)
 			return
 		}
 	}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -370,6 +370,19 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	var lastTaskResponseDigest types.TaskResponseDigest
 	for {
 		select {
+		case <-windowTimer.C:
+			a.logger.Debug("Window timer expired")
+			a.sendAggregatedResponse(
+				operatorsAvsStateDict,
+				taskIndex,
+				taskCreatedBlock,
+				lastSignedTaskResponseDigest,
+				lastDigestAggregatedOperators,
+				quorumNumbers,
+				lastTaskResponseDigest,
+				quorumApksG1,
+			)
+			return
 		case signedTaskResponseDigest := <-signedTaskRespsC:
 			a.logger.Debug(
 				"Task goroutine received new signed task response digest",
@@ -483,19 +496,6 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 				Err:       TaskExpiredErrorFn(taskIndex),
 				TaskIndex: taskIndex,
 			}
-			return
-		case <-windowTimer.C:
-			a.logger.Debug("Window timer expired")
-			a.sendAggregatedResponse(
-				operatorsAvsStateDict,
-				taskIndex,
-				taskCreatedBlock,
-				lastSignedTaskResponseDigest,
-				lastDigestAggregatedOperators,
-				quorumNumbers,
-				lastTaskResponseDigest,
-				quorumApksG1,
-			)
 			return
 		}
 	}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -82,8 +82,9 @@ type aggregatedOperators struct {
 // Currently its only implementation is the BlsAggregatorService, so see the comment there for more details
 type BlsAggregationService interface {
 	// InitializeNewTask creates a new task goroutine meant to process new signed task responses for that task
-	// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to it.
-	// The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered complete, which
+	// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to
+	// it. The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered
+	// complete, which
 	// happens when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers
 	// whose stake in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in
 	// that quorum
@@ -96,12 +97,14 @@ type BlsAggregationService interface {
 	) error
 
 	// InitializeNewTaskWithWindow creates a new task goroutine meant to process new signed task responses for that task
-	// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to it.
-	// The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered complete, which
+	// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to
+	// it. The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered
+	// complete, which
 	// happens when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers
 	// whose stake in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in
 	// that quorum.
-	// Once the quorum is reached, the task is still open for a window of `windowDuration` time to receive more signatures,
+	// Once the quorum is reached, the task is still open for a window of `windowDuration` time to receive more
+	// signatures,
 	// before sending the aggregation response through the aggregatedResponsesC channel.
 	InitializeNewTaskWithWindow(
 		taskIndex types.TaskIndex,

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -213,7 +213,7 @@ func (a *BlsAggregatorService) InitializeNewTaskWithWindow(
 	quorumNumbers types.QuorumNums,
 	quorumThresholdPercentages types.QuorumThresholdPercentages,
 	timeToExpiry time.Duration,
-	windowTime time.Duration,
+	windowDuration time.Duration,
 ) error {
 	a.logger.Debug(
 		"AggregatorService initializing new task",
@@ -243,7 +243,7 @@ func (a *BlsAggregatorService) InitializeNewTaskWithWindow(
 		quorumNumbers,
 		quorumThresholdPercentages,
 		timeToExpiry,
-		windowTime,
+		windowDuration,
 		signedTaskRespsC,
 	)
 	return nil
@@ -291,7 +291,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	quorumNumbers types.QuorumNums,
 	quorumThresholdPercentages []types.QuorumThresholdPercentage,
 	timeToExpiry time.Duration,
-	windowTime time.Duration,
+	windowDuration time.Duration,
 	signedTaskRespsC <-chan types.SignedTaskResponseDigest,
 ) {
 	a.logger.Debug("AggregatorService goroutine processing new task",
@@ -451,22 +451,19 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			// because of https://github.com/golang/go/issues/3117
 			aggregatedOperatorsDict[taskResponseDigest] = digestAggregatedOperators
 
-			if checkIfStakeThresholdsMet(
+			if !openWindow && checkIfStakeThresholdsMet(
 				a.logger,
 				digestAggregatedOperators.signersTotalStakePerQuorum,
 				totalStakePerQuorum,
 				quorumThresholdPercentagesMap,
 			) {
-				if !openWindow {
-					openWindow = true
-					windowTimer = time.NewTimer(windowTime * time.Second)
-					a.logger.Debug("Window timer started")
-					continue
-				}
 				a.logger.Debug("Task goroutine stake threshold reached",
 					"taskIndex", taskIndex,
 					"taskResponseDigest", taskResponseDigest)
-				return
+
+				openWindow = true
+				windowTimer = time.NewTimer(windowDuration * time.Second)
+				a.logger.Debug("Window timer started")
 			}
 		case <-taskExpiredTimer.C:
 			if openWindow {

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -370,19 +370,6 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	var lastTaskResponseDigest types.TaskResponseDigest
 	for {
 		select {
-		case <-windowTimer.C:
-			a.logger.Debug("Window timer expired")
-			a.sendAggregatedResponse(
-				operatorsAvsStateDict,
-				taskIndex,
-				taskCreatedBlock,
-				lastSignedTaskResponseDigest,
-				lastDigestAggregatedOperators,
-				quorumNumbers,
-				lastTaskResponseDigest,
-				quorumApksG1,
-			)
-			return
 		case signedTaskResponseDigest := <-signedTaskRespsC:
 			a.logger.Debug(
 				"Task goroutine received new signed task response digest",
@@ -496,6 +483,19 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 				Err:       TaskExpiredErrorFn(taskIndex),
 				TaskIndex: taskIndex,
 			}
+			return
+		case <-windowTimer.C:
+			a.logger.Debug("Window timer expired")
+			a.sendAggregatedResponse(
+				operatorsAvsStateDict,
+				taskIndex,
+				taskCreatedBlock,
+				lastSignedTaskResponseDigest,
+				lastDigestAggregatedOperators,
+				quorumNumbers,
+				lastTaskResponseDigest,
+				quorumApksG1,
+			)
 			return
 		}
 	}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -363,7 +363,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	taskExpiredTimer := time.NewTimer(timeToExpiry)
 
 	aggregatedOperatorsDict := map[types.TaskResponseDigest]aggregatedOperators{}
-	windowTimer := time.NewTimer(timeToExpiry + 1)
+	windowTimer := time.NewTimer(timeToExpiry + 1*time.Second)
 	openWindow := false
 	var lastSignedTaskResponseDigest types.SignedTaskResponseDigest
 	var lastDigestAggregatedOperators aggregatedOperators
@@ -462,7 +462,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 					"taskResponseDigest", taskResponseDigest)
 
 				openWindow = true
-				windowTimer = time.NewTimer(windowDuration * time.Second)
+				windowTimer = time.NewTimer(windowDuration)
 				a.logger.Debug("Window timer started")
 			}
 		case <-taskExpiredTimer.C:

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -342,6 +342,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	taskExpiredTimer := time.NewTimer(timeToExpiry)
 
 	aggregatedOperatorsDict := map[types.TaskResponseDigest]aggregatedOperators{}
+	windowTimer := time.NewTimer(timeToExpiry + 1)
+	openWindow := false
 	for {
 		select {
 		case signedTaskResponseDigest := <-signedTaskRespsC:
@@ -425,6 +427,12 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 				totalStakePerQuorum,
 				quorumThresholdPercentagesMap,
 			) {
+				if !openWindow {
+					openWindow = true
+					windowTimer = time.NewTimer(2 * time.Second)
+					a.logger.Info("Window timer started")
+					continue
+				}
 				a.logger.Debug("Task goroutine stake threshold reached",
 					"taskIndex", taskIndex,
 					"taskResponseDigest", taskResponseDigest)
@@ -443,10 +451,18 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 
 			}
 		case <-taskExpiredTimer.C:
+			if openWindow {
+				// send the aggregated response
+			}
+
 			a.aggregatedResponsesC <- BlsAggregationServiceResponse{
 				Err:       TaskExpiredErrorFn(taskIndex),
 				TaskIndex: taskIndex,
 			}
+			return
+		case <-windowTimer.C:
+			a.logger.Info("Window timer expired")
+			// a.sendAggregatedResponse()
 			return
 		}
 	}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -429,57 +429,18 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 					"taskIndex", taskIndex,
 					"taskResponseDigest", taskResponseDigest)
 
-				nonSignersOperatorIds := []types.OperatorId{}
-				for operatorId := range operatorsAvsStateDict {
-					if _, operatorSigned := digestAggregatedOperators.signersOperatorIdsSet[operatorId]; !operatorSigned {
-						nonSignersOperatorIds = append(nonSignersOperatorIds, operatorId)
-					}
-				}
-
-				// the contract requires a sorted nonSignersOperatorIds
-				sort.SliceStable(nonSignersOperatorIds, func(i, j int) bool {
-					iOprInt := new(big.Int).SetBytes(nonSignersOperatorIds[i][:])
-					jOprInt := new(big.Int).SetBytes(nonSignersOperatorIds[j][:])
-					return iOprInt.Cmp(jOprInt) == -1
-				})
-
-				nonSignersG1Pubkeys := []*bls.G1Point{}
-				for _, operatorId := range nonSignersOperatorIds {
-					operator := operatorsAvsStateDict[operatorId]
-					nonSignersG1Pubkeys = append(nonSignersG1Pubkeys, operator.OperatorInfo.Pubkeys.G1Pubkey)
-				}
-
-				indices, err := a.avsRegistryService.GetCheckSignaturesIndices(
-					&bind.CallOpts{},
+				a.sendAggregatedResponse(
+					operatorsAvsStateDict,
+					taskIndex,
 					taskCreatedBlock,
+					signedTaskResponseDigest,
+					digestAggregatedOperators,
 					quorumNumbers,
-					nonSignersOperatorIds,
+					taskResponseDigest,
+					quorumApksG1,
 				)
-				if err != nil {
-					a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-						Err:       utils.WrapError(errors.New("Failed to get check signatures indices"), err),
-						TaskIndex: taskIndex,
-					}
-					return
-				}
-
-				blsAggregationServiceResponse := BlsAggregationServiceResponse{
-					Err:                          nil,
-					TaskIndex:                    taskIndex,
-					TaskResponse:                 signedTaskResponseDigest.TaskResponse,
-					TaskResponseDigest:           taskResponseDigest,
-					NonSignersPubkeysG1:          nonSignersG1Pubkeys,
-					QuorumApksG1:                 quorumApksG1,
-					SignersApkG2:                 digestAggregatedOperators.signersApkG2,
-					SignersAggSigG1:              digestAggregatedOperators.signersAggSigG1,
-					NonSignerQuorumBitmapIndices: indices.NonSignerQuorumBitmapIndices,
-					QuorumApkIndices:             indices.QuorumApkIndices,
-					TotalStakeIndices:            indices.TotalStakeIndices,
-					NonSignerStakeIndices:        indices.NonSignerStakeIndices,
-				}
-				a.aggregatedResponsesC <- blsAggregationServiceResponse
 				taskExpiredTimer.Stop()
-				return
+
 			}
 		case <-taskExpiredTimer.C:
 			a.aggregatedResponsesC <- BlsAggregationServiceResponse{
@@ -489,7 +450,67 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			return
 		}
 	}
+}
 
+func (a *BlsAggregatorService) sendAggregatedResponse(
+	operatorsAvsStateDict map[types.OperatorId]types.OperatorAvsState,
+	taskIndex types.TaskIndex,
+	taskCreatedBlock uint32,
+	signedTaskResponseDigest types.SignedTaskResponseDigest,
+	digestAggregatedOperators aggregatedOperators,
+	quorumNumbers types.QuorumNums,
+	taskResponseDigest types.TaskResponseDigest,
+	quorumApksG1 []*bls.G1Point,
+) {
+	nonSignersOperatorIds := []types.OperatorId{}
+	for operatorId := range operatorsAvsStateDict {
+		if _, operatorSigned := digestAggregatedOperators.signersOperatorIdsSet[operatorId]; !operatorSigned {
+			nonSignersOperatorIds = append(nonSignersOperatorIds, operatorId)
+		}
+	}
+
+	// the contract requires a sorted nonSignersOperatorIds
+	sort.SliceStable(nonSignersOperatorIds, func(i, j int) bool {
+		iOprInt := new(big.Int).SetBytes(nonSignersOperatorIds[i][:])
+		jOprInt := new(big.Int).SetBytes(nonSignersOperatorIds[j][:])
+		return iOprInt.Cmp(jOprInt) == -1
+	})
+
+	nonSignersG1Pubkeys := []*bls.G1Point{}
+	for _, operatorId := range nonSignersOperatorIds {
+		operator := operatorsAvsStateDict[operatorId]
+		nonSignersG1Pubkeys = append(nonSignersG1Pubkeys, operator.OperatorInfo.Pubkeys.G1Pubkey)
+	}
+
+	indices, err := a.avsRegistryService.GetCheckSignaturesIndices(
+		&bind.CallOpts{},
+		taskCreatedBlock,
+		quorumNumbers,
+		nonSignersOperatorIds,
+	)
+	if err != nil {
+		a.aggregatedResponsesC <- BlsAggregationServiceResponse{
+			Err:       utils.WrapError(errors.New("Failed to get check signatures indices"), err),
+			TaskIndex: taskIndex,
+		}
+		return
+	}
+
+	blsAggregationServiceResponse := BlsAggregationServiceResponse{
+		Err:                          nil,
+		TaskIndex:                    taskIndex,
+		TaskResponse:                 signedTaskResponseDigest.TaskResponse,
+		TaskResponseDigest:           taskResponseDigest,
+		NonSignersPubkeysG1:          nonSignersG1Pubkeys,
+		QuorumApksG1:                 quorumApksG1,
+		SignersApkG2:                 digestAggregatedOperators.signersApkG2,
+		SignersAggSigG1:              digestAggregatedOperators.signersAggSigG1,
+		NonSignerQuorumBitmapIndices: indices.NonSignerQuorumBitmapIndices,
+		QuorumApkIndices:             indices.QuorumApkIndices,
+		TotalStakeIndices:            indices.TotalStakeIndices,
+		NonSignerStakeIndices:        indices.NonSignerStakeIndices,
+	}
+	a.aggregatedResponsesC <- blsAggregationServiceResponse
 }
 
 // closeTaskGoroutine is run when the goroutine processing taskIndex's task responses ends (for whatever reason)

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -370,6 +370,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	taskExpiredTimer := time.NewTimer(timeToExpiry)
 
 	aggregatedOperatorsDict := map[types.TaskResponseDigest]aggregatedOperators{}
+	// The windowTimer is initialized to be longer than the taskExpiredTimer as it will
+	// be overwritten once the stake threshold is met
 	windowTimer := time.NewTimer(timeToExpiry + 1*time.Second)
 	openWindow := false
 	var lastSignedTaskResponseDigest types.SignedTaskResponseDigest

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -106,6 +106,8 @@ type BlsAggregationService interface {
 	// Once the quorum is reached, the task is still open for a window of `windowDuration` time to receive more
 	// signatures,
 	// before sending the aggregation response through the aggregatedResponsesC channel.
+	// If the task expiration is reached before the window finishes, the task response will still be sent to the
+	// aggregatedResponsesC channel.
 	InitializeNewTaskWithWindow(
 		taskIndex types.TaskIndex,
 		taskCreatedBlock uint32,

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -185,11 +185,11 @@ func (a *BlsAggregatorService) GetResponseChannel() <-chan BlsAggregationService
 }
 
 // InitializeNewTask creates a new task goroutine meant to process new signed task responses for that task
-// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to it
-// quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered complete, which
-// happens
-// when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers whose stake
-// in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in that quorum
+// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to it.
+// The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered complete, which
+// happens when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers
+// whose stake in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in
+// that quorum
 func (a *BlsAggregatorService) InitializeNewTask(
 	taskIndex types.TaskIndex,
 	taskCreatedBlock uint32,
@@ -207,6 +207,14 @@ func (a *BlsAggregatorService) InitializeNewTask(
 	)
 }
 
+// InitializeNewTaskWithWindow creates a new task goroutine meant to process new signed task responses for that task
+// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to it.
+// The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered complete, which
+// happens when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers
+// whose stake in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in
+// that quorum.
+// Once the quorum is reached, the task is still open for a window of `windowDuration` time to receive more signatures,
+// before sending the aggregation response through the aggregatedResponsesC channel.
 func (a *BlsAggregatorService) InitializeNewTaskWithWindow(
 	taskIndex types.TaskIndex,
 	taskCreatedBlock uint32,
@@ -284,7 +292,6 @@ func (a *BlsAggregatorService) ProcessNewSignature(
 	}
 }
 
-// TODO: document this
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	taskIndex types.TaskIndex,
 	taskCreatedBlock uint32,

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -1392,7 +1392,6 @@ func TestBlsAgg(t *testing.T) {
 		require.True(t, elapsed.Seconds() < windowDuration.Seconds())
 	})
 
-	// cannot test this as processing new signatures is blocking
 	t.Run("if window duration is zero, no signatures are aggregated after reaching quorum", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -30,7 +30,6 @@ import (
 // TestBlsAgg is a suite of test that tests the main aggregation logic of the aggregation service
 // it don't check any of the indices fields because those are just provided as a convenience to the caller
 // and aren't related to the main logic which we actually need to test
-// they are gotten from a call to the chain at the end of the aggregation so we should test that elsewhere
 func TestBlsAgg(t *testing.T) {
 
 	// we hardcode this for now, until we implement this feature properly
@@ -1188,6 +1187,314 @@ func TestBlsAgg(t *testing.T) {
 			require.EqualError(t, err, "Signature verification failed. Incorrect Signature.")
 		},
 	)
+
+	t.Run("signatures are processed during window even after quorum", func(t *testing.T) {
+		testOperator1 := types.TestOperator{
+			OperatorId:     types.OperatorId{1},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			BlsKeypair:     newBlsKeyPairPanics("0x1"),
+		}
+		testOperator2 := types.TestOperator{
+			OperatorId:     types.OperatorId{2},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			BlsKeypair:     newBlsKeyPairPanics("0x2"),
+		}
+		testOperator3 := types.TestOperator{
+			OperatorId:     types.OperatorId{3},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(100)},
+			BlsKeypair:     newBlsKeyPairPanics("0x3"),
+		}
+		blockNum := uint32(1)
+		taskIndex := types.TaskIndex(0)
+		quorumNumbers := types.QuorumNums{0}
+		quorumThresholdPercentages := []types.QuorumThresholdPercentage{50}
+		taskResponse := mockTaskResponse{123}
+
+		timeToExpiry := 5 * time.Second
+		windowDuration := 1 * time.Second
+
+		taskResponseDigest, err := hashFunction(taskResponse)
+		require.Nil(t, err)
+
+		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(
+			blockNum,
+			[]types.TestOperator{testOperator1, testOperator2, testOperator3},
+		)
+		logger := testutils.GetTestLogger()
+		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+
+		start := time.Now()
+		err = blsAggServ.InitializeNewTaskWithWindow(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			timeToExpiry,
+			windowDuration,
+		)
+		require.Nil(t, err)
+
+		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
+		)
+		require.Nil(t, err)
+		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
+		)
+		// quorum has already been reached, but window should still be open
+		require.Nil(t, err)
+		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
+		)
+		require.Nil(t, err)
+
+		wantAggregationServiceResponse := BlsAggregationServiceResponse{
+			Err:                 nil,
+			TaskIndex:           taskIndex,
+			TaskResponse:        taskResponse,
+			TaskResponseDigest:  taskResponseDigest,
+			NonSignersPubkeysG1: []*bls.G1Point{},
+			QuorumApksG1: []*bls.G1Point{testOperator1.BlsKeypair.GetPubKeyG1().
+				Add(testOperator2.BlsKeypair.GetPubKeyG1()).
+				Add(testOperator3.BlsKeypair.GetPubKeyG1()),
+			},
+			SignersApkG2: testOperator1.BlsKeypair.GetPubKeyG2().
+				Add(testOperator2.BlsKeypair.GetPubKeyG2()).
+				Add(testOperator3.BlsKeypair.GetPubKeyG2()),
+			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
+				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
+				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
+		}
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
+		elapsed := time.Since(start)
+		t.Log("elapsed: ", elapsed.Seconds())
+		require.True(t, elapsed.Seconds() >= windowDuration.Seconds(), "The aggregation response should be sent after the window finishes")
+		require.True(t, elapsed.Seconds() < timeToExpiry.Seconds())
+	})
+
+	t.Run("if quorum has been reached and the task expires during window, the response is sent", func(t *testing.T) {
+		testOperator1 := types.TestOperator{
+			OperatorId:     types.OperatorId{1},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			BlsKeypair:     newBlsKeyPairPanics("0x1"),
+		}
+		testOperator2 := types.TestOperator{
+			OperatorId:     types.OperatorId{2},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			BlsKeypair:     newBlsKeyPairPanics("0x2"),
+		}
+		testOperator3 := types.TestOperator{
+			OperatorId:     types.OperatorId{3},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(100)},
+			BlsKeypair:     newBlsKeyPairPanics("0x3"),
+		}
+		blockNum := uint32(1)
+		taskIndex := types.TaskIndex(0)
+		quorumNumbers := types.QuorumNums{0}
+		quorumThresholdPercentages := []types.QuorumThresholdPercentage{50}
+		taskResponse := mockTaskResponse{123}
+
+		timeToExpiry := 5 * time.Second
+		windowDuration := 6 * time.Second
+
+		taskResponseDigest, err := hashFunction(taskResponse)
+		require.Nil(t, err)
+
+		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(
+			blockNum,
+			[]types.TestOperator{testOperator1, testOperator2, testOperator3},
+		)
+		logger := testutils.GetTestLogger()
+		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+
+		start := time.Now()
+		err = blsAggServ.InitializeNewTaskWithWindow(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			timeToExpiry,
+			windowDuration,
+		)
+		require.Nil(t, err)
+
+		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
+		)
+		require.Nil(t, err)
+		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
+		)
+		require.Nil(t, err)
+
+		// quorum has already been reached, window will be open and receiving signature until the task expires
+
+		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
+		)
+		require.Nil(t, err)
+
+		wantAggregationServiceResponse := BlsAggregationServiceResponse{
+			Err:                 nil,
+			TaskIndex:           taskIndex,
+			TaskResponse:        taskResponse,
+			TaskResponseDigest:  taskResponseDigest,
+			NonSignersPubkeysG1: []*bls.G1Point{},
+			QuorumApksG1: []*bls.G1Point{testOperator1.BlsKeypair.GetPubKeyG1().
+				Add(testOperator2.BlsKeypair.GetPubKeyG1()).
+				Add(testOperator3.BlsKeypair.GetPubKeyG1()),
+			},
+			SignersApkG2: testOperator1.BlsKeypair.GetPubKeyG2().
+				Add(testOperator2.BlsKeypair.GetPubKeyG2()).
+				Add(testOperator3.BlsKeypair.GetPubKeyG2()),
+			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
+				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
+				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
+		}
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
+		elapsed := time.Since(start)
+		t.Log("elapsed: ", elapsed.Seconds())
+		require.True(t, elapsed.Seconds() >= timeToExpiry.Seconds())
+		require.True(t, elapsed.Seconds() < windowDuration.Seconds())
+	})
+
+	// cannot test this as processing new signatures is blocking
+	t.Run("if window duration is zero, no signatures are aggregated after reaching quorum", func(t *testing.T) {
+		testOperator1 := types.TestOperator{
+			OperatorId:     types.OperatorId{1},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			BlsKeypair:     newBlsKeyPairPanics("0x1"),
+		}
+		testOperator2 := types.TestOperator{
+			OperatorId:     types.OperatorId{2},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			BlsKeypair:     newBlsKeyPairPanics("0x2"),
+		}
+		testOperator3 := types.TestOperator{
+			OperatorId:     types.OperatorId{3},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(100)},
+			BlsKeypair:     newBlsKeyPairPanics("0x3"),
+		}
+		blockNum := uint32(1)
+		taskIndex := types.TaskIndex(0)
+		quorumNumbers := types.QuorumNums{0}
+		quorumThresholdPercentages := []types.QuorumThresholdPercentage{50}
+		taskResponse := mockTaskResponse{123}
+
+		timeToExpiry := 5 * time.Second
+		windowDuration := 0 * time.Second
+
+		taskResponseDigest, err := hashFunction(taskResponse)
+		require.Nil(t, err)
+
+		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(
+			blockNum,
+			[]types.TestOperator{testOperator1, testOperator2, testOperator3},
+		)
+		logger := testutils.GetTestLogger()
+		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+
+		err = blsAggServ.InitializeNewTaskWithWindow(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			timeToExpiry,
+			windowDuration,
+		)
+		require.Nil(t, err)
+
+		start := time.Now()
+
+		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
+		)
+		require.Nil(t, err)
+		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
+		)
+		require.Nil(t, err)
+
+		// quorum has already been reached, next signatures should not be aggregated
+		// this should timeout as the task goroutine is blocked on the response channel
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			ctx,
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
+		)
+		require.Equal(t, context.DeadlineExceeded, err)
+
+		wantAggregationServiceResponse := BlsAggregationServiceResponse{
+			Err:                 nil,
+			TaskIndex:           taskIndex,
+			TaskResponse:        taskResponse,
+			TaskResponseDigest:  taskResponseDigest,
+			NonSignersPubkeysG1: []*bls.G1Point{testOperator3.BlsKeypair.GetPubKeyG1()},
+			QuorumApksG1: []*bls.G1Point{testOperator1.BlsKeypair.GetPubKeyG1().
+				Add(testOperator2.BlsKeypair.GetPubKeyG1()).
+				Add(testOperator3.BlsKeypair.GetPubKeyG1()),
+			},
+			SignersApkG2: testOperator1.BlsKeypair.GetPubKeyG2().
+				Add(testOperator2.BlsKeypair.GetPubKeyG2()),
+			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
+				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
+		}
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
+		elapsed := time.Since(start)
+		t.Log("elapsed: ", elapsed.Seconds())
+		require.True(t, elapsed.Seconds() < timeToExpiry.Seconds())
+	})
 }
 
 func TestIntegrationBlsAgg(t *testing.T) {

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -1285,7 +1285,11 @@ func TestBlsAgg(t *testing.T) {
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
 		t.Log("elapsed: ", elapsed.Seconds())
-		require.True(t, elapsed.Seconds() >= windowDuration.Seconds(), "The aggregation response should be sent after the window finishes")
+		require.True(
+			t,
+			elapsed.Seconds() >= windowDuration.Seconds(),
+			"The aggregation response should be sent after the window finishes",
+		)
 		require.True(t, elapsed.Seconds() < timeToExpiry.Seconds())
 	})
 

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -1191,23 +1191,23 @@ func TestBlsAgg(t *testing.T) {
 	t.Run("signatures are processed during window after quorum", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(200)},
 			BlsKeypair:     newBlsKeyPairPanics("0x1"),
 		}
 		testOperator2 := types.TestOperator{
 			OperatorId:     types.OperatorId{2},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(200)},
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 		}
 		testOperator3 := types.TestOperator{
 			OperatorId:     types.OperatorId{3},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(100)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x3"),
 		}
 		blockNum := uint32(1)
 		taskIndex := types.TaskIndex(0)
 		quorumNumbers := types.QuorumNums{0}
-		quorumThresholdPercentages := []types.QuorumThresholdPercentage{50}
+		quorumThresholdPercentages := []types.QuorumThresholdPercentage{67}
 		taskResponse := mockTaskResponse{123}
 
 		timeToExpiry := 5 * time.Second
@@ -1457,6 +1457,111 @@ func TestBlsAgg(t *testing.T) {
 			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
+
+		// quorum has already been reached, next signatures should not be aggregated
+		// this should timeout as the task goroutine is blocked on the response channel
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			ctx,
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
+		)
+		require.Equal(t, context.DeadlineExceeded, err)
+
+		wantAggregationServiceResponse := BlsAggregationServiceResponse{
+			Err:                 nil,
+			TaskIndex:           taskIndex,
+			TaskResponse:        taskResponse,
+			TaskResponseDigest:  taskResponseDigest,
+			NonSignersPubkeysG1: []*bls.G1Point{testOperator3.BlsKeypair.GetPubKeyG1()},
+			QuorumApksG1: []*bls.G1Point{testOperator1.BlsKeypair.GetPubKeyG1().
+				Add(testOperator2.BlsKeypair.GetPubKeyG1()).
+				Add(testOperator3.BlsKeypair.GetPubKeyG1()),
+			},
+			SignersApkG2: testOperator1.BlsKeypair.GetPubKeyG2().
+				Add(testOperator2.BlsKeypair.GetPubKeyG2()),
+			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
+				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
+		}
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
+		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
+		elapsed := time.Since(start)
+		t.Log("elapsed: ", elapsed.Seconds())
+		require.True(t, elapsed.Seconds() < timeToExpiry.Seconds())
+	})
+
+	t.Run("no signatures are aggregated after window", func(t *testing.T) {
+		testOperator1 := types.TestOperator{
+			OperatorId:     types.OperatorId{1},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			BlsKeypair:     newBlsKeyPairPanics("0x1"),
+		}
+		testOperator2 := types.TestOperator{
+			OperatorId:     types.OperatorId{2},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			BlsKeypair:     newBlsKeyPairPanics("0x2"),
+		}
+		testOperator3 := types.TestOperator{
+			OperatorId:     types.OperatorId{3},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(100)},
+			BlsKeypair:     newBlsKeyPairPanics("0x3"),
+		}
+		blockNum := uint32(1)
+		taskIndex := types.TaskIndex(0)
+		quorumNumbers := types.QuorumNums{0}
+		quorumThresholdPercentages := []types.QuorumThresholdPercentage{50}
+		taskResponse := mockTaskResponse{123}
+
+		timeToExpiry := 10 * time.Second
+		windowDuration := 1 * time.Second
+
+		taskResponseDigest, err := hashFunction(taskResponse)
+		require.Nil(t, err)
+
+		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(
+			blockNum,
+			[]types.TestOperator{testOperator1, testOperator2, testOperator3},
+		)
+		logger := testutils.GetTestLogger()
+		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+
+		err = blsAggServ.InitializeNewTaskWithWindow(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			timeToExpiry,
+			windowDuration,
+		)
+		require.Nil(t, err)
+
+		start := time.Now()
+
+		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
+		)
+		require.Nil(t, err)
+		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
+		)
+		require.Nil(t, err)
+
+		time.Sleep(2 * time.Second)
 
 		// quorum has already been reached, next signatures should not be aggregated
 		// this should timeout as the task goroutine is blocked on the response channel

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -30,6 +30,7 @@ import (
 // TestBlsAgg is a suite of test that tests the main aggregation logic of the aggregation service
 // it don't check any of the indices fields because those are just provided as a convenience to the caller
 // and aren't related to the main logic which we actually need to test
+// they are gotten from a call to the chain at the end of the aggregation so we should test that elsewhere
 func TestBlsAgg(t *testing.T) {
 
 	// we hardcode this for now, until we implement this feature properly

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -1462,6 +1462,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		require.Nil(t, err)
 
+		time.Sleep(1 * time.Millisecond)
 		// quorum has already been reached, next signatures should not be aggregated
 		// this should timeout as the task goroutine is blocked on the response channel
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -1188,7 +1188,7 @@ func TestBlsAgg(t *testing.T) {
 		},
 	)
 
-	t.Run("signatures are processed during window even after quorum", func(t *testing.T) {
+	t.Run("signatures are processed during window after quorum", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},
 			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},


### PR DESCRIPTION
Closes #300 

Add BLS aggregation window-waiting-after-quorum feature. Once the aggregator reaches quorum, instead of sending the aggregated signature response, it will wait for a `windowDuration` time. During that window time, it will continue to receive and aggregate new signatures, allowing to reduce the gas cost of validating the aggregation on chain. When the window time finishes, the aggregation is sent.
In the case that task's expiry time is reached during that window, the aggregation response is sent.

To implement this feature, the aggregation loop was modified. There are 3 posible cases:
- receiving a new signature,
- expiration timer, 
- window timer.

Each time a new signature is received, it checks if quorum is reached. Once it's reached, the window timer fires. The loop continues until one of the two timers finish (window timer or task expiration).

This tests cases were added:
- signatures are processed during window after quorum
- if quorum has been reached and the task expires during window, the response is sent
- if window duration is zero, no signatures are aggregated after reaching quorum
- no signatures are aggregated after window

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it