### PR TITLE
fix: generate am from delegation manager

### DIFF
--- a/chainio/clients/avsregistry/bindings.go
+++ b/chainio/clients/avsregistry/bindings.go
@@ -3,6 +3,7 @@ package avsregistry
 import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	blsapkregistry "github.com/Layr-Labs/eigensdk-go/contracts/bindings/BLSApkRegistry"
+	contractDelegationManager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/DelegationManager"
 	indexregistry "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IndexRegistry"
 	opstateretriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
 	regcoordinator "github.com/Layr-Labs/eigensdk-go/contracts/bindings/RegistryCoordinator"
@@ -211,7 +212,14 @@ func NewBindingsFromConfig(
 		if err != nil {
 			return nil, utils.WrapError("Failed to get AvsDirectory address", err)
 		}
-		allocationManagerAddr, err = contractServiceManager.AllocationManager(&bind.CallOpts{})
+
+		delegationManager, err := contractDelegationManager.NewContractDelegationManager(
+			delegationManagerAddr,
+			client)
+		if err != nil {
+			return nil, utils.WrapError("Failed to get DelegationManager contract", err)
+		}
+		allocationManagerAddr, err = delegationManager.AllocationManager(&bind.CallOpts{})
 		if err != nil {
 			return nil, utils.WrapError("Failed to get AllocationManager address", err)
 		}


### PR DESCRIPTION
Fixes # .
Currently if we use old service manager to get allocation manager, it will fail because pre slashing upgrade there was no concept of allocation manager.
To make it backward compatible, we will generate allocationManager from DelegationManager since core contract has those.

### What Changed?
Use DelegationManager to get AllocationManager

Verified against an old service manager contract
```
cast call 0x90c6d6f2A78d5Ce22AB8631Ddb142C03AC87De7a "serviceManager" --rpc-url $HOLESKY_RPC_URL 
Contract at 0x90c6d6f2A78d5Ce22AB8631Ddb142C03AC87De7a is a proxy, trying to fetch source at 0x8C380bB35e3c5ba28085974BFc3eaB2703098D34...
0xEA3E82F9Ae371A6a372A6DCffB1a9bD17e0608eF

cast call 0xEA3E82F9Ae371A6a372A6DCffB1a9bD17e0608eF "delegation" --rpc-url $HOLESKY_RPC_URL
Contract at 0xEA3E82F9Ae371A6a372A6DCffB1a9bD17e0608eF is a proxy, trying to fetch source at 0x2F12430429f4a5b8EaEa284d0511065622A3b1a7...
0xA44151489861Fe9e3055d95adC98FbD462B948e7

cast call 0xA44151489861Fe9e3055d95adC98FbD462B948e7 "allocationManager" --rpc-url $HOLESKY_RPC_URL
Contract at 0xA44151489861Fe9e3055d95adC98FbD462B948e7 is a proxy, trying to fetch source at 0xDa6F662777aDB5209644cF5cf1A61A2F8a99BF48...
0x78469728304326CBc65f8f95FA756B0B73164462
```

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it