### PR TITLE
Fix typos

### DIFF
--- a/contracts/script/RegisterOperatorsWithEigenlayer.s.sol
+++ b/contracts/script/RegisterOperatorsWithEigenlayer.s.sol
@@ -11,7 +11,7 @@ import {ConfigsReadWriter} from "./parsers/ConfigsReadWriter.sol";
 
 // This script registers a bunch of operators with eigenlayer
 // We don't register with eigencert/eigenda because events are not registered in saved anvil state, so we need to register
-// them at runtime whenver we start anvil for a test or localnet.
+// them at runtime whenever we start anvil for a test or localnet.
 contract RegisterOperators is
     ConfigsReadWriter,
     EigenlayerContractsParser,

--- a/crypto/bls/attestation.go
+++ b/crypto/bls/attestation.go
@@ -19,7 +19,7 @@ import (
 // We are using similar structure for saving bls keys as ethereum keystore
 // https://github.com/ethereum/go-ethereum/blob/master/accounts/keystore/key.go
 //
-// We are storing PubKey sepearately so that we can list the pubkey without
+// We are storing PubKey separately so that we can list the pubkey without
 // needing password to decrypt the private key
 type encryptedBLSKeyJSONV3 struct {
 	PubKey string              `json:"pubKey"`


### PR DESCRIPTION
# Fix Typos in Documentation and Code Comments

## Description
This pull request fixes minor typos in comments within two files:
1. `RegisterOperatorsWithEigenlayer.s.sol`
2. `attestation.go`

### Changes Made:
- **File:** `RegisterOperatorsWithEigenlayer.s.sol`
  - Fixed the typo in the comment:
    - **Old:** `them at runtime whenver we start anvil for a test or localnet.`
    - **New:** `them at runtime whenever we start anvil for a test or localnet.`
    
- **File:** `attestation.go`
  - Fixed the typo in the comment:
    - **Old:** `We are storing PubKey sepearately so that we can list the pubkey without needing password to decrypt the private key.`
    - **New:** `We are storing PubKey separately so that we can list the pubkey without needing password to decrypt the private key.`

## Checklist
- [x] Typos fixed without altering the functionality of the code.
- [x] Comments remain accurate and relevant to the code.
- [x] Build and tests pass successfully.


