### PR TITLE
test: use read clients builder

### DIFF
--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestChainReader(t *testing.T) {
-	clients, anvilHttpEndpoint := testclients.BuildTestClients(t)
+	read_clients, anvilHttpEndpoint := testclients.BuildTestReadClients(t)
 	ctx := context.Background()
 
 	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
@@ -27,13 +27,13 @@ func TestChainReader(t *testing.T) {
 	}
 
 	t.Run("is operator registered", func(t *testing.T) {
-		isOperator, err := clients.ElChainReader.IsOperatorRegistered(ctx, operator)
+		isOperator, err := read_clients.ElChainReader.IsOperatorRegistered(ctx, operator)
 		assert.NoError(t, err)
 		assert.Equal(t, isOperator, true)
 	})
 
 	t.Run("get operator details", func(t *testing.T) {
-		operatorDetails, err := clients.ElChainReader.GetOperatorDetails(ctx, operator)
+		operatorDetails, err := read_clients.ElChainReader.GetOperatorDetails(ctx, operator)
 		assert.NoError(t, err)
 		assert.NotNil(t, operatorDetails)
 		assert.Equal(t, operator.Address, operatorDetails.Address)
@@ -41,7 +41,7 @@ func TestChainReader(t *testing.T) {
 
 	t.Run("get strategy and underlying token", func(t *testing.T) {
 		strategyAddr := contractAddrs.Erc20MockStrategy
-		strategy, underlyingTokenAddr, err := clients.ElChainReader.GetStrategyAndUnderlyingToken(
+		strategy, underlyingTokenAddr, err := read_clients.ElChainReader.GetStrategyAndUnderlyingToken(
 			ctx,
 			strategyAddr,
 		)
@@ -49,7 +49,7 @@ func TestChainReader(t *testing.T) {
 		assert.NotNil(t, strategy)
 		assert.NotEqual(t, common.Address{}, underlyingTokenAddr)
 
-		erc20Token, err := erc20.NewContractIERC20(underlyingTokenAddr, clients.EthHttpClient)
+		erc20Token, err := erc20.NewContractIERC20(underlyingTokenAddr, read_clients.EthHttpClient)
 		assert.NoError(t, err)
 
 		tokenName, err := erc20Token.Name(&bind.CallOpts{})
@@ -59,7 +59,7 @@ func TestChainReader(t *testing.T) {
 
 	t.Run("get strategy and underlying ERC20 token", func(t *testing.T) {
 		strategyAddr := contractAddrs.Erc20MockStrategy
-		strategy, contractUnderlyingToken, underlyingTokenAddr, err := clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
+		strategy, contractUnderlyingToken, underlyingTokenAddr, err := read_clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
 			ctx,
 			strategyAddr,
 		)
@@ -74,7 +74,7 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get operator shares in strategy", func(t *testing.T) {
-		shares, err := clients.ElChainReader.GetOperatorSharesInStrategy(
+		shares, err := read_clients.ElChainReader.GetOperatorSharesInStrategy(
 			ctx,
 			common.HexToAddress(operator.Address),
 			contractAddrs.Erc20MockStrategy,
@@ -88,7 +88,7 @@ func TestChainReader(t *testing.T) {
 		delegationApprover := common.Address{0x0}
 		approverSalt := [32]byte{}
 		expiry := big.NewInt(0)
-		digest, err := clients.ElChainReader.CalculateDelegationApprovalDigestHash(
+		digest, err := read_clients.ElChainReader.CalculateDelegationApprovalDigestHash(
 			ctx,
 			staker,
 			common.HexToAddress(operator.Address),
@@ -104,7 +104,7 @@ func TestChainReader(t *testing.T) {
 		avs := common.Address{0x0}
 		salt := [32]byte{}
 		expiry := big.NewInt(0)
-		digest, err := clients.ElChainReader.CalculateOperatorAVSRegistrationDigestHash(
+		digest, err := read_clients.ElChainReader.CalculateOperatorAVSRegistrationDigestHash(
 			ctx,
 			common.HexToAddress(operator.Address),
 			avs,

--- a/testutils/testclients/testclients.go
+++ b/testutils/testclients/testclients.go
@@ -58,7 +58,7 @@ func BuildTestClients(t *testing.T) (*clients.Clients, string) {
 	return clients, anvilHttpEndpoint
 }
 
-// Starts an anvil container and builds the ChainIO Clients for testing.
+// Starts an anvil container and builds the ChainIO ReadClients for read-only testing.
 func BuildTestReadClients(t *testing.T) (*clients.ReadClients, string) {
 	testConfig := testutils.GetDefaultTestConfig()
 	anvilC, err := testutils.StartAnvilContainer(testConfig.AnvilStateFileName)

--- a/testutils/testclients/testclients.go
+++ b/testutils/testclients/testclients.go
@@ -58,6 +58,39 @@ func BuildTestClients(t *testing.T) (*clients.Clients, string) {
 	return clients, anvilHttpEndpoint
 }
 
+// Starts an anvil container and builds the ChainIO Clients for testing.
+func BuildTestReadClients(t *testing.T) (*clients.ReadClients, string) {
+	testConfig := testutils.GetDefaultTestConfig()
+	anvilC, err := testutils.StartAnvilContainer(testConfig.AnvilStateFileName)
+	require.NoError(t, err)
+
+	anvilHttpEndpoint, err := anvilC.Endpoint(context.Background(), "http")
+	require.NoError(t, err)
+
+	anvilWsEndpoint, err := anvilC.Endpoint(context.Background(), "ws")
+	require.NoError(t, err)
+	logger := logging.NewTextSLogger(os.Stdout, &logging.SLoggerOptions{Level: testConfig.LogLevel})
+
+	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
+	require.NoError(t, err)
+
+	chainioConfig := clients.BuildAllConfig{
+		EthHttpUrl:                 anvilHttpEndpoint,
+		EthWsUrl:                   anvilWsEndpoint,
+		RegistryCoordinatorAddr:    contractAddrs.RegistryCoordinator.String(),
+		OperatorStateRetrieverAddr: contractAddrs.OperatorStateRetriever.String(),
+		AvsName:                    "exampleAvs",
+		PromMetricsIpPortAddress:   ":9090",
+	}
+
+	clients, err := clients.BuildReadClients(
+		chainioConfig,
+		logger,
+	)
+	require.NoError(t, err)
+	return clients, anvilHttpEndpoint
+}
+
 // Creates a testing ChainWriter from an httpEndpoint, private key and config.
 // This is needed because the existing testclients.BuildTestClients returns a
 // ChainReader with a null rewardsCoordinator, which is required for some of the tests.


### PR DESCRIPTION
### What Changed?
This PR adds coverage to test Reader Clients builder. Creates an intermediate function to use the builder in the chain reader tests. Increases `chainio/clients/elcontracts/builder.go` Coverage from 45.5% to 81.8%

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it