### PR TITLE
chore: remove staker_opt_out_window_blocks

### DIFF
--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -71,7 +71,6 @@ func TestRegisterOperator(t *testing.T) {
 			types.Operator{
 				Address:                   fundedAccount,
 				DelegationApproverAddress: "0xd5e099c71b797516c10ed0f0d895f429c2781142",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "https://madhur-test-public.s3.us-east-2.amazonaws.com/metadata.json",
 			}
 
@@ -98,7 +97,6 @@ func TestRegisterOperator(t *testing.T) {
 			types.Operator{
 				Address:                   operatorAddress,
 				DelegationApproverAddress: "0xd5e099c71b797516c10ed0f0d895f429c2781142",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "https://madhur-test-public.s3.us-east-2.amazonaws.com/metadata.json",
 			}
 
@@ -119,7 +117,6 @@ func TestChainWriter(t *testing.T) {
 		operatorModified := types.Operator{
 			Address:                   walletModifiedAddress.Hex(),
 			DelegationApproverAddress: walletModifiedAddress.Hex(),
-			StakerOptOutWindowBlocks:  101,
 			MetadataUrl:               "eigensdk-go",
 		}
 

--- a/types/operator.go
+++ b/types/operator.go
@@ -25,8 +25,7 @@ type Operator struct {
 	Address string `yaml:"address" json:"address"`
 
 	// https://github.com/Layr-Labs/eigenlayer-contracts/blob/delegation-redesign/src/contracts/interfaces/IDelegationManager.sol#L18
-	DelegationApproverAddress string `yaml:"delegation_approver_address"  json:"delegation_approver_address"`
-	StakerOptOutWindowBlocks  uint32 `yaml:"staker_opt_out_window_blocks" json:"staker_opt_out_window_blocks"`
+	DelegationApproverAddress string `yaml:"delegation_approver_address" json:"delegation_approver_address"`
 
 	// MetadataUrl URL where operator metadata is stored
 	MetadataUrl string `yaml:"metadata_url" json:"metadata_url"`

--- a/types/operator_test.go
+++ b/types/operator_test.go
@@ -23,7 +23,6 @@ func TestOperatorValidate(t *testing.T) {
 			operator: Operator{
 				Address:                   "0xd5e099c71b797516c10ed0f0d895f429c2781142",
 				DelegationApproverAddress: "0xd5e099c71b797516c10ed0f0d895f429c2781142",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "https://madhur-test-public.s3.us-east-2.amazonaws.com/metadata.json",
 			},
 			wantErr: false,
@@ -33,7 +32,6 @@ func TestOperatorValidate(t *testing.T) {
 			operator: Operator{
 				Address:                   "0xd5e099c71b797516c10ed0f0d895f429c2781142",
 				DelegationApproverAddress: ZeroAddress,
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "https://madhur-test-public.s3.us-east-2.amazonaws.com/metadata.json",
 			},
 			wantErr: false,
@@ -43,7 +41,6 @@ func TestOperatorValidate(t *testing.T) {
 			operator: Operator{
 				Address:                   "0xd5e099c71b797516c10ed0f0d895f429c2781142",
 				DelegationApproverAddress: "0xd5e099c71b797516c10ed0f0d895f429c2781142",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "",
 			},
 			wantErr:     true,
@@ -54,7 +51,6 @@ func TestOperatorValidate(t *testing.T) {
 			operator: Operator{
 				Address:                   "0xd5e099c71b797516c10ed0f0d895f429c2781142",
 				DelegationApproverAddress: "0xd5e099c71b797516c10ed0f0d895f429c2781142",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "http://localhost:8080/metadata.json",
 			},
 			wantErr:     true,
@@ -65,7 +61,6 @@ func TestOperatorValidate(t *testing.T) {
 			operator: Operator{
 				Address:                   "0xd5e099c71b797516c10ed0f0d895f429c2781142",
 				DelegationApproverAddress: "0xd5e099c71b797516c10ed0f0d895f429c2781142",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "http://127.0.0.1:8080/metadata.json",
 			},
 			wantErr:     true,
@@ -76,7 +71,6 @@ func TestOperatorValidate(t *testing.T) {
 			operator: Operator{
 				Address:                   "0xd5e099c71b797516c10ed0f0d895f429c2781142",
 				DelegationApproverAddress: "0xd5e099c71b797516c10ed0f0d895f429c2781142",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "https://example.com/metadata.json",
 			},
 			wantErr: true,
@@ -90,7 +84,6 @@ func TestOperatorValidate(t *testing.T) {
 			operator: Operator{
 				Address:                   "0xa",
 				DelegationApproverAddress: "0xd5e099c71b797516c10ed0f0d895f429c2781142",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "https://example.com/metadata.json",
 			},
 			wantErr:     true,
@@ -101,7 +94,6 @@ func TestOperatorValidate(t *testing.T) {
 			operator: Operator{
 				Address:                   "0xd5e099c71b797516c10ed0f0d895f429c2781142",
 				DelegationApproverAddress: "0x12",
-				StakerOptOutWindowBlocks:  100,
 				MetadataUrl:               "https://example.com/metadata.json",
 			},
 			wantErr:     true,


### PR DESCRIPTION
Remove the `staker_opt_out_window_blocks ` as it is not used in protocol with the new slashing release. 