### PR TITLE
feat: methods to set and read operator avs split

### DIFF
--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -341,16 +341,16 @@ func (r *ChainReader) GetOperatorAVSSplit(
 	ctx context.Context,
 	operator gethcommon.Address,
 	avs gethcommon.Address,
-) (*uint16, error) {
+) (uint16, error) {
 	if r.rewardsCoordinator == nil {
-		return nil, errors.New("RewardsCoordinator contract not provided")
+		return 0, errors.New("RewardsCoordinator contract not provided")
 	}
 
 	split, err := r.rewardsCoordinator.GetOperatorAVSSplit(&bind.CallOpts{Context: ctx}, operator, avs)
 
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &split, err
+	return split, nil
 }

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -336,3 +336,21 @@ func (r *ChainReader) CheckClaim(
 
 	return r.rewardsCoordinator.CheckClaim(&bind.CallOpts{Context: ctx}, claim)
 }
+
+func (r *ChainReader) GetOperatorAVSSplit(
+	ctx context.Context,
+	operator gethcommon.Address,
+	avs gethcommon.Address,
+) (*uint16, error) {
+	if r.rewardsCoordinator == nil {
+		return nil, errors.New("RewardsCoordinator contract not provided")
+	}
+
+	split, err := r.rewardsCoordinator.GetOperatorAVSSplit(&bind.CallOpts{Context: ctx}, operator, avs)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &split, err
+}

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -359,7 +359,6 @@ func (w *ChainWriter) ProcessClaim(
 
 func (w *ChainWriter) SetOperatorAVSSplit(
 	ctx context.Context,
-	claim rewardscoordinator.IRewardsCoordinatorRewardsMerkleClaim,
 	operator gethcommon.Address,
 	avs gethcommon.Address,
 	split uint16,

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -357,6 +357,35 @@ func (w *ChainWriter) ProcessClaim(
 	return receipt, nil
 }
 
+func (w *ChainWriter) SetOperatorAVSSplit(
+	ctx context.Context,
+	claim rewardscoordinator.IRewardsCoordinatorRewardsMerkleClaim,
+	operator gethcommon.Address,
+	avs gethcommon.Address,
+	split uint16,
+	waitForReceipt bool,
+) (*gethtypes.Receipt, error) {
+	if w.rewardsCoordinator == nil {
+		return nil, errors.New("RewardsCoordinator contract not provided")
+	}
+
+	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
+	if err != nil {
+		return nil, utils.WrapError("failed to get no send tx opts", err)
+	}
+
+	tx, err := w.rewardsCoordinator.SetOperatorAVSSplit(noSendTxOpts, operator, avs, split)
+	if err != nil {
+		return nil, utils.WrapError("failed to create SetOperatorAVSSplit tx", err)
+	}
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	if err != nil {
+		return nil, utils.WrapError("failed to send tx", err)
+	}
+
+	return receipt, nil
+}
+
 func (w *ChainWriter) ProcessClaims(
 	ctx context.Context,
 	claims []rewardscoordinator.IRewardsCoordinatorRewardsMerkleClaim,


### PR DESCRIPTION
Adds convenience methods for reading and setting operator AVS split

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it