### PR TITLE
Fixed #422 : The infinite loop issue when signing using fireblocks

### DIFF
--- a/chainio/clients/mocks/wallet.go
+++ b/chainio/clients/mocks/wallet.go
@@ -36,6 +36,10 @@ func NewMockWallet(ctrl *gomock.Controller) *MockWallet {
 	return mock
 }
 
+func (m *MockWallet) IsHexTxID() bool {
+	return true
+}
+
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWallet) EXPECT() *MockWalletMockRecorder {
 	return m.recorder

--- a/chainio/clients/wallet/fireblocks_wallet.go
+++ b/chainio/clients/wallet/fireblocks_wallet.go
@@ -91,6 +91,10 @@ func NewFireblocksWallet(
 	}, nil
 }
 
+func (t *fireblocksWallet) IsHexTxID() bool {
+	return false
+}
+
 func (t *fireblocksWallet) getAccount(ctx context.Context) (*fireblocks.VaultAccount, error) {
 	if t.account == nil {
 		accounts, err := t.fireblocksClient.ListVaultAccounts(ctx)

--- a/chainio/clients/wallet/privatekey_wallet.go
+++ b/chainio/clients/wallet/privatekey_wallet.go
@@ -39,6 +39,10 @@ func NewPrivateKeyWallet(
 	}, nil
 }
 
+func (t *privateKeyWallet) IsHexTxID() bool {
+	return true
+}
+
 func (t *privateKeyWallet) SendTransaction(ctx context.Context, tx *types.Transaction) (TxID, error) {
 
 	t.logger.Debug("Getting signer for tx")

--- a/chainio/clients/wallet/wallet.go
+++ b/chainio/clients/wallet/wallet.go
@@ -20,4 +20,8 @@ type Wallet interface {
 	GetTransactionReceipt(ctx context.Context, txID TxID) (*types.Receipt, error)
 	// SenderAddress returns the address of the wallet
 	SenderAddress(ctx context.Context) (common.Address, error)
+
+	// IsHexTxID returns true if the transaction ID (TxID) is represented as a hexadecimal string; otherwise, false.
+	// Some wallets use custom formats like uuid for representing the TxID instead of raw hex
+	IsHexTxID() bool
 }

--- a/chainio/txmgr/simple.go
+++ b/chainio/txmgr/simple.go
@@ -74,7 +74,7 @@ func (m *SimpleTxManager) Send(
 	waitForReceipt bool,
 ) (*types.Receipt, error) {
 
-	r, err := m.send(ctx, tx)
+	r, txID, err := m.send(ctx, tx)
 	if err != nil {
 		return nil, errors.Join(errors.New("send: failed to estimate gas and nonce"), err)
 	}
@@ -82,7 +82,13 @@ func (m *SimpleTxManager) Send(
 		return r, nil
 	}
 
-	receipt, err := m.waitForReceipt(ctx, r.TxHash.Hex())
+	var receipt *types.Receipt
+	if m.wallet.IsHexTxID() {
+		receipt, err = m.waitForReceipt(ctx, r.TxHash.Hex())
+	} else {
+		receipt, err = m.waitForReceipt(ctx, txID)
+	}
+
 	if err != nil {
 		log.Info("Transaction receipt not found", "err", err)
 		return nil, err
@@ -91,14 +97,14 @@ func (m *SimpleTxManager) Send(
 	return receipt, nil
 }
 
-func (m *SimpleTxManager) send(ctx context.Context, tx *types.Transaction) (*types.Receipt, error) {
+func (m *SimpleTxManager) send(ctx context.Context, tx *types.Transaction) (*types.Receipt, string, error) {
 	// Estimate gas and nonce
 	// can't print tx hash in logs because the tx changes below when we complete and sign it
 	// so the txHash is meaningless at this point
 	m.logger.Debug("Estimating gas and nonce")
 	tx, err := m.estimateGasAndNonce(ctx, tx)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	bumpedGasTx := &types.DynamicFeeTx{
 		To:        tx.To(),
@@ -111,11 +117,11 @@ func (m *SimpleTxManager) send(ctx context.Context, tx *types.Transaction) (*typ
 	}
 	txID, err := m.wallet.SendTransaction(ctx, types.NewTx(bumpedGasTx))
 	if err != nil {
-		return nil, errors.Join(errors.New("send: failed to estimate gas and nonce"), err)
+		return nil, "", errors.Join(errors.New("send: failed to estimate gas and nonce"), err)
 	}
 	return &types.Receipt{
 		TxHash: common.HexToHash(txID),
-	}, nil
+	}, txID, nil
 }
 
 func NoopSigner(addr common.Address, tx *types.Transaction) (*types.Transaction, error) {


### PR DESCRIPTION
Fixes #422 .

### What Changed?
Introduce `isTxIdHex` to handle tx ID formats in transaction receipt retrieval. Updated relevant function signatures and logic to support this flag and added necessary changes across dependent tests and usages.


### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it