### PR TITLE
test: `avsregistry` add tests for subscriber

### DIFF
--- a/chainio/clients/avsregistry/subscriber_test.go
+++ b/chainio/clients/avsregistry/subscriber_test.go
@@ -19,36 +19,58 @@ func TestSubscriberAvsRegistry(t *testing.T) {
 	chainSubscriber := client.AvsRegistryChainSubscriber
 	chainWriter := client.AvsRegistryChainWriter
 
-	pubKeyRegistrations, event, err := chainSubscriber.SubscribeToNewPubkeyRegistrations()
-	defer event.Unsubscribe()
-	require.NoError(t, err)
+	t.Run("subscribe to new pubkey registrations", func(t *testing.T) {
+		pubKeyRegistrationsC, event, err := chainSubscriber.SubscribeToNewPubkeyRegistrations()
+		defer event.Unsubscribe()
+		require.NoError(t, err)
 
-	// Emit a NewPubkeyRegistration event creating a new operator
-	keypair, err := bls.NewKeyPairFromString("0x01")
-	require.NoError(t, err, "Failed to create BLS key pair")
+		// Emit a NewPubkeyRegistration event creating a new operator
+		keypair, err := bls.NewKeyPairFromString("0x01")
+		require.NoError(t, err, "Failed to create BLS key pair")
 
-	ecdsaPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
-	require.NoError(t, err, "Failed to parse ECDSA private key")
+		ecdsaPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
+		require.NoError(t, err, "Failed to parse ECDSA private key")
 
-	quorumNumbers := types.QuorumNums{0}
+		quorumNumbers := types.QuorumNums{0}
 
-	receipt, err := chainWriter.RegisterOperator(
-		context.Background(),
-		ecdsaPrivateKey,
-		keypair,
-		quorumNumbers,
-		"",
-		true,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, receipt)
+		receipt, err := chainWriter.RegisterOperator(
+			context.Background(),
+			ecdsaPrivateKey,
+			keypair,
+			quorumNumbers,
+			"",
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
 
-	select {
-	case newPubkeyRegistration := <-pubKeyRegistrations:
-		expectedOperator := crypto.PubkeyToAddress(ecdsaPrivateKey.PublicKey)
-		assert.Equal(t, expectedOperator, newPubkeyRegistration.Operator)
-	case <-time.After(10 * time.Second):
-		// Throw an error if the event is not received within 10 seconds, making the test fail
-		t.Fatal("Timed out waiting for NewPubkeyRegistration event")
-	}
+		select {
+		case newPubkeyRegistration := <-pubKeyRegistrationsC:
+			expectedOperator := crypto.PubkeyToAddress(ecdsaPrivateKey.PublicKey)
+			assert.Equal(t, expectedOperator, newPubkeyRegistration.Operator)
+		case <-time.After(10 * time.Second):
+			// Throw an error if the event is not received within 10 seconds, making the test fail
+			t.Fatal("Timed out waiting for NewPubkeyRegistration event")
+		}
+	})
+
+	t.Run("subscribe to operator socket updates", func(t *testing.T) {
+		socketC, event, err := chainSubscriber.SubscribeToOperatorSocketUpdates()
+		defer event.Unsubscribe()
+		require.NoError(t, err)
+
+		// Emit a SocketUpdate event
+		socketUpdate := "socket-update"
+		receipt, err := chainWriter.UpdateSocket(context.Background(), types.Socket(socketUpdate), true)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+
+		select {
+		case operatorSocketUpdate := <-socketC:
+			assert.Equal(t, socketUpdate, operatorSocketUpdate.Socket)
+		case <-time.After(10 * time.Second):
+			// Throw an error if the event is not received within 10 seconds, making the test fail
+			t.Fatal("Timed out waiting for NewPubkeyRegistration event")
+		}
+	})
 }

--- a/chainio/clients/avsregistry/subscriber_test.go
+++ b/chainio/clients/avsregistry/subscriber_test.go
@@ -21,15 +21,15 @@ func TestSubscriberAvsRegistry(t *testing.T) {
 
 	t.Run("subscribe to new pubkey registrations", func(t *testing.T) {
 		pubKeyRegistrationsC, event, err := chainSubscriber.SubscribeToNewPubkeyRegistrations()
-		defer event.Unsubscribe()
 		require.NoError(t, err)
+		defer event.Unsubscribe()
 
 		// Emit a NewPubkeyRegistration event creating a new operator
 		keypair, err := bls.NewKeyPairFromString("0x01")
-		require.NoError(t, err, "Failed to create BLS key pair")
+		require.NoError(t, err)
 
 		ecdsaPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
-		require.NoError(t, err, "Failed to parse ECDSA private key")
+		require.NoError(t, err)
 
 		quorumNumbers := types.QuorumNums{0}
 
@@ -56,8 +56,8 @@ func TestSubscriberAvsRegistry(t *testing.T) {
 
 	t.Run("subscribe to operator socket updates", func(t *testing.T) {
 		socketC, event, err := chainSubscriber.SubscribeToOperatorSocketUpdates()
-		defer event.Unsubscribe()
 		require.NoError(t, err)
+		defer event.Unsubscribe()
 
 		// Emit a SocketUpdate event
 		socketUpdate := "socket-update"
@@ -70,7 +70,7 @@ func TestSubscriberAvsRegistry(t *testing.T) {
 			assert.Equal(t, socketUpdate, operatorSocketUpdate.Socket)
 		case <-time.After(10 * time.Second):
 			// Throw an error if the event is not received within 10 seconds, making the test fail
-			t.Fatal("Timed out waiting for NewPubkeyRegistration event")
+			t.Fatal("Timed out waiting for operatorSocketUpdate event")
 		}
 	})
 }

--- a/chainio/clients/avsregistry/subscriber_test.go
+++ b/chainio/clients/avsregistry/subscriber_test.go
@@ -1,0 +1,54 @@
+package avsregistry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	"github.com/Layr-Labs/eigensdk-go/testutils"
+	"github.com/Layr-Labs/eigensdk-go/testutils/testclients"
+	"github.com/Layr-Labs/eigensdk-go/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscriberAvsRegistry(t *testing.T) {
+	client, _ := testclients.BuildTestClients(t)
+	chainSubscriber := client.AvsRegistryChainSubscriber
+	chainWriter := client.AvsRegistryChainWriter
+
+	pubKeyRegistrations, event, err := chainSubscriber.SubscribeToNewPubkeyRegistrations()
+	defer event.Unsubscribe()
+	require.NoError(t, err)
+
+	// Emit a NewPubkeyRegistration event creating a new operator
+	keypair, err := bls.NewKeyPairFromString("0x01")
+	require.NoError(t, err, "Failed to create BLS key pair")
+
+	ecdsaPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
+	require.NoError(t, err, "Failed to parse ECDSA private key")
+
+	quorumNumbers := types.QuorumNums{0}
+
+	receipt, err := chainWriter.RegisterOperator(
+		context.Background(),
+		ecdsaPrivateKey,
+		keypair,
+		quorumNumbers,
+		"",
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	select {
+	case newPubkeyRegistration := <-pubKeyRegistrations:
+		expectedOperator := crypto.PubkeyToAddress(ecdsaPrivateKey.PublicKey)
+		assert.Equal(t, expectedOperator, newPubkeyRegistration.Operator)
+	case <-time.After(10 * time.Second):
+		// Throw an error if the event is not received within 10 seconds, making the test fail
+		t.Fatal("Timed out waiting for NewPubkeyRegistration event")
+	}
+}

--- a/chainio/clients/avsregistry/subscriber_test.go
+++ b/chainio/clients/avsregistry/subscriber_test.go
@@ -70,7 +70,7 @@ func TestSubscriberAvsRegistry(t *testing.T) {
 			assert.Equal(t, socketUpdate, operatorSocketUpdate.Socket)
 		case <-time.After(10 * time.Second):
 			// Throw an error if the event is not received within 10 seconds, making the test fail
-			t.Fatal("Timed out waiting for operatorSocketUpdate event")
+			t.Fatal("Timed out waiting for OperatorSocketUpdate event")
 		}
 	})
 }


### PR DESCRIPTION
### What Changed?
This PR introduces tests for previously untested functions in `avsregistry`:
- `SubscribeToNewPubkeyRegistrations`
- `SubscribeToOperatorSocketUpdates`

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it