### PR TITLE
test: increase avsRegistry chainWriter coverage

### DIFF
--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	chainioutils "github.com/Layr-Labs/eigensdk-go/chainio/utils"
-	regcoord "github.com/Layr-Labs/eigensdk-go/contracts/bindings/RegistryCoordinator"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/testutils"
 	"github.com/Layr-Labs/eigensdk-go/testutils/testclients"
 	"github.com/Layr-Labs/eigensdk-go/types"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -112,48 +110,71 @@ func TestWriterMethods(t *testing.T) {
 		require.NotNil(t, receipt)
 	})
 
-	t.Run("deregister operator operator sets", func(t *testing.T) {
-		operator := types.Operator{
-			Address: testutils.ANVIL_FIRST_ADDRESS,
-		}
-
+	// Error cases
+	t.Run("fail register operator cancelling context", func(t *testing.T) {
+		subCtx, cancelFn := context.WithCancel(context.Background())
+		cancelFn()
 		receipt, err := chainWriter.RegisterOperator(
-			context.Background(),
+			subCtx,
 			ecdsaPrivateKey,
 			keypair,
 			quorumNumbers,
 			"",
 			true,
 		)
-		require.NoError(t, err)
-		require.NotNil(t, receipt)
+		assert.Error(t, err)
+		assert.Nil(t, receipt)
+	})
 
-		ethHttpClient, err := ethclient.Dial(anvilHttpEndpoint)
-		require.NoError(t, err)
-
-		registryCoordinatorAddress := contractAddrs.RegistryCoordinator
-		registryCoordinator, err := regcoord.NewContractRegistryCoordinator(
-			registryCoordinatorAddress,
-			ethHttpClient,
+	t.Run("fail update stake of operator subset cancelling context", func(t *testing.T) {
+		subCtx, cancelFn := context.WithCancel(context.Background())
+		cancelFn()
+		receipt, err := chainWriter.UpdateStakesOfOperatorSubsetForAllQuorums(
+			subCtx,
+			[]gethcommon.Address{addr},
+			true,
 		)
-		require.NoError(t, err)
+		assert.Error(t, err)
+		assert.Nil(t, receipt)
+	})
 
-		txManager, err := testclients.NewTestTxManager(anvilHttpEndpoint, testutils.ANVIL_FIRST_PRIVATE_KEY)
-		require.NoError(t, err)
+	t.Run("fail update stake of entire operator set cancelling context", func(t *testing.T) {
+		subCtx, cancelFn := context.WithCancel(context.Background())
+		cancelFn()
+		receipt, err := chainWriter.UpdateStakesOfEntireOperatorSetForQuorums(
+			subCtx,
+			[][]gethcommon.Address{{addr}},
+			quorumNumbers,
+			true,
+		)
+		assert.Error(t, err)
+		assert.Nil(t, receipt)
+	})
 
-		noSendTxOpts, err := txManager.GetNoSendTxOpts()
-		require.NoError(t, err)
+	t.Run("fail deregister operator cancelling context", func(t *testing.T) {
+		subCtx, cancelFn := context.WithCancel(context.Background())
+		cancelFn()
+		receipt, err := chainWriter.DeregisterOperator(
+			subCtx,
+			quorumNumbers,
+			chainioutils.ConvertToBN254G1Point(keypair.PubKey),
+			true,
+		)
+		assert.Error(t, err)
+		assert.Nil(t, receipt)
+	})
 
-		tx, err := registryCoordinator.EnableOperatorSets(noSendTxOpts)
-		require.NoError(t, err)
+	t.Run("fail update socket cancelling context", func(t *testing.T) {
+		subCtx, cancelFn := context.WithCancel(context.Background())
 
-		_, err = txManager.Send(context.Background(), tx, true)
-		require.NoError(t, err)
-
-		// Failing because OperatorSetsNotSupported() err, which means operator was registered but not as set.
-		receipt, err = chainWriter.DeregisterOperatorOperatorSets(context.Background(), types.OperatorSetIds{0}, operator, chainioutils.ConvertToBN254G1Point(keypair.PubKey), true)
-		require.NoError(t, err)
-		require.NotNil(t, receipt)
+		cancelFn()
+		receipt, err := chainWriter.UpdateSocket(
+			subCtx,
+			types.Socket(""),
+			true,
+		)
+		assert.Error(t, err)
+		assert.Nil(t, receipt)
 	})
 }
 

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -44,6 +44,16 @@ func TestWriterMethods(t *testing.T) {
 
 	quorumNumbers := types.QuorumNums{0}
 
+	t.Run("update socket without being registered", func(t *testing.T) {
+		receipt, err := chainWriter.UpdateSocket(
+			context.Background(),
+			types.Socket("102901920192019201902910291209"),
+			true,
+		)
+		assert.Error(t, err)
+		assert.Nil(t, receipt)
+	})
+
 	t.Run("register operator", func(t *testing.T) {
 		receipt, err := chainWriter.RegisterOperator(
 			context.Background(),

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -161,6 +161,18 @@ func TestWriterMethods(t *testing.T) {
 		assert.Nil(t, receipt)
 	})
 
+	t.Run("fail update stake of entire operator set because of quorum length", func(t *testing.T) {
+		// Fails because operators per quorum length is distinct from quorum numbers
+		receipt, err := chainWriter.UpdateStakesOfEntireOperatorSetForQuorums(
+			context.Background(),
+			[][]gethcommon.Address{{addr, addr}},
+			quorumNumbers,
+			true,
+		)
+		assert.Error(t, err)
+		assert.Nil(t, receipt)
+	})
+
 	t.Run("fail deregister operator cancelling context", func(t *testing.T) {
 		subCtx, cancelFn := context.WithCancel(context.Background())
 		cancelFn()

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -16,8 +16,23 @@ import (
 )
 
 func TestWriterMethods(t *testing.T) {
-	clients, _ := testclients.BuildTestClients(t)
-	chainWriter := clients.AvsRegistryChainWriter
+	testConfig := testutils.GetDefaultTestConfig()
+	anvilC, err := testutils.StartAnvilContainer(testConfig.AnvilStateFileName)
+	require.NoError(t, err)
+
+	anvilHttpEndpoint, err := anvilC.Endpoint(context.Background(), "http")
+	require.NoError(t, err)
+	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
+
+	operatorPrivateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
+
+	config := avsregistry.Config{
+		RegistryCoordinatorAddress:    contractAddrs.RegistryCoordinator,
+		OperatorStateRetrieverAddress: contractAddrs.OperatorStateRetriever,
+	}
+
+	chainWriter, err := testclients.NewTestAvsRegistryWriterFromConfig(anvilHttpEndpoint, operatorPrivateKeyHex, config)
+	require.NoError(t, err)
 
 	keypair, err := bls.NewKeyPairFromString("0x01")
 	require.NoError(t, err)

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -186,6 +186,18 @@ func TestWriterMethods(t *testing.T) {
 		assert.Nil(t, receipt)
 	})
 
+	t.Run("fail deregister operator because of operator not registered", func(t *testing.T) {
+		quorumNumbers := types.QuorumNums{}
+		receipt, err := chainWriter.DeregisterOperator(
+			context.Background(),
+			quorumNumbers,
+			chainioutils.ConvertToBN254G1Point(keypair.PubKey),
+			true,
+		)
+		assert.Error(t, err)
+		assert.Nil(t, receipt)
+	})
+
 	t.Run("fail update socket cancelling context", func(t *testing.T) {
 		subCtx, cancelFn := context.WithCancel(context.Background())
 

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	chainioutils "github.com/Layr-Labs/eigensdk-go/chainio/utils"
+	regcoord "github.com/Layr-Labs/eigensdk-go/contracts/bindings/RegistryCoordinator"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/testutils"
 	"github.com/Layr-Labs/eigensdk-go/testutils/testclients"
 	"github.com/Layr-Labs/eigensdk-go/types"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,6 +87,71 @@ func TestWriterMethods(t *testing.T) {
 			chainioutils.ConvertToBN254G1Point(keypair.PubKey),
 			true,
 		)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+	})
+
+	t.Run("update socket", func(t *testing.T) {
+		receipt, err := chainWriter.RegisterOperator(
+			context.Background(),
+			ecdsaPrivateKey,
+			keypair,
+			quorumNumbers,
+			"",
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+
+		receipt, err = chainWriter.UpdateSocket(
+			context.Background(),
+			types.Socket(""),
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+	})
+
+	t.Run("deregister operator operator sets", func(t *testing.T) {
+		operator := types.Operator{
+			Address: testutils.ANVIL_FIRST_ADDRESS,
+		}
+
+		receipt, err := chainWriter.RegisterOperator(
+			context.Background(),
+			ecdsaPrivateKey,
+			keypair,
+			quorumNumbers,
+			"",
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+
+		ethHttpClient, err := ethclient.Dial(anvilHttpEndpoint)
+		require.NoError(t, err)
+
+		registryCoordinatorAddress := contractAddrs.RegistryCoordinator
+		registryCoordinator, err := regcoord.NewContractRegistryCoordinator(
+			registryCoordinatorAddress,
+			ethHttpClient,
+		)
+		require.NoError(t, err)
+
+		txManager, err := testclients.NewTestTxManager(anvilHttpEndpoint, testutils.ANVIL_FIRST_PRIVATE_KEY)
+		require.NoError(t, err)
+
+		noSendTxOpts, err := txManager.GetNoSendTxOpts()
+		require.NoError(t, err)
+
+		tx, err := registryCoordinator.EnableOperatorSets(noSendTxOpts)
+		require.NoError(t, err)
+
+		_, err = txManager.Send(context.Background(), tx, true)
+		require.NoError(t, err)
+
+		// Failing because OperatorSetsNotSupported() err, which means operator was registered but not as set.
+		receipt, err = chainWriter.DeregisterOperatorOperatorSets(context.Background(), types.OperatorSetIds{0}, operator, chainioutils.ConvertToBN254G1Point(keypair.PubKey), true)
 		require.NoError(t, err)
 		require.NotNil(t, receipt)
 	})


### PR DESCRIPTION
### What Changed?
The goal is to increase `avsRegistry` chainWriter coverage by adding test cases covering functions not covered yet.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it