### PR TITLE
refactor: `elcontracts/reader` interface

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -28,11 +28,9 @@ import (
 type eLReader interface {
 	CalculateOperatorAVSRegistrationDigestHash(
 		ctx context.Context,
-		operatorAddr gethcommon.Address,
-		serviceManagerAddr gethcommon.Address,
-		operatorToAvsRegistrationSigSalt [32]byte,
-		operatorToAvsRegistrationSigExpiry *big.Int,
-	) ([32]byte, error)
+		blockNumber *big.Int,
+		request elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest,
+	) (elcontracts.CalculateOperatorAVSRegistrationDigestHashResponse, error)
 }
 
 type ChainWriter struct {
@@ -161,17 +159,22 @@ func (w *ChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(
 	}
 
 	// params to register operator in delegation manager's operator-avs mapping
-	msgToSign, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
+	// TODO: Review this function after finishing the refactor of the ChainReader
+	request := elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest{
+		OperatorAddress: operatorAddr,
+		AVSAddress:      w.serviceManagerAddr,
+		Salt:            operatorToAvsRegistrationSigSalt,
+		Expiry:          operatorToAvsRegistrationSigExpiry,
+	}
+	response, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
 		ctx,
-		operatorAddr,
-		w.serviceManagerAddr,
-		operatorToAvsRegistrationSigSalt,
-		operatorToAvsRegistrationSigExpiry,
+		nil,
+		request,
 	)
 	if err != nil {
 		return nil, err
 	}
-	operatorSignature, err := crypto.Sign(msgToSign[:], operatorEcdsaPrivateKey)
+	operatorSignature, err := crypto.Sign(response.DigestHash[:], operatorEcdsaPrivateKey)
 	if err != nil {
 		return nil, err
 	}
@@ -283,17 +286,22 @@ func (w *ChainWriter) RegisterOperator(
 	).Add(new(big.Int).SetUint64(curBlock.Time()), big.NewInt(sigValidForSeconds))
 
 	// params to register operator in delegation manager's operator-avs mapping
-	msgToSign, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
+	// TODO: Review this function after finishing the refactor of the ChainReader
+	request := elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest{
+		OperatorAddress: operatorAddr,
+		AVSAddress:      w.serviceManagerAddr,
+		Salt:            operatorToAvsRegistrationSigSalt,
+		Expiry:          operatorToAvsRegistrationSigExpiry,
+	}
+	response, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
 		ctx,
-		operatorAddr,
-		w.serviceManagerAddr,
-		operatorToAvsRegistrationSigSalt,
-		operatorToAvsRegistrationSigExpiry,
+		nil,
+		request,
 	)
 	if err != nil {
 		return nil, err
 	}
-	operatorSignature, err := crypto.Sign(msgToSign[:], operatorEcdsaPrivateKey)
+	operatorSignature, err := crypto.Sign(response.DigestHash[:], operatorEcdsaPrivateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -28,7 +28,6 @@ import (
 type eLReader interface {
 	CalculateOperatorAVSRegistrationDigestHash(
 		ctx context.Context,
-		blockNumber *big.Int,
 		request elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest,
 	) (elcontracts.CalculateOperatorAVSRegistrationDigestHashResponse, error)
 }
@@ -168,7 +167,6 @@ func (w *ChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(
 	}
 	response, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
 		ctx,
-		nil,
 		request,
 	)
 	if err != nil {
@@ -295,7 +293,6 @@ func (w *ChainWriter) RegisterOperator(
 	}
 	response, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
 		ctx,
-		nil,
 		request,
 	)
 	if err != nil {

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -158,7 +158,6 @@ func (w *ChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(
 	}
 
 	// params to register operator in delegation manager's operator-avs mapping
-	// TODO: Review this function after finishing the refactor of the ChainReader
 	request := elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest{
 		OperatorAddress: operatorAddr,
 		AVSAddress:      w.serviceManagerAddr,
@@ -284,7 +283,6 @@ func (w *ChainWriter) RegisterOperator(
 	).Add(new(big.Int).SetUint64(curBlock.Time()), big.NewInt(sigValidForSeconds))
 
 	// params to register operator in delegation manager's operator-avs mapping
-	// TODO: Review this function after finishing the refactor of the ChainReader
 	request := elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest{
 		OperatorAddress: operatorAddr,
 		AVSAddress:      w.serviceManagerAddr,

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -405,14 +405,23 @@ func (r *ChainReader) GetRootIndexFromHash(
 
 func (r *ChainReader) GetCumulativeClaimed(
 	ctx context.Context,
-	earner gethcommon.Address,
-	token gethcommon.Address,
-) (*big.Int, error) {
+	blockNumber *big.Int,
+	request GetCumulativeClaimedRequest,
+) (GetCumulativeClaimedResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return nil, errors.New("RewardsCoordinator contract not provided")
+		return GetCumulativeClaimedResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	return r.rewardsCoordinator.CumulativeClaimed(&bind.CallOpts{Context: ctx}, earner, token)
+	cumulativeClaimed, err := r.rewardsCoordinator.CumulativeClaimed(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.ClaimerAddress,
+		request.TokenAddress,
+	)
+	if err != nil {
+		return GetCumulativeClaimedResponse{}, utils.WrapError("failed to get cumulative claimed", err)
+	}
+
+	return GetCumulativeClaimedResponse{CumulativeClaimed: cumulativeClaimed}, nil
 }
 
 func (r *ChainReader) CheckClaim(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -490,14 +490,23 @@ func (r *ChainReader) GetAllocatableMagnitude(
 
 func (r *ChainReader) GetMaxMagnitudes(
 	ctx context.Context,
-	operatorAddress gethcommon.Address,
-	strategyAddresses []gethcommon.Address,
-) ([]uint64, error) {
+	blockNumber *big.Int,
+	request GetMaxMagnitudes0Request,
+) (GetMaxMagnitudes0Response, error) {
 	if r.allocationManager == nil {
-		return []uint64{}, errors.New("AllocationManager contract not provided")
+		return GetMaxMagnitudes0Response{}, errors.New("AllocationManager contract not provided")
 	}
 
-	return r.allocationManager.GetMaxMagnitudes0(&bind.CallOpts{Context: ctx}, operatorAddress, strategyAddresses)
+	maxMagnitudes, err := r.allocationManager.GetMaxMagnitudes0(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+		request.StrategiesAddresses,
+	)
+	if err != nil {
+		return GetMaxMagnitudes0Response{}, utils.WrapError("failed to get max magnitudes", err)
+	}
+
+	return GetMaxMagnitudes0Response{MaxMagnitudes: maxMagnitudes}, nil
 }
 
 func (r *ChainReader) GetAllocationInfo(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -900,7 +900,7 @@ func (r *ChainReader) GetAllocationDelay(
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return GetAllocationDelayResponse{}, err
+		return GetAllocationDelayResponse{}, utils.WrapError("failed to get allocation delay", err)
 	}
 	if !isSet {
 		return GetAllocationDelayResponse{}, errors.New("allocation delay not set")
@@ -910,12 +910,21 @@ func (r *ChainReader) GetAllocationDelay(
 
 func (r *ChainReader) GetRegisteredSets(
 	ctx context.Context,
-	operatorAddress gethcommon.Address,
-) ([]allocationmanager.OperatorSet, error) {
+	blockNumber *big.Int,
+	request GetRegisteredSetsRequest,
+) (GetRegisteredSetsResponse, error) {
 	if r.allocationManager == nil {
-		return nil, errors.New("AllocationManager contract not provided")
+		return GetRegisteredSetsResponse{}, errors.New("AllocationManager contract not provided")
 	}
-	return r.allocationManager.GetRegisteredSets(&bind.CallOpts{Context: ctx}, operatorAddress)
+	reigsteredSets, err := r.allocationManager.GetRegisteredSets(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+	)
+	if err != nil {
+		return GetRegisteredSetsResponse{}, utils.WrapError("failed to get registered sets", err)
+	}
+
+	return GetRegisteredSetsResponse{OperatorSets: reigsteredSets}, nil
 }
 
 func (r *ChainReader) CanCall(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -587,16 +587,17 @@ func (r *ChainReader) GetOperatorsShares(
 // Doesn't include M2 AVSs
 func (r *ChainReader) GetNumOperatorSetsForOperator(
 	ctx context.Context,
-	operatorAddress gethcommon.Address,
-) (*big.Int, error) {
+	blockNumber *big.Int,
+	request GetNumOperatorSetsForOperatorRequest,
+) (GetNumOperatorSetsForOperatorResponse, error) {
 	if r.allocationManager == nil {
-		return nil, errors.New("AllocationManager contract not provided")
+		return GetNumOperatorSetsForOperatorResponse{}, errors.New("AllocationManager contract not provided")
 	}
-	opSets, err := r.allocationManager.GetAllocatedSets(&bind.CallOpts{Context: ctx}, operatorAddress)
+	opSets, err := r.allocationManager.GetAllocatedSets(&bind.CallOpts{Context: ctx}, request.OperatorAddress)
 	if err != nil {
-		return nil, err
+		return GetNumOperatorSetsForOperatorResponse{}, err
 	}
-	return big.NewInt(int64(len(opSets))), nil
+	return GetNumOperatorSetsForOperatorResponse{NumOperatorSets: big.NewInt(int64(len(opSets)))}, nil
 }
 
 // GetOperatorSetsForOperator returns the list of operator sets that an operator is part of

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -137,13 +137,23 @@ func (r *ChainReader) GetStakerShares(
 // GetDelegatedOperator returns the operator that a staker has delegated to
 func (r *ChainReader) GetDelegatedOperator(
 	ctx context.Context,
-	stakerAddress gethcommon.Address,
 	blockNumber *big.Int,
-) (gethcommon.Address, error) {
+	request GetDelegatedOperatorRequest,
+) (GetDelegatedOperatorResponse, error) {
 	if r.delegationManager == nil {
-		return gethcommon.Address{}, errors.New("DelegationManager contract not provided")
+		return GetDelegatedOperatorResponse{}, errors.New("DelegationManager contract not provided")
 	}
-	return r.delegationManager.DelegatedTo(&bind.CallOpts{Context: ctx}, stakerAddress)
+
+	operator, err := r.delegationManager.DelegatedTo(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.StakerAddress,
+	)
+
+	if err != nil {
+		return GetDelegatedOperatorResponse{}, utils.WrapError("failed to get delegated operator", err)
+	}
+
+	return GetDelegatedOperatorResponse{OperatorAddress: operator}, nil
 }
 
 func (r *ChainReader) GetOperatorDetails(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -1036,19 +1036,23 @@ func (r *ChainReader) ListAdmins(
 
 func (r *ChainReader) IsPendingAdmin(
 	ctx context.Context,
-	accountAddress gethcommon.Address,
-	pendingAdminAddress gethcommon.Address,
-) (bool, error) {
+	blockNumber *big.Int,
+	request IsPendingAdminRequest,
+) (IsPendingAdminResponse, error) {
+	if r.permissionController == nil {
+		return IsPendingAdminResponse{}, errors.New("PermissionController contract not provided")
+	}
+
 	isPendingAdmin, err := r.permissionController.IsPendingAdmin(
-		&bind.CallOpts{Context: ctx},
-		accountAddress,
-		pendingAdminAddress,
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.AccountAddress,
+		request.PendingAdminAddress,
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return false, utils.WrapError("call to permission controller failed", err)
+		return IsPendingAdminResponse{}, utils.WrapError("call to permission controller failed", err)
 	}
-	return isPendingAdmin, nil
+	return IsPendingAdminResponse{IsPendingAdmin: isPendingAdmin}, nil
 }
 
 func (r *ChainReader) IsAdmin(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -1057,13 +1057,21 @@ func (r *ChainReader) IsPendingAdmin(
 
 func (r *ChainReader) IsAdmin(
 	ctx context.Context,
-	accountAddress gethcommon.Address,
-	adminAddress gethcommon.Address,
-) (bool, error) {
-	isAdmin, err := r.permissionController.IsAdmin(&bind.CallOpts{Context: ctx}, accountAddress, adminAddress)
+	blockNumber *big.Int,
+	request IsAdminRequest,
+) (IsAdminResponse, error) {
+	if r.permissionController == nil {
+		return IsAdminResponse{}, errors.New("PermissionController contract not provided")
+	}
+
+	isAdmin, err := r.permissionController.IsAdmin(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.AccountAddress,
+		request.AdminAddress,
+	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return false, utils.WrapError("call to permission controller failed", err)
+		return IsAdminResponse{}, utils.WrapError("call to permission controller failed", err)
 	}
-	return isAdmin, nil
+	return IsAdminResponse{IsAdmin: isAdmin}, nil
 }

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -362,14 +362,25 @@ func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 
 func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	ctx context.Context,
-) (rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot, error) {
+	blockNumber *big.Int,
+) (GetCurrentClaimableDistributionRootResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot{}, errors.New(
+		return GetCurrentClaimableDistributionRootResponse{}, errors.New(
 			"RewardsCoordinator contract not provided",
 		)
 	}
 
-	return r.rewardsCoordinator.GetCurrentClaimableDistributionRoot(&bind.CallOpts{Context: ctx})
+	root, err := r.rewardsCoordinator.GetCurrentClaimableDistributionRoot(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+	)
+	if err != nil {
+		return GetCurrentClaimableDistributionRootResponse{}, utils.WrapError(
+			"failed to get current claimable distribution root",
+			err,
+		)
+	}
+
+	return GetCurrentClaimableDistributionRootResponse{DistributionRoot: root}, nil
 }
 
 func (r *ChainReader) GetRootIndexFromHash(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -929,23 +929,25 @@ func (r *ChainReader) GetRegisteredSets(
 
 func (r *ChainReader) CanCall(
 	ctx context.Context,
-	accountAddress gethcommon.Address,
-	appointeeAddress gethcommon.Address,
-	target gethcommon.Address,
-	selector [4]byte,
-) (bool, error) {
+	blockNumber *big.Int,
+	request CanCallRequest,
+) (CanCallResponse, error) {
+	if r.permissionController == nil {
+		return CanCallResponse{}, errors.New("PermissionController contract not provided")
+	}
+
 	canCall, err := r.permissionController.CanCall(
-		&bind.CallOpts{Context: ctx},
-		accountAddress,
-		appointeeAddress,
-		target,
-		selector,
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.AccountAddress,
+		request.AppointeeAddress,
+		request.Target,
+		request.Selector,
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return false, utils.WrapError("call to permission controller failed", err)
+		return CanCallResponse{}, utils.WrapError("call to permission controller failed", err)
 	}
-	return canCall, nil
+	return CanCallResponse{CanCall: canCall}, nil
 }
 
 func (r *ChainReader) ListAppointees(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -564,13 +564,23 @@ func (r *ChainReader) GetOperatorShares(
 
 func (r *ChainReader) GetOperatorsShares(
 	ctx context.Context,
-	operatorAddresses []gethcommon.Address,
-	strategyAddresses []gethcommon.Address,
-) ([][]*big.Int, error) {
+	blockNumber *big.Int,
+	request GetOperatorsSharesRequest,
+) (GetOperatorsSharesResponse, error) {
 	if r.delegationManager == nil {
-		return nil, errors.New("DelegationManager contract not provided")
+		return GetOperatorsSharesResponse{}, errors.New("DelegationManager contract not provided")
 	}
-	return r.delegationManager.GetOperatorsShares(&bind.CallOpts{Context: ctx}, operatorAddresses, strategyAddresses)
+
+	shares, err := r.delegationManager.GetOperatorsShares(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorsAddresses,
+		request.StrategiesAddresses,
+	)
+	if err != nil {
+		return GetOperatorsSharesResponse{}, utils.WrapError("failed to get operators shares", err)
+	}
+
+	return GetOperatorsSharesResponse{Shares: shares}, nil
 }
 
 // GetNumOperatorSetsForOperator returns the number of operator sets that an operator is part of

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -446,18 +446,6 @@ func (r *ChainReader) CheckClaim(
 
 func (r *ChainReader) GetOperatorAVSSplit(
 	ctx context.Context,
-	operator gethcommon.Address,
-	avs gethcommon.Address,
-) (uint16, error) {
-	if r.rewardsCoordinator == nil {
-		return 0, errors.New("RewardsCoordinator contract not provided")
-	}
-
-	return r.rewardsCoordinator.GetOperatorAVSSplit(&bind.CallOpts{Context: ctx}, operator, avs)
-}
-
-func (r *ChainReader) GetOperatorPISplit(
-	ctx context.Context,
 	blockNumber *big.Int,
 	request GetOperatorAVSSplitRequest,
 ) (GetOperatorAVSSplitResponse, error) {
@@ -465,15 +453,36 @@ func (r *ChainReader) GetOperatorPISplit(
 		return GetOperatorAVSSplitResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
+	split, err := r.rewardsCoordinator.GetOperatorAVSSplit(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+		request.AvsAddress,
+	)
+	if err != nil {
+		return GetOperatorAVSSplitResponse{}, utils.WrapError("failed to get operator AVS split", err)
+	}
+
+	return GetOperatorAVSSplitResponse{Split: split}, nil
+}
+
+func (r *ChainReader) GetOperatorPISplit(
+	ctx context.Context,
+	blockNumber *big.Int,
+	request GetOperatorPISplitRequest,
+) (GetOperatorPISplitResponse, error) {
+	if r.rewardsCoordinator == nil {
+		return GetOperatorPISplitResponse{}, errors.New("RewardsCoordinator contract not provided")
+	}
+
 	split, err := r.rewardsCoordinator.GetOperatorPISplit(
 		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
-		return GetOperatorAVSSplitResponse{}, utils.WrapError("failed to get operator PI split", err)
+		return GetOperatorPISplitResponse{}, utils.WrapError("failed to get operator PI split", err)
 	}
 
-	return GetOperatorAVSSplitResponse{Split: split}, nil
+	return GetOperatorPISplitResponse{Split: split}, nil
 }
 
 func (r *ChainReader) GetAllocatableMagnitude(
@@ -786,6 +795,7 @@ func (r *ChainReader) GetSlashableShares(
 // GetSlashableSharesForOperatorSets returns the strategies the operatorSets take into account, their
 // operators, and the minimum amount of shares that are slashable by the operatorSets.
 // Not supported for M2 AVSs
+// VOY X ACAAAA
 func (r *ChainReader) GetSlashableSharesForOperatorSets(
 	ctx context.Context,
 	operatorSets []allocationmanager.OperatorSet,

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -106,7 +106,7 @@ func (r *ChainReader) IsOperatorRegistered(
 	)
 
 	if err != nil {
-		return IsOperatorRegisteredResponse{}, err
+		return IsOperatorRegisteredResponse{}, utils.WrapError("failed to check if operator is registered", err)
 	}
 
 	return IsOperatorRegisteredResponse{IsRegistered: isOperatorRegistered}, nil

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -1016,14 +1016,22 @@ func (r *ChainReader) ListPendingAdmins(
 
 func (r *ChainReader) ListAdmins(
 	ctx context.Context,
-	accountAddress gethcommon.Address,
-) ([]gethcommon.Address, error) {
-	pendingAdmins, err := r.permissionController.GetAdmins(&bind.CallOpts{Context: ctx}, accountAddress)
+	blockNumber *big.Int,
+	request ListAdminsRequest,
+) (ListAdminsResponse, error) {
+	if r.permissionController == nil {
+		return ListAdminsResponse{}, errors.New("PermissionController contract not provided")
+	}
+
+	admins, err := r.permissionController.GetAdmins(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.AccountAddress,
+	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return nil, utils.WrapError("call to permission controller failed", err)
+		return ListAdminsResponse{}, utils.WrapError("call to permission controller failed", err)
 	}
-	return pendingAdmins, nil
+	return ListAdminsResponse{Admins: admins}, nil
 }
 
 func (r *ChainReader) IsPendingAdmin(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -116,12 +116,22 @@ func (r *ChainReader) IsOperatorRegistered(
 // shares
 func (r *ChainReader) GetStakerShares(
 	ctx context.Context,
-	stakerAddress gethcommon.Address,
-) ([]gethcommon.Address, []*big.Int, error) {
+	blockNumer *big.Int,
+	request GetStakerSharesRequest,
+) (GetStakerSharesResponse, error) {
 	if r.delegationManager == nil {
-		return nil, nil, errors.New("DelegationManager contract not provided")
+		return GetStakerSharesResponse{}, errors.New("DelegationManager contract not provided")
 	}
-	return r.delegationManager.GetDepositedShares(&bind.CallOpts{Context: ctx}, stakerAddress)
+
+	strategies, shares, err := r.delegationManager.GetDepositedShares(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumer},
+		request.StakerAddress,
+	)
+	if err != nil {
+		return GetStakerSharesResponse{}, utils.WrapError("failed to get staker shares", err)
+	}
+
+	return GetStakerSharesResponse{StrategiesAddresses: strategies, Shares: shares}, nil
 }
 
 // GetDelegatedOperator returns the operator that a staker has delegated to

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -339,12 +339,25 @@ func (r *ChainReader) GetDistributionRootsLength(
 	return GetDistributionRootsLengthResponse{Length: rootLength}, nil
 }
 
-func (r *ChainReader) CurrRewardsCalculationEndTimestamp(ctx context.Context) (uint32, error) {
+func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
+	ctx context.Context,
+	blockNumber *big.Int,
+) (CurrRewardsCalculationEndTimestampResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return 0, errors.New("RewardsCoordinator contract not provided")
+		return CurrRewardsCalculationEndTimestampResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	return r.rewardsCoordinator.CurrRewardsCalculationEndTimestamp(&bind.CallOpts{Context: ctx})
+	timestamp, err := r.rewardsCoordinator.CurrRewardsCalculationEndTimestamp(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+	)
+	if err != nil {
+		return CurrRewardsCalculationEndTimestampResponse{}, utils.WrapError(
+			"failed to get current rewards calculation end timestamp",
+			err,
+		)
+	}
+
+	return CurrRewardsCalculationEndTimestampResponse{Timestamp: timestamp}, nil
 }
 
 func (r *ChainReader) GetCurrentClaimableDistributionRoot(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -974,19 +974,23 @@ func (r *ChainReader) ListAppointees(
 
 func (r *ChainReader) ListAppointeePermissions(
 	ctx context.Context,
-	accountAddress gethcommon.Address,
-	appointeeAddress gethcommon.Address,
-) ([]gethcommon.Address, [][4]byte, error) {
+	blockNumber *big.Int,
+	request ListAppointeePermissionsRequest,
+) (ListAppointeePermissionsResponse, error) {
+	if r.permissionController == nil {
+		return ListAppointeePermissionsResponse{}, errors.New("PermissionController contract not provided")
+	}
+
 	targets, selectors, err := r.permissionController.GetAppointeePermissions(
-		&bind.CallOpts{Context: ctx},
-		accountAddress,
-		appointeeAddress,
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.AccountAddress,
+		request.AppointeeAddress,
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return nil, nil, utils.WrapError("call to permission controller failed", err)
+		return ListAppointeePermissionsResponse{}, utils.WrapError("call to permission controller failed", err)
 	}
-	return targets, selectors, nil
+	return ListAppointeePermissionsResponse{AppinteeAddress: targets, Selector: selectors}, nil
 }
 
 func (r *ChainReader) ListPendingAdmins(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -544,16 +544,22 @@ func (r *ChainReader) GetAllocationInfo(
 
 func (r *ChainReader) GetOperatorShares(
 	ctx context.Context,
-	operatorAddress gethcommon.Address,
-	strategyAddresses []gethcommon.Address,
-) ([]*big.Int, error) {
+	blockNumber *big.Int,
+	request GetOperatorSharesRequest,
+) (GetOperatorSharesResponse, error) {
 	if r.delegationManager == nil {
-		return nil, errors.New("DelegationManager contract not provided")
+		return GetOperatorSharesResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
-	return r.delegationManager.GetOperatorShares(&bind.CallOpts{
-		Context: ctx,
-	}, operatorAddress, strategyAddresses)
+	shares, err := r.delegationManager.GetOperatorShares(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+		request.StrategiesAddresses)
+	if err != nil {
+		return GetOperatorSharesResponse{}, utils.WrapError("failed to get operator shares", err)
+	}
+
+	return GetOperatorSharesResponse{Shares: shares}, nil
 }
 
 func (r *ChainReader) GetOperatorsShares(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -93,13 +93,23 @@ func NewReaderFromConfig(
 
 func (r *ChainReader) IsOperatorRegistered(
 	ctx context.Context,
-	operator types.Operator,
-) (bool, error) {
+	blockNumber *big.Int,
+	request IsOperatorRegisteredRequest,
+) (IsOperatorRegisteredResponse, error) {
 	if r.delegationManager == nil {
-		return false, errors.New("DelegationManager contract not provided")
+		return IsOperatorRegisteredResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
-	return r.delegationManager.IsOperator(&bind.CallOpts{Context: ctx}, gethcommon.HexToAddress(operator.Address))
+	isOperatorRegistered, err := r.delegationManager.IsOperator(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+	)
+
+	if err != nil {
+		return IsOperatorRegisteredResponse{}, err
+	}
+
+	return IsOperatorRegisteredResponse{IsRegistered: isOperatorRegistered}, nil
 }
 
 // GetStakerShares returns the amount of shares that a staker has in all of the strategies in which they have nonzero

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -888,20 +888,24 @@ func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 
 func (r *ChainReader) GetAllocationDelay(
 	ctx context.Context,
-	operatorAddress gethcommon.Address,
-) (uint32, error) {
+	blockNumber *big.Int,
+	request GetAllocationDelayRequest,
+) (GetAllocationDelayResponse, error) {
 	if r.allocationManager == nil {
-		return 0, errors.New("AllocationManager contract not provided")
+		return GetAllocationDelayResponse{}, errors.New("AllocationManager contract not provided")
 	}
-	isSet, delay, err := r.allocationManager.GetAllocationDelay(&bind.CallOpts{Context: ctx}, operatorAddress)
+	isSet, delay, err := r.allocationManager.GetAllocationDelay(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return 0, err
+		return GetAllocationDelayResponse{}, err
 	}
 	if !isSet {
-		return 0, errors.New("allocation delay not set")
+		return GetAllocationDelayResponse{}, errors.New("allocation delay not set")
 	}
-	return delay, nil
+	return GetAllocationDelayResponse{AllocationDelay: delay}, nil
 }
 
 func (r *ChainReader) GetRegisteredSets(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -487,14 +487,23 @@ func (r *ChainReader) GetOperatorPISplit(
 
 func (r *ChainReader) GetAllocatableMagnitude(
 	ctx context.Context,
-	operatorAddress gethcommon.Address,
-	strategyAddress gethcommon.Address,
-) (uint64, error) {
+	blockNumber *big.Int,
+	request GetAllocatableMagnitudeRequest,
+) (GetAllocatableMagnitudeResponse, error) {
 	if r.allocationManager == nil {
-		return 0, errors.New("AllocationManager contract not provided")
+		return GetAllocatableMagnitudeResponse{}, errors.New("AllocationManager contract not provided")
 	}
 
-	return r.allocationManager.GetAllocatableMagnitude(&bind.CallOpts{Context: ctx}, operatorAddress, strategyAddress)
+	magnitude, err := r.allocationManager.GetAllocatableMagnitude(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+		request.StrategyAddress,
+	)
+	if err != nil {
+		return GetAllocatableMagnitudeResponse{}, utils.WrapError("failed to get allocatable magnitude", err)
+	}
+
+	return GetAllocatableMagnitudeResponse{AllocatableMagnitude: magnitude}, nil
 }
 
 func (r *ChainReader) GetMaxMagnitudes(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -321,12 +321,22 @@ func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	return CalculateOperatorAVSRegistrationDigestHashResponse{DigestHash: digestHash}, nil
 }
 
-func (r *ChainReader) GetDistributionRootsLength(ctx context.Context) (*big.Int, error) {
+func (r *ChainReader) GetDistributionRootsLength(
+	ctx context.Context,
+	blockNumber *big.Int,
+) (GetDistributionRootsLengthResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return nil, errors.New("RewardsCoordinator contract not provided")
+		return GetDistributionRootsLengthResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	return r.rewardsCoordinator.GetDistributionRootsLength(&bind.CallOpts{Context: ctx})
+	rootLength, err := r.rewardsCoordinator.GetDistributionRootsLength(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+	)
+	if err != nil {
+		return GetDistributionRootsLengthResponse{}, utils.WrapError("failed to get distribution roots length", err)
+	}
+
+	return GetDistributionRootsLengthResponse{Length: rootLength}, nil
 }
 
 func (r *ChainReader) CurrRewardsCalculationEndTimestamp(ctx context.Context) (uint32, error) {

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -426,13 +426,22 @@ func (r *ChainReader) GetCumulativeClaimed(
 
 func (r *ChainReader) CheckClaim(
 	ctx context.Context,
-	claim rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim,
-) (bool, error) {
+	blockNumber *big.Int,
+	request CheckClaimRequest,
+) (CheckClaimResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return false, errors.New("RewardsCoordinator contract not provided")
+		return CheckClaimResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	return r.rewardsCoordinator.CheckClaim(&bind.CallOpts{Context: ctx}, claim)
+	isClaimed, err := r.rewardsCoordinator.CheckClaim(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.Claim,
+	)
+	if err != nil {
+		return CheckClaimResponse{}, utils.WrapError("failed to check claim", err)
+	}
+
+	return CheckClaimResponse{IsValid: isClaimed}, nil
 }
 
 func (r *ChainReader) GetOperatorAVSSplit(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -990,19 +990,28 @@ func (r *ChainReader) ListAppointeePermissions(
 	if err != nil {
 		return ListAppointeePermissionsResponse{}, utils.WrapError("call to permission controller failed", err)
 	}
-	return ListAppointeePermissionsResponse{AppinteeAddress: targets, Selector: selectors}, nil
+	return ListAppointeePermissionsResponse{AppointeeAddress: targets, Selector: selectors}, nil
 }
 
 func (r *ChainReader) ListPendingAdmins(
 	ctx context.Context,
-	accountAddress gethcommon.Address,
-) ([]gethcommon.Address, error) {
-	pendingAdmins, err := r.permissionController.GetPendingAdmins(&bind.CallOpts{Context: ctx}, accountAddress)
+	blockNumber *big.Int,
+	request ListPendingAdminsRequest,
+) (ListPendingAdminsResponse, error) {
+	if r.permissionController == nil {
+		return ListPendingAdminsResponse{}, errors.New("PermissionController contract not provided")
+	}
+
+	pendingAdmins, err := r.permissionController.GetPendingAdmins(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.AccountAddress,
+	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return nil, utils.WrapError("call to permission controller failed", err)
+		return ListPendingAdminsResponse{}, utils.WrapError("call to permission controller failed", err)
 	}
-	return pendingAdmins, nil
+
+	return ListPendingAdminsResponse{PendingAdmins: pendingAdmins}, nil
 }
 
 func (r *ChainReader) ListAdmins(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -385,13 +385,22 @@ func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 
 func (r *ChainReader) GetRootIndexFromHash(
 	ctx context.Context,
-	rootHash [32]byte,
-) (uint32, error) {
+	blockNumber *big.Int,
+	request GetRootIndexFromHashRequest,
+) (GetRootIndexFromHashResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return 0, errors.New("RewardsCoordinator contract not provided")
+		return GetRootIndexFromHashResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	return r.rewardsCoordinator.GetRootIndexFromHash(&bind.CallOpts{Context: ctx}, rootHash)
+	rootIndex, err := r.rewardsCoordinator.GetRootIndexFromHash(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.RootHash,
+	)
+	if err != nil {
+		return GetRootIndexFromHashResponse{}, utils.WrapError("failed to get root index from hash", err)
+	}
+
+	return GetRootIndexFromHashResponse{RootIndex: rootIndex}, nil
 }
 
 func (r *ChainReader) GetCumulativeClaimed(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -99,7 +99,7 @@ func (r *ChainReader) IsOperatorRegistered(
 	}
 
 	isOperatorRegistered, err := r.delegationManager.IsOperator(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -120,7 +120,7 @@ func (r *ChainReader) GetStakerShares(
 	}
 
 	strategies, shares, err := r.delegationManager.GetDepositedShares(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.StakerAddress,
 	)
 	if err != nil {
@@ -140,7 +140,7 @@ func (r *ChainReader) GetDelegatedOperator(
 	}
 
 	operator, err := r.delegationManager.DelegatedTo(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.StakerAddress,
 	)
 	if err != nil {
@@ -159,7 +159,7 @@ func (r *ChainReader) GetOperatorDetails(
 	}
 
 	delegationManagerAddress, err := r.delegationManager.DelegationApprover(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 	)
 	// This call should not fail since it's a getter
@@ -170,7 +170,7 @@ func (r *ChainReader) GetOperatorDetails(
 	isSet, delay, err := r.allocationManager.GetAllocationDelay(
 		&bind.CallOpts{
 			Context:     ctx,
-			BlockNumber: request.blockNumber,
+			BlockNumber: request.BlockNumber,
 		},
 		request.OperatorAddress,
 	)
@@ -204,7 +204,7 @@ func (r *ChainReader) GetStrategyAndUnderlyingToken(
 		return StrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 	)
 	if err != nil {
 		return StrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
@@ -227,7 +227,7 @@ func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 		return StrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 	)
 	if err != nil {
 		return StrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
@@ -253,7 +253,7 @@ func (r *ChainReader) GetOperatorSharesInStrategy(
 	}
 
 	shares, err := r.delegationManager.OperatorShares(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 		request.StrategyAddress,
 	)
@@ -273,7 +273,7 @@ func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 	}
 
 	digestHash, err := r.delegationManager.CalculateDelegationApprovalDigestHash(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.StakerAddress,
 		request.OperatorAddress,
 		request.ApproverAddress,
@@ -299,7 +299,7 @@ func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	}
 
 	digestHash, err := r.avsDirectory.CalculateOperatorAVSRegistrationDigestHash(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 		request.AVSAddress,
 		request.Salt,
@@ -324,7 +324,7 @@ func (r *ChainReader) GetDistributionRootsLength(
 	}
 
 	rootLength, err := r.rewardsCoordinator.GetDistributionRootsLength(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 	)
 	if err != nil {
 		return DistributionRootsLengthResponse{}, utils.WrapError("failed to get distribution roots length", err)
@@ -342,7 +342,7 @@ func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 	}
 
 	timestamp, err := r.rewardsCoordinator.CurrRewardsCalculationEndTimestamp(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 	)
 	if err != nil {
 		return CurrRewardsCalculationEndTimestampResponse{}, utils.WrapError(
@@ -365,7 +365,7 @@ func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	}
 
 	root, err := r.rewardsCoordinator.GetCurrentClaimableDistributionRoot(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 	)
 	if err != nil {
 		return CurrentClaimableDistributionRootResponse{}, utils.WrapError(
@@ -386,7 +386,7 @@ func (r *ChainReader) GetRootIndexFromHash(
 	}
 
 	rootIndex, err := r.rewardsCoordinator.GetRootIndexFromHash(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.RootHash,
 	)
 	if err != nil {
@@ -405,7 +405,7 @@ func (r *ChainReader) GetCumulativeClaimed(
 	}
 
 	cumulativeClaimed, err := r.rewardsCoordinator.CumulativeClaimed(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.ClaimerAddress,
 		request.TokenAddress,
 	)
@@ -425,7 +425,7 @@ func (r *ChainReader) CheckClaim(
 	}
 
 	isClaimed, err := r.rewardsCoordinator.CheckClaim(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.Claim,
 	)
 	if err != nil {
@@ -444,7 +444,7 @@ func (r *ChainReader) GetOperatorAVSSplit(
 	}
 
 	split, err := r.rewardsCoordinator.GetOperatorAVSSplit(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 		request.AvsAddress,
 	)
@@ -464,7 +464,7 @@ func (r *ChainReader) GetOperatorPISplit(
 	}
 
 	split, err := r.rewardsCoordinator.GetOperatorPISplit(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -483,7 +483,7 @@ func (r *ChainReader) GetAllocatableMagnitude(
 	}
 
 	magnitude, err := r.allocationManager.GetAllocatableMagnitude(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 		request.StrategyAddress,
 	)
@@ -503,7 +503,7 @@ func (r *ChainReader) GetMaxMagnitudes(
 	}
 
 	maxMagnitudes, err := r.allocationManager.GetMaxMagnitudes0(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 		request.StrategiesAddresses,
 	)
@@ -523,7 +523,7 @@ func (r *ChainReader) GetAllocationInfo(
 	}
 
 	opSets, allocationInfo, err := r.allocationManager.GetStrategyAllocations(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 		request.StrategyAddress,
 	)
@@ -555,7 +555,7 @@ func (r *ChainReader) GetOperatorShares(
 	}
 
 	shares, err := r.delegationManager.GetOperatorShares(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 		request.StrategiesAddresses)
 	if err != nil {
@@ -574,7 +574,7 @@ func (r *ChainReader) GetOperatorsShares(
 	}
 
 	shares, err := r.delegationManager.GetOperatorsShares(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorsAddresses,
 		request.StrategiesAddresses,
 	)
@@ -595,7 +595,7 @@ func (r *ChainReader) GetNumOperatorSetsForOperator(
 		return NumOperatorSetsForOperatorResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	opSets, err := r.allocationManager.GetAllocatedSets(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -616,7 +616,7 @@ func (r *ChainReader) GetOperatorSetsForOperator(
 	// TODO: we're fetching max int64 operatorSets here. What's the practical limit for timeout by RPC? do we need to
 	// paginate?
 	opSets, err := r.allocationManager.GetAllocatedSets(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -638,7 +638,7 @@ func (r *ChainReader) IsOperatorRegisteredWithOperatorSet(
 		}
 
 		status, err := r.avsDirectory.AvsOperatorStatus(
-			&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+			&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 			request.OperatorSet.Avs,
 			request.OperatorAddress,
 		)
@@ -657,7 +657,7 @@ func (r *ChainReader) IsOperatorRegisteredWithOperatorSet(
 		if r.allocationManager == nil {
 			return IsOperatorRegisteredResponse{IsRegistered: false}, errors.New("AllocationManager contract not provided")
 		}
-		registeredOperatorSets, err := r.allocationManager.GetRegisteredSets(&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber}, request.OperatorAddress)
+		registeredOperatorSets, err := r.allocationManager.GetRegisteredSets(&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber}, request.OperatorAddress)
 		// This call should not fail since it's a getter
 		if err != nil {
 			return IsOperatorRegisteredResponse{IsRegistered: false}, utils.WrapError("failed to get registered operator sets", err)
@@ -684,7 +684,7 @@ func (r *ChainReader) GetOperatorsForOperatorSet(
 		if r.allocationManager == nil {
 			return OperatorsForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
 		}
-		members, err := r.allocationManager.GetMembers(&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber}, request.OperatorSet)
+		members, err := r.allocationManager.GetMembers(&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber}, request.OperatorSet)
 		if err != nil {
 			return OperatorsForOperatorSetResponse{}, utils.WrapError("failed to get members", err)
 		}
@@ -705,7 +705,7 @@ func (r *ChainReader) GetNumOperatorsForOperatorSet(
 			return NumOperatorsForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
 		}
 
-		memberCount, err := r.allocationManager.GetMemberCount(&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber}, request.OperatorSet)
+		memberCount, err := r.allocationManager.GetMemberCount(&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber}, request.OperatorSet)
 		if err != nil {
 			return NumOperatorsForOperatorSetResponse{}, utils.WrapError("failed to get member count", err)
 		}
@@ -728,7 +728,7 @@ func (r *ChainReader) GetStrategiesForOperatorSet(
 		}
 
 		strategies, err := r.allocationManager.GetStrategiesInOperatorSet(
-			&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+			&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 			request.OperatorSet,
 		)
 		if err != nil {
@@ -755,7 +755,7 @@ func (r *ChainReader) GetSlashableShares(
 	}
 
 	slashableShares, err := r.allocationManager.GetMinimumSlashableStake(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorSet,
 		[]gethcommon.Address{request.OperatorAddress},
 		request.StrategiesAddresses,
@@ -792,7 +792,7 @@ func (r *ChainReader) GetSlashableSharesForOperatorSets(
 	}
 
 	requestBefore := SlashableSharesForOperatorSetsBeforeRequest{
-		blockNumber:  request.blockNumber,
+		BlockNumber:  request.BlockNumber,
 		OperatorSets: request.OperatorSets,
 		FutureBlock:  uint32(currentBlock),
 	}
@@ -805,7 +805,7 @@ func (r *ChainReader) GetSlashableSharesForOperatorSets(
 		)
 	}
 
-	return SlashableSharesForOperatorSetsResponse{OperatorSetStakes: resp.OperatorSetStakes}, nil
+	return SlashableSharesForOperatorSetsResponse(resp), nil
 }
 
 // GetSlashableSharesForOperatorSetsBefore returns the strategies the operatorSets take into account, their
@@ -820,7 +820,7 @@ func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 	operatorSetStakes := make([]OperatorSetStakes, len(request.OperatorSets))
 	for i, operatorSet := range request.OperatorSets {
 		requestOperator := OperatorsForOperatorSetRequest{
-			blockNumber: request.blockNumber,
+			BlockNumber: request.BlockNumber,
 			OperatorSet: operatorSet,
 		}
 		responseOperators, err := r.GetOperatorsForOperatorSet(ctx, requestOperator)
@@ -832,7 +832,7 @@ func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 		}
 
 		requestStrategies := StrategiesForOperatorSetRequest{
-			blockNumber: request.blockNumber,
+			BlockNumber: request.BlockNumber,
 			OperatorSet: operatorSet,
 		}
 		responseStrategies, err := r.GetStrategiesForOperatorSet(ctx, requestStrategies)
@@ -845,7 +845,7 @@ func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 		}
 
 		slashableShares, err := r.allocationManager.GetMinimumSlashableStake(
-			&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+			&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 			allocationmanager.OperatorSet{
 				Id:  operatorSet.Id,
 				Avs: operatorSet.Avs,
@@ -881,7 +881,7 @@ func (r *ChainReader) GetAllocationDelay(
 		return AllocationDelayResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	isSet, delay, err := r.allocationManager.GetAllocationDelay(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 	)
 	// This call should not fail since it's a getter
@@ -902,7 +902,7 @@ func (r *ChainReader) GetRegisteredSets(
 		return RegisteredSetsResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	reigsteredSets, err := r.allocationManager.GetRegisteredSets(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -921,7 +921,7 @@ func (r *ChainReader) CanCall(
 	}
 
 	canCall, err := r.permissionController.CanCall(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.AccountAddress,
 		request.AppointeeAddress,
 		request.Target,
@@ -943,7 +943,7 @@ func (r *ChainReader) ListAppointees(
 	}
 
 	appointees, err := r.permissionController.GetAppointees(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.AccountAddress,
 		request.Target,
 		request.Select,
@@ -964,7 +964,7 @@ func (r *ChainReader) ListAppointeePermissions(
 	}
 
 	targets, selectors, err := r.permissionController.GetAppointeePermissions(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.AccountAddress,
 		request.AppointeeAddress,
 	)
@@ -984,7 +984,7 @@ func (r *ChainReader) ListPendingAdmins(
 	}
 
 	pendingAdmins, err := r.permissionController.GetPendingAdmins(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.AccountAddress,
 	)
 	// This call should not fail since it's a getter
@@ -1004,7 +1004,7 @@ func (r *ChainReader) ListAdmins(
 	}
 
 	admins, err := r.permissionController.GetAdmins(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.AccountAddress,
 	)
 	// This call should not fail since it's a getter
@@ -1023,7 +1023,7 @@ func (r *ChainReader) IsPendingAdmin(
 	}
 
 	isPendingAdmin, err := r.permissionController.IsPendingAdmin(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.AccountAddress,
 		request.PendingAdminAddress,
 	)
@@ -1043,7 +1043,7 @@ func (r *ChainReader) IsAdmin(
 	}
 
 	isAdmin, err := r.permissionController.IsAdmin(
-		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
 		request.AccountAddress,
 		request.AdminAddress,
 	)

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -297,22 +297,28 @@ func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 
 func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	ctx context.Context,
-	operator gethcommon.Address,
-	avs gethcommon.Address,
-	salt [32]byte,
-	expiry *big.Int,
-) ([32]byte, error) {
+	blockNumber *big.Int,
+	request CalculateOperatorAVSRegistrationDigestHashRequest,
+) (CalculateOperatorAVSRegistrationDigestHashResponse, error) {
 	if r.avsDirectory == nil {
-		return [32]byte{}, errors.New("AVSDirectory contract not provided")
+		return CalculateOperatorAVSRegistrationDigestHashResponse{}, errors.New("AVSDirectory contract not provided")
 	}
 
-	return r.avsDirectory.CalculateOperatorAVSRegistrationDigestHash(
-		&bind.CallOpts{Context: ctx},
-		operator,
-		avs,
-		salt,
-		expiry,
+	digestHash, err := r.avsDirectory.CalculateOperatorAVSRegistrationDigestHash(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+		request.AVSAddress,
+		request.Salt,
+		request.Expiry,
 	)
+	if err != nil {
+		return CalculateOperatorAVSRegistrationDigestHashResponse{}, utils.WrapError(
+			"failed to calculate operator AVS registration digest hash",
+			err,
+		)
+	}
+
+	return CalculateOperatorAVSRegistrationDigestHashResponse{DigestHash: digestHash}, nil
 }
 
 func (r *ChainReader) GetDistributionRootsLength(ctx context.Context) (*big.Int, error) {

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -458,13 +458,22 @@ func (r *ChainReader) GetOperatorAVSSplit(
 
 func (r *ChainReader) GetOperatorPISplit(
 	ctx context.Context,
-	operator gethcommon.Address,
-) (uint16, error) {
+	blockNumber *big.Int,
+	request GetOperatorAVSSplitRequest,
+) (GetOperatorAVSSplitResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return 0, errors.New("RewardsCoordinator contract not provided")
+		return GetOperatorAVSSplitResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	return r.rewardsCoordinator.GetOperatorPISplit(&bind.CallOpts{Context: ctx}, operator)
+	split, err := r.rewardsCoordinator.GetOperatorPISplit(
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.OperatorAddress,
+	)
+	if err != nil {
+		return GetOperatorAVSSplitResponse{}, utils.WrapError("failed to get operator PI split", err)
+	}
+
+	return GetOperatorAVSSplitResponse{Split: split}, nil
 }
 
 func (r *ChainReader) GetAllocatableMagnitude(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -952,21 +952,24 @@ func (r *ChainReader) CanCall(
 
 func (r *ChainReader) ListAppointees(
 	ctx context.Context,
-	accountAddress gethcommon.Address,
-	target gethcommon.Address,
-	selector [4]byte,
-) ([]gethcommon.Address, error) {
+	blockNumber *big.Int,
+	request ListAppointeesRequest,
+) (ListAppointeesResponse, error) {
+	if r.permissionController == nil {
+		return ListAppointeesResponse{}, errors.New("PermissionController contract not provided")
+	}
+
 	appointees, err := r.permissionController.GetAppointees(
-		&bind.CallOpts{Context: ctx},
-		accountAddress,
-		target,
-		selector,
+		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		request.AccountAddress,
+		request.Target,
+		request.Select,
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return nil, utils.WrapError("call to permission controller failed", err)
+		return ListAppointeesResponse{}, utils.WrapError("call to permission controller failed", err)
 	}
-	return appointees, nil
+	return ListAppointeesResponse{Appointees: appointees}, nil
 }
 
 func (r *ChainReader) ListAppointeePermissions(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -90,6 +90,7 @@ func NewReaderFromConfig(
 	), nil
 }
 
+// IsOperatorRegistered checks if an operator is registered
 func (r *ChainReader) IsOperatorRegistered(
 	ctx context.Context,
 	request IsOperatorRegisteredRequest,
@@ -150,6 +151,7 @@ func (r *ChainReader) GetDelegatedOperator(
 	return DelegatedOperatorResponse{OperatorAddress: operator}, nil
 }
 
+// GetOperatorDetails returns the delegation approver address and allocation delay for a specified operator
 func (r *ChainReader) GetOperatorDetails(
 	ctx context.Context,
 	request OperatorDetailsRequest,
@@ -244,6 +246,7 @@ func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 	}, nil
 }
 
+// GetOperatorSharesInStrategy returns the amount of shares that an operator has in a specific strategy
 func (r *ChainReader) GetOperatorSharesInStrategy(
 	ctx context.Context,
 	request OperatorSharesInStrategyRequest,
@@ -264,6 +267,7 @@ func (r *ChainReader) GetOperatorSharesInStrategy(
 	return OperatorSharesInStrategyResponse{Shares: shares}, nil
 }
 
+// CalculateDelegationApprovalDigestHash computes the digest hash required for delegation approval
 func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 	ctx context.Context,
 	request CalculateDelegationApprovalDigestHashRequest,
@@ -290,6 +294,7 @@ func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 	return CalculateDelegationApprovalDigestHashResponse{DigestHash: digestHash}, nil
 }
 
+// CalculateOperatorAVSRegistrationDigestHash computes the digest hash required for operator AVS registration
 func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	ctx context.Context,
 	request CalculateOperatorAVSRegistrationDigestHashRequest,
@@ -315,6 +320,7 @@ func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	return CalculateOperatorAVSRegistrationDigestHashResponse{DigestHash: digestHash}, nil
 }
 
+// GetDistributionRootsLength returns the total number of distribution roots
 func (r *ChainReader) GetDistributionRootsLength(
 	ctx context.Context,
 	request DistributionRootsLengthRequest,
@@ -333,6 +339,7 @@ func (r *ChainReader) GetDistributionRootsLength(
 	return DistributionRootsLengthResponse{Length: rootLength}, nil
 }
 
+// CurrRewardsCalculationEndTimestamp returns the timestamp when the current rewards calculation ends
 func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 	ctx context.Context,
 	request CurrRewardsCalculationEndTimestampRequest,
@@ -354,6 +361,7 @@ func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 	return CurrRewardsCalculationEndTimestampResponse{Timestamp: timestamp}, nil
 }
 
+// GetCurrentClaimableDistributionRoot returns the current claimable distribution root
 func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	ctx context.Context,
 	request CurrentClaimableDistributionRootRequest,
@@ -377,6 +385,7 @@ func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	return CurrentClaimableDistributionRootResponse{DistributionRoot: root}, nil
 }
 
+// GetRootIndexFromHash returns the root index from a given root hash
 func (r *ChainReader) GetRootIndexFromHash(
 	ctx context.Context,
 	request RootIndexFromHashRequest,
@@ -396,6 +405,7 @@ func (r *ChainReader) GetRootIndexFromHash(
 	return RootIndexFromHashResponse{RootIndex: rootIndex}, nil
 }
 
+// GetCumulativeClaimed
 func (r *ChainReader) GetCumulativeClaimed(
 	ctx context.Context,
 	request CumulativeClaimedRequest,
@@ -416,6 +426,7 @@ func (r *ChainReader) GetCumulativeClaimed(
 	return CumulativeClaimedResponse{CumulativeClaimed: cumulativeClaimed}, nil
 }
 
+// CheckClaim returns if a clam is valid
 func (r *ChainReader) CheckClaim(
 	ctx context.Context,
 	request CheckClaimRequest,
@@ -435,6 +446,7 @@ func (r *ChainReader) CheckClaim(
 	return CheckClaimResponse{IsValid: isClaimed}, nil
 }
 
+// GetOperatorAVSSplit returns the AVS split for an operator
 func (r *ChainReader) GetOperatorAVSSplit(
 	ctx context.Context,
 	request OperatorAVSSplitRequest,
@@ -455,6 +467,7 @@ func (r *ChainReader) GetOperatorAVSSplit(
 	return OperatorAVSSplitResponse{Split: split}, nil
 }
 
+// GetOperatorPISplit returns the PI split for an operator
 func (r *ChainReader) GetOperatorPISplit(
 	ctx context.Context,
 	request OperatorPISplitRequest,
@@ -474,6 +487,7 @@ func (r *ChainReader) GetOperatorPISplit(
 	return OperatorPISplitResponse{Split: split}, nil
 }
 
+// GetAllocatableMagnitude returns the allocatable magnitude for an operator and strategy
 func (r *ChainReader) GetAllocatableMagnitude(
 	ctx context.Context,
 	request AllocatableMagnitudeRequest,
@@ -494,6 +508,7 @@ func (r *ChainReader) GetAllocatableMagnitude(
 	return AllocatableMagnitudeResponse{AllocatableMagnitude: magnitude}, nil
 }
 
+// GetMaxMagnitudes returns the max magnitudes for an operator and strategies
 func (r *ChainReader) GetMaxMagnitudes(
 	ctx context.Context,
 	request MaxMagnitudes0Request,
@@ -514,6 +529,7 @@ func (r *ChainReader) GetMaxMagnitudes(
 	return MaxMagnitudes0Response{MaxMagnitudes: maxMagnitudes}, nil
 }
 
+// GetAllocationInfo returns the allocation information for an operator and strategy
 func (r *ChainReader) GetAllocationInfo(
 	ctx context.Context,
 	request AllocationInfoRequest,
@@ -546,6 +562,7 @@ func (r *ChainReader) GetAllocationInfo(
 	return AllocationInfoResponse{AllocationInfo: allocationsInfo}, nil
 }
 
+// GetOperatorShares returns the amount of shares that an operator has in all of the strategies
 func (r *ChainReader) GetOperatorShares(
 	ctx context.Context,
 	request OperatorSharesRequest,
@@ -565,6 +582,7 @@ func (r *ChainReader) GetOperatorShares(
 	return OperatorSharesResponse{Shares: shares}, nil
 }
 
+// GetOperatorsShares returns the amount of shares that operators have in all of the strategies
 func (r *ChainReader) GetOperatorsShares(
 	ctx context.Context,
 	request OperatorsSharesRequest,
@@ -739,6 +757,7 @@ func (r *ChainReader) GetStrategiesForOperatorSet(
 	}
 }
 
+// GetSlashableShares returns the slashable share amounts for an operator in each specified strategy
 func (r *ChainReader) GetSlashableShares(
 	ctx context.Context,
 	request SlashableSharesRequest,
@@ -873,6 +892,7 @@ func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 	return SlashableSharesForOperatorSetsBeforeResponse{OperatorSetStakes: operatorSetStakes}, nil
 }
 
+// GetAllocationDelay returns the current allocation delay for an operator
 func (r *ChainReader) GetAllocationDelay(
 	ctx context.Context,
 	request AllocationDelayRequest,
@@ -894,6 +914,7 @@ func (r *ChainReader) GetAllocationDelay(
 	return AllocationDelayResponse{AllocationDelay: delay}, nil
 }
 
+// GetRegisteredSets returns the operator sets that an operator is registered with
 func (r *ChainReader) GetRegisteredSets(
 	ctx context.Context,
 	request RegisteredSetsRequest,
@@ -912,6 +933,7 @@ func (r *ChainReader) GetRegisteredSets(
 	return RegisteredSetsResponse{OperatorSets: reigsteredSets}, nil
 }
 
+// CanCall checks if an appointee can call a target on behalf of an account
 func (r *ChainReader) CanCall(
 	ctx context.Context,
 	request CanCallRequest,
@@ -934,6 +956,7 @@ func (r *ChainReader) CanCall(
 	return CanCallResponse{CanCall: canCall}, nil
 }
 
+// ListAppointees returns the list of appointees for a target that an account has
 func (r *ChainReader) ListAppointees(
 	ctx context.Context,
 	request ListAppointeesRequest,
@@ -955,6 +978,7 @@ func (r *ChainReader) ListAppointees(
 	return ListAppointeesResponse{Appointees: appointees}, nil
 }
 
+// ListAppointeePermissions returns the list of permissions that an appointee has for a target that an account has
 func (r *ChainReader) ListAppointeePermissions(
 	ctx context.Context,
 	request ListAppointeePermissionsRequest,
@@ -975,6 +999,7 @@ func (r *ChainReader) ListAppointeePermissions(
 	return ListAppointeePermissionsResponse{AppointeeAddress: targets, Selector: selectors}, nil
 }
 
+// ListPendingAdmins returns the list of pending admins for an account
 func (r *ChainReader) ListPendingAdmins(
 	ctx context.Context,
 	request ListPendingAdminsRequest,
@@ -995,6 +1020,7 @@ func (r *ChainReader) ListPendingAdmins(
 	return ListPendingAdminsResponse{PendingAdmins: pendingAdmins}, nil
 }
 
+// ListAdmins returns the list of admins for an account
 func (r *ChainReader) ListAdmins(
 	ctx context.Context,
 	request ListAdminsRequest,
@@ -1014,6 +1040,7 @@ func (r *ChainReader) ListAdmins(
 	return ListAdminsResponse{Admins: admins}, nil
 }
 
+// IsPendingAdmin checks if an address is a pending admin for an account
 func (r *ChainReader) IsPendingAdmin(
 	ctx context.Context,
 	request IsPendingAdminRequest,
@@ -1034,6 +1061,7 @@ func (r *ChainReader) IsPendingAdmin(
 	return IsPendingAdminResponse{IsPendingAdmin: isPendingAdmin}, nil
 }
 
+// IsAdmin checks if an address is an admin for an account
 func (r *ChainReader) IsAdmin(
 	ctx context.Context,
 	request IsAdminRequest,

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -113,10 +113,10 @@ func (r *ChainReader) IsOperatorRegistered(
 // shares
 func (r *ChainReader) GetStakerShares(
 	ctx context.Context,
-	request GetStakerSharesRequest,
-) (GetStakerSharesResponse, error) {
+	request StakerSharesRequest,
+) (StakerSharesResponse, error) {
 	if r.delegationManager == nil {
-		return GetStakerSharesResponse{}, errors.New("DelegationManager contract not provided")
+		return StakerSharesResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
 	strategies, shares, err := r.delegationManager.GetDepositedShares(
@@ -124,19 +124,19 @@ func (r *ChainReader) GetStakerShares(
 		request.StakerAddress,
 	)
 	if err != nil {
-		return GetStakerSharesResponse{}, utils.WrapError("failed to get staker shares", err)
+		return StakerSharesResponse{}, utils.WrapError("failed to get staker shares", err)
 	}
 
-	return GetStakerSharesResponse{StrategiesAddresses: strategies, Shares: shares}, nil
+	return StakerSharesResponse{StrategiesAddresses: strategies, Shares: shares}, nil
 }
 
 // GetDelegatedOperator returns the operator that a staker has delegated to
 func (r *ChainReader) GetDelegatedOperator(
 	ctx context.Context,
-	request GetDelegatedOperatorRequest,
-) (GetDelegatedOperatorResponse, error) {
+	request DelegatedOperatorRequest,
+) (DelegatedOperatorResponse, error) {
 	if r.delegationManager == nil {
-		return GetDelegatedOperatorResponse{}, errors.New("DelegationManager contract not provided")
+		return DelegatedOperatorResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
 	operator, err := r.delegationManager.DelegatedTo(
@@ -144,18 +144,18 @@ func (r *ChainReader) GetDelegatedOperator(
 		request.StakerAddress,
 	)
 	if err != nil {
-		return GetDelegatedOperatorResponse{}, utils.WrapError("failed to get delegated operator", err)
+		return DelegatedOperatorResponse{}, utils.WrapError("failed to get delegated operator", err)
 	}
 
-	return GetDelegatedOperatorResponse{OperatorAddress: operator}, nil
+	return DelegatedOperatorResponse{OperatorAddress: operator}, nil
 }
 
 func (r *ChainReader) GetOperatorDetails(
 	ctx context.Context,
-	request GetOperatorDetailsRequest,
-) (GetOperatorDetailsResponse, error) {
+	request OperatorDetailsRequest,
+) (OperatorDetailsResponse, error) {
 	if r.delegationManager == nil {
-		return GetOperatorDetailsResponse{}, errors.New("DelegationManager contract not provided")
+		return OperatorDetailsResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
 	delegationManagerAddress, err := r.delegationManager.DelegationApprover(
@@ -164,7 +164,7 @@ func (r *ChainReader) GetOperatorDetails(
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return GetOperatorDetailsResponse{}, utils.WrapError("failed to get delegation approver", err)
+		return OperatorDetailsResponse{}, utils.WrapError("failed to get delegation approver", err)
 	}
 
 	isSet, delay, err := r.allocationManager.GetAllocationDelay(
@@ -176,7 +176,7 @@ func (r *ChainReader) GetOperatorDetails(
 	)
 	// This call should not fail
 	if err != nil {
-		return GetOperatorDetailsResponse{}, utils.WrapError("failed to get allocation delay", err)
+		return OperatorDetailsResponse{}, utils.WrapError("failed to get allocation delay", err)
 	}
 
 	var allocationDelay uint32
@@ -186,7 +186,7 @@ func (r *ChainReader) GetOperatorDetails(
 		allocationDelay = 0
 	}
 
-	return GetOperatorDetailsResponse{
+	return OperatorDetailsResponse{
 		OperatorAddress:           request.OperatorAddress,
 		DelegationApproverAddress: delegationManagerAddress,
 		AllocationDelay:           allocationDelay,
@@ -196,20 +196,20 @@ func (r *ChainReader) GetOperatorDetails(
 // GetStrategyAndUnderlyingToken returns the strategy contract and the underlying token address
 func (r *ChainReader) GetStrategyAndUnderlyingToken(
 	ctx context.Context,
-	request GetStrategyAndUnderlyingTokenRequest,
-) (GetStrategyAndUnderlyingTokenResponse, error) {
+	request StrategyAndUnderlyingTokenRequest,
+) (StrategyAndUnderlyingTokenResponse, error) {
 	contractStrategy, err := strategy.NewContractIStrategy(request.StrategyAddress, r.ethClient)
 	// This call should not fail since it's an init
 	if err != nil {
-		return GetStrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
+		return StrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(
 		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 	)
 	if err != nil {
-		return GetStrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
+		return StrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
 	}
-	return GetStrategyAndUnderlyingTokenResponse{
+	return StrategyAndUnderlyingTokenResponse{
 		StrategyContract:       contractStrategy,
 		UnderlyingTokenAddress: underlyingTokenAddr,
 	}, nil
@@ -219,25 +219,25 @@ func (r *ChainReader) GetStrategyAndUnderlyingToken(
 // and the underlying token address
 func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 	ctx context.Context,
-	request GetStrategyAndUnderlyingERC20TokenRequest,
-) (GetStrategyAndUnderlyingERC20TokenResponse, error) {
+	request StrategyAndUnderlyingERC20TokenRequest,
+) (StrategyAndUnderlyingERC20TokenResponse, error) {
 	contractStrategy, err := strategy.NewContractIStrategy(request.StrategyAddress, r.ethClient)
 	// This call should not fail since it's an init
 	if err != nil {
-		return GetStrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
+		return StrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(
 		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 	)
 	if err != nil {
-		return GetStrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
+		return StrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
 	}
 	contractUnderlyingToken, err := erc20.NewContractIERC20(underlyingTokenAddr, r.ethClient)
 	// This call should not fail, if the strategy does not have an underlying token then it would enter the if above
 	if err != nil {
-		return GetStrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
+		return StrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
 	}
-	return GetStrategyAndUnderlyingERC20TokenResponse{
+	return StrategyAndUnderlyingERC20TokenResponse{
 		StrategyContract:       contractStrategy,
 		ERC20Bindings:          contractUnderlyingToken,
 		UnderlyingTokenAddress: underlyingTokenAddr,
@@ -246,10 +246,10 @@ func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 
 func (r *ChainReader) GetOperatorSharesInStrategy(
 	ctx context.Context,
-	request GetOperatorSharesInStrategyRequest,
-) (GetOperatorSharesInStrategyResponse, error) {
+	request OperatorSharesInStrategyRequest,
+) (OperatorSharesInStrategyResponse, error) {
 	if r.delegationManager == nil {
-		return GetOperatorSharesInStrategyResponse{}, errors.New("DelegationManager contract not provided")
+		return OperatorSharesInStrategyResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
 	shares, err := r.delegationManager.OperatorShares(
@@ -258,10 +258,10 @@ func (r *ChainReader) GetOperatorSharesInStrategy(
 		request.StrategyAddress,
 	)
 	if err != nil {
-		return GetOperatorSharesInStrategyResponse{}, utils.WrapError("failed to get operator shares in strategy", err)
+		return OperatorSharesInStrategyResponse{}, utils.WrapError("failed to get operator shares in strategy", err)
 	}
 
-	return GetOperatorSharesInStrategyResponse{Shares: shares}, nil
+	return OperatorSharesInStrategyResponse{Shares: shares}, nil
 }
 
 func (r *ChainReader) CalculateDelegationApprovalDigestHash(
@@ -317,20 +317,20 @@ func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 
 func (r *ChainReader) GetDistributionRootsLength(
 	ctx context.Context,
-	request GetDistributionRootsLengthRequest,
-) (GetDistributionRootsLengthResponse, error) {
+	request DistributionRootsLengthRequest,
+) (DistributionRootsLengthResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return GetDistributionRootsLengthResponse{}, errors.New("RewardsCoordinator contract not provided")
+		return DistributionRootsLengthResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
 	rootLength, err := r.rewardsCoordinator.GetDistributionRootsLength(
 		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 	)
 	if err != nil {
-		return GetDistributionRootsLengthResponse{}, utils.WrapError("failed to get distribution roots length", err)
+		return DistributionRootsLengthResponse{}, utils.WrapError("failed to get distribution roots length", err)
 	}
 
-	return GetDistributionRootsLengthResponse{Length: rootLength}, nil
+	return DistributionRootsLengthResponse{Length: rootLength}, nil
 }
 
 func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
@@ -356,10 +356,10 @@ func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 
 func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	ctx context.Context,
-	request GetCurrentClaimableDistributionRootRequest,
-) (GetCurrentClaimableDistributionRootResponse, error) {
+	request CurrentClaimableDistributionRootRequest,
+) (CurrentClaimableDistributionRootResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return GetCurrentClaimableDistributionRootResponse{}, errors.New(
+		return CurrentClaimableDistributionRootResponse{}, errors.New(
 			"RewardsCoordinator contract not provided",
 		)
 	}
@@ -368,21 +368,21 @@ func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 	)
 	if err != nil {
-		return GetCurrentClaimableDistributionRootResponse{}, utils.WrapError(
+		return CurrentClaimableDistributionRootResponse{}, utils.WrapError(
 			"failed to get current claimable distribution root",
 			err,
 		)
 	}
 
-	return GetCurrentClaimableDistributionRootResponse{DistributionRoot: root}, nil
+	return CurrentClaimableDistributionRootResponse{DistributionRoot: root}, nil
 }
 
 func (r *ChainReader) GetRootIndexFromHash(
 	ctx context.Context,
-	request GetRootIndexFromHashRequest,
-) (GetRootIndexFromHashResponse, error) {
+	request RootIndexFromHashRequest,
+) (RootIndexFromHashResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return GetRootIndexFromHashResponse{}, errors.New("RewardsCoordinator contract not provided")
+		return RootIndexFromHashResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
 	rootIndex, err := r.rewardsCoordinator.GetRootIndexFromHash(
@@ -390,18 +390,18 @@ func (r *ChainReader) GetRootIndexFromHash(
 		request.RootHash,
 	)
 	if err != nil {
-		return GetRootIndexFromHashResponse{}, utils.WrapError("failed to get root index from hash", err)
+		return RootIndexFromHashResponse{}, utils.WrapError("failed to get root index from hash", err)
 	}
 
-	return GetRootIndexFromHashResponse{RootIndex: rootIndex}, nil
+	return RootIndexFromHashResponse{RootIndex: rootIndex}, nil
 }
 
 func (r *ChainReader) GetCumulativeClaimed(
 	ctx context.Context,
-	request GetCumulativeClaimedRequest,
-) (GetCumulativeClaimedResponse, error) {
+	request CumulativeClaimedRequest,
+) (CumulativeClaimedResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return GetCumulativeClaimedResponse{}, errors.New("RewardsCoordinator contract not provided")
+		return CumulativeClaimedResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
 	cumulativeClaimed, err := r.rewardsCoordinator.CumulativeClaimed(
@@ -410,10 +410,10 @@ func (r *ChainReader) GetCumulativeClaimed(
 		request.TokenAddress,
 	)
 	if err != nil {
-		return GetCumulativeClaimedResponse{}, utils.WrapError("failed to get cumulative claimed", err)
+		return CumulativeClaimedResponse{}, utils.WrapError("failed to get cumulative claimed", err)
 	}
 
-	return GetCumulativeClaimedResponse{CumulativeClaimed: cumulativeClaimed}, nil
+	return CumulativeClaimedResponse{CumulativeClaimed: cumulativeClaimed}, nil
 }
 
 func (r *ChainReader) CheckClaim(
@@ -437,10 +437,10 @@ func (r *ChainReader) CheckClaim(
 
 func (r *ChainReader) GetOperatorAVSSplit(
 	ctx context.Context,
-	request GetOperatorAVSSplitRequest,
-) (GetOperatorAVSSplitResponse, error) {
+	request OperatorAVSSplitRequest,
+) (OperatorAVSSplitResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return GetOperatorAVSSplitResponse{}, errors.New("RewardsCoordinator contract not provided")
+		return OperatorAVSSplitResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
 	split, err := r.rewardsCoordinator.GetOperatorAVSSplit(
@@ -449,18 +449,18 @@ func (r *ChainReader) GetOperatorAVSSplit(
 		request.AvsAddress,
 	)
 	if err != nil {
-		return GetOperatorAVSSplitResponse{}, utils.WrapError("failed to get operator AVS split", err)
+		return OperatorAVSSplitResponse{}, utils.WrapError("failed to get operator AVS split", err)
 	}
 
-	return GetOperatorAVSSplitResponse{Split: split}, nil
+	return OperatorAVSSplitResponse{Split: split}, nil
 }
 
 func (r *ChainReader) GetOperatorPISplit(
 	ctx context.Context,
-	request GetOperatorPISplitRequest,
-) (GetOperatorPISplitResponse, error) {
+	request OperatorPISplitRequest,
+) (OperatorPISplitResponse, error) {
 	if r.rewardsCoordinator == nil {
-		return GetOperatorPISplitResponse{}, errors.New("RewardsCoordinator contract not provided")
+		return OperatorPISplitResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
 	split, err := r.rewardsCoordinator.GetOperatorPISplit(
@@ -468,18 +468,18 @@ func (r *ChainReader) GetOperatorPISplit(
 		request.OperatorAddress,
 	)
 	if err != nil {
-		return GetOperatorPISplitResponse{}, utils.WrapError("failed to get operator PI split", err)
+		return OperatorPISplitResponse{}, utils.WrapError("failed to get operator PI split", err)
 	}
 
-	return GetOperatorPISplitResponse{Split: split}, nil
+	return OperatorPISplitResponse{Split: split}, nil
 }
 
 func (r *ChainReader) GetAllocatableMagnitude(
 	ctx context.Context,
-	request GetAllocatableMagnitudeRequest,
-) (GetAllocatableMagnitudeResponse, error) {
+	request AllocatableMagnitudeRequest,
+) (AllocatableMagnitudeResponse, error) {
 	if r.allocationManager == nil {
-		return GetAllocatableMagnitudeResponse{}, errors.New("AllocationManager contract not provided")
+		return AllocatableMagnitudeResponse{}, errors.New("AllocationManager contract not provided")
 	}
 
 	magnitude, err := r.allocationManager.GetAllocatableMagnitude(
@@ -488,18 +488,18 @@ func (r *ChainReader) GetAllocatableMagnitude(
 		request.StrategyAddress,
 	)
 	if err != nil {
-		return GetAllocatableMagnitudeResponse{}, utils.WrapError("failed to get allocatable magnitude", err)
+		return AllocatableMagnitudeResponse{}, utils.WrapError("failed to get allocatable magnitude", err)
 	}
 
-	return GetAllocatableMagnitudeResponse{AllocatableMagnitude: magnitude}, nil
+	return AllocatableMagnitudeResponse{AllocatableMagnitude: magnitude}, nil
 }
 
 func (r *ChainReader) GetMaxMagnitudes(
 	ctx context.Context,
-	request GetMaxMagnitudes0Request,
-) (GetMaxMagnitudes0Response, error) {
+	request MaxMagnitudes0Request,
+) (MaxMagnitudes0Response, error) {
 	if r.allocationManager == nil {
-		return GetMaxMagnitudes0Response{}, errors.New("AllocationManager contract not provided")
+		return MaxMagnitudes0Response{}, errors.New("AllocationManager contract not provided")
 	}
 
 	maxMagnitudes, err := r.allocationManager.GetMaxMagnitudes0(
@@ -508,18 +508,18 @@ func (r *ChainReader) GetMaxMagnitudes(
 		request.StrategiesAddresses,
 	)
 	if err != nil {
-		return GetMaxMagnitudes0Response{}, utils.WrapError("failed to get max magnitudes", err)
+		return MaxMagnitudes0Response{}, utils.WrapError("failed to get max magnitudes", err)
 	}
 
-	return GetMaxMagnitudes0Response{MaxMagnitudes: maxMagnitudes}, nil
+	return MaxMagnitudes0Response{MaxMagnitudes: maxMagnitudes}, nil
 }
 
 func (r *ChainReader) GetAllocationInfo(
 	ctx context.Context,
-	request GetAllocationInfoRequest,
-) (GetAllocationInfoResponse, error) {
+	request AllocationInfoRequest,
+) (AllocationInfoResponse, error) {
 	if r.allocationManager == nil {
-		return GetAllocationInfoResponse{}, errors.New("AllocationManager contract not provided")
+		return AllocationInfoResponse{}, errors.New("AllocationManager contract not provided")
 	}
 
 	opSets, allocationInfo, err := r.allocationManager.GetStrategyAllocations(
@@ -529,7 +529,7 @@ func (r *ChainReader) GetAllocationInfo(
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return GetAllocationInfoResponse{}, err
+		return AllocationInfoResponse{}, err
 	}
 
 	allocationsInfo := make([]AllocationInfo, len(opSets))
@@ -543,15 +543,15 @@ func (r *ChainReader) GetAllocationInfo(
 		}
 	}
 
-	return GetAllocationInfoResponse{AllocationInfo: allocationsInfo}, nil
+	return AllocationInfoResponse{AllocationInfo: allocationsInfo}, nil
 }
 
 func (r *ChainReader) GetOperatorShares(
 	ctx context.Context,
-	request GetOperatorSharesRequest,
-) (GetOperatorSharesResponse, error) {
+	request OperatorSharesRequest,
+) (OperatorSharesResponse, error) {
 	if r.delegationManager == nil {
-		return GetOperatorSharesResponse{}, errors.New("DelegationManager contract not provided")
+		return OperatorSharesResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
 	shares, err := r.delegationManager.GetOperatorShares(
@@ -559,18 +559,18 @@ func (r *ChainReader) GetOperatorShares(
 		request.OperatorAddress,
 		request.StrategiesAddresses)
 	if err != nil {
-		return GetOperatorSharesResponse{}, utils.WrapError("failed to get operator shares", err)
+		return OperatorSharesResponse{}, utils.WrapError("failed to get operator shares", err)
 	}
 
-	return GetOperatorSharesResponse{Shares: shares}, nil
+	return OperatorSharesResponse{Shares: shares}, nil
 }
 
 func (r *ChainReader) GetOperatorsShares(
 	ctx context.Context,
-	request GetOperatorsSharesRequest,
-) (GetOperatorsSharesResponse, error) {
+	request OperatorsSharesRequest,
+) (OperatorsSharesResponse, error) {
 	if r.delegationManager == nil {
-		return GetOperatorsSharesResponse{}, errors.New("DelegationManager contract not provided")
+		return OperatorsSharesResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
 	shares, err := r.delegationManager.GetOperatorsShares(
@@ -579,39 +579,39 @@ func (r *ChainReader) GetOperatorsShares(
 		request.StrategiesAddresses,
 	)
 	if err != nil {
-		return GetOperatorsSharesResponse{}, utils.WrapError("failed to get operators shares", err)
+		return OperatorsSharesResponse{}, utils.WrapError("failed to get operators shares", err)
 	}
 
-	return GetOperatorsSharesResponse{Shares: shares}, nil
+	return OperatorsSharesResponse{Shares: shares}, nil
 }
 
 // GetNumOperatorSetsForOperator returns the number of operator sets that an operator is part of
 // Doesn't include M2 AVSs
 func (r *ChainReader) GetNumOperatorSetsForOperator(
 	ctx context.Context,
-	request GetNumOperatorSetsForOperatorRequest,
-) (GetNumOperatorSetsForOperatorResponse, error) {
+	request NumOperatorSetsForOperatorRequest,
+) (NumOperatorSetsForOperatorResponse, error) {
 	if r.allocationManager == nil {
-		return GetNumOperatorSetsForOperatorResponse{}, errors.New("AllocationManager contract not provided")
+		return NumOperatorSetsForOperatorResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	opSets, err := r.allocationManager.GetAllocatedSets(
 		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
-		return GetNumOperatorSetsForOperatorResponse{}, err
+		return NumOperatorSetsForOperatorResponse{}, err
 	}
-	return GetNumOperatorSetsForOperatorResponse{NumOperatorSets: big.NewInt(int64(len(opSets)))}, nil
+	return NumOperatorSetsForOperatorResponse{NumOperatorSets: big.NewInt(int64(len(opSets)))}, nil
 }
 
 // GetOperatorSetsForOperator returns the list of operator sets that an operator is part of
 // Doesn't include M2 AVSs
 func (r *ChainReader) GetOperatorSetsForOperator(
 	ctx context.Context,
-	request GetOperatorSetsForOperatorRequest,
-) (GetOperatorSetsForOperatorResponse, error) {
+	request OperatorSetsForOperatorRequest,
+) (OperatorSetsForOperatorResponse, error) {
 	if r.allocationManager == nil {
-		return GetOperatorSetsForOperatorResponse{}, errors.New("AllocationManager contract not provided")
+		return OperatorSetsForOperatorResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	// TODO: we're fetching max int64 operatorSets here. What's the practical limit for timeout by RPC? do we need to
 	// paginate?
@@ -620,10 +620,10 @@ func (r *ChainReader) GetOperatorSetsForOperator(
 		request.OperatorAddress,
 	)
 	if err != nil {
-		return GetOperatorSetsForOperatorResponse{}, err
+		return OperatorSetsForOperatorResponse{}, err
 	}
 
-	return GetOperatorSetsForOperatorResponse{OperatorSets: opSets}, nil
+	return OperatorSetsForOperatorResponse{OperatorSets: opSets}, nil
 }
 
 // IsOperatorRegisteredWithOperatorSet returns if an operator is registered with a specific operator set
@@ -676,41 +676,41 @@ func (r *ChainReader) IsOperatorRegisteredWithOperatorSet(
 // Not supported for M2 AVSs
 func (r *ChainReader) GetOperatorsForOperatorSet(
 	ctx context.Context,
-	request GetOperatorsForOperatorSetRequest,
-) (GetOperatorsForOperatorSetResponse, error) {
+	request OperatorsForOperatorSetRequest,
+) (OperatorsForOperatorSetResponse, error) {
 	if request.OperatorSet.Id == 0 {
-		return GetOperatorsForOperatorSetResponse{}, errLegacyAVSsNotSupported
+		return OperatorsForOperatorSetResponse{}, errLegacyAVSsNotSupported
 	} else {
 		if r.allocationManager == nil {
-			return GetOperatorsForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
+			return OperatorsForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
 		}
 		members, err := r.allocationManager.GetMembers(&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber}, request.OperatorSet)
 		if err != nil {
-			return GetOperatorsForOperatorSetResponse{}, utils.WrapError("failed to get members", err)
+			return OperatorsForOperatorSetResponse{}, utils.WrapError("failed to get members", err)
 		}
 
-		return GetOperatorsForOperatorSetResponse{Operators: members}, nil
+		return OperatorsForOperatorSetResponse{Operators: members}, nil
 	}
 }
 
 // GetNumOperatorsForOperatorSet returns the number of operators in a specific operator set
 func (r *ChainReader) GetNumOperatorsForOperatorSet(
 	ctx context.Context,
-	request GetNumOperatorsForOperatorSetRequest,
-) (GetNumOperatorsForOperatorSetResponse, error) {
+	request NumOperatorsForOperatorSetRequest,
+) (NumOperatorsForOperatorSetResponse, error) {
 	if request.OperatorSet.Id == 0 {
-		return GetNumOperatorsForOperatorSetResponse{}, errLegacyAVSsNotSupported
+		return NumOperatorsForOperatorSetResponse{}, errLegacyAVSsNotSupported
 	} else {
 		if r.allocationManager == nil {
-			return GetNumOperatorsForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
+			return NumOperatorsForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
 		}
 
 		memberCount, err := r.allocationManager.GetMemberCount(&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber}, request.OperatorSet)
 		if err != nil {
-			return GetNumOperatorsForOperatorSetResponse{}, utils.WrapError("failed to get member count", err)
+			return NumOperatorsForOperatorSetResponse{}, utils.WrapError("failed to get member count", err)
 		}
 
-		return GetNumOperatorsForOperatorSetResponse{NumOperators: memberCount}, nil
+		return NumOperatorsForOperatorSetResponse{NumOperators: memberCount}, nil
 	}
 }
 
@@ -718,13 +718,13 @@ func (r *ChainReader) GetNumOperatorsForOperatorSet(
 // Not supported for M2 AVSs
 func (r *ChainReader) GetStrategiesForOperatorSet(
 	ctx context.Context,
-	request GetStrategiesForOperatorSetRequest,
-) (GetStrategiesForOperatorSetResponse, error) {
+	request StrategiesForOperatorSetRequest,
+) (StrategiesForOperatorSetResponse, error) {
 	if request.OperatorSet.Id == 0 {
-		return GetStrategiesForOperatorSetResponse{}, errLegacyAVSsNotSupported
+		return StrategiesForOperatorSetResponse{}, errLegacyAVSsNotSupported
 	} else {
 		if r.allocationManager == nil {
-			return GetStrategiesForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
+			return StrategiesForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
 		}
 
 		strategies, err := r.allocationManager.GetStrategiesInOperatorSet(
@@ -732,26 +732,26 @@ func (r *ChainReader) GetStrategiesForOperatorSet(
 			request.OperatorSet,
 		)
 		if err != nil {
-			return GetStrategiesForOperatorSetResponse{}, utils.WrapError("failed to get strategies", err)
+			return StrategiesForOperatorSetResponse{}, utils.WrapError("failed to get strategies", err)
 		}
 
-		return GetStrategiesForOperatorSetResponse{StrategiesAddresses: strategies}, nil
+		return StrategiesForOperatorSetResponse{StrategiesAddresses: strategies}, nil
 	}
 }
 
 func (r *ChainReader) GetSlashableShares(
 	ctx context.Context,
-	request GetSlashableSharesRequest,
-) (GetSlashableSharesResponse, error) {
+	request SlashableSharesRequest,
+) (SlashableSharesResponse, error) {
 	if r.allocationManager == nil {
-		return GetSlashableSharesResponse{}, errors.New("AllocationManager contract not provided")
+		return SlashableSharesResponse{}, errors.New("AllocationManager contract not provided")
 	}
 
 	// TODO: Is necessary to get the block number here? Or should we use the one passed as argument?
 	currentBlock, err := r.ethClient.BlockNumber(ctx)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return GetSlashableSharesResponse{}, err
+		return SlashableSharesResponse{}, err
 	}
 
 	slashableShares, err := r.allocationManager.GetMinimumSlashableStake(
@@ -763,10 +763,10 @@ func (r *ChainReader) GetSlashableShares(
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return GetSlashableSharesResponse{}, err
+		return SlashableSharesResponse{}, err
 	}
 	if len(slashableShares) == 0 {
-		return GetSlashableSharesResponse{}, errors.New("no slashable shares found for operator")
+		return SlashableSharesResponse{}, errors.New("no slashable shares found for operator")
 	}
 
 	slashableShareStrategyMap := make(map[gethcommon.Address]*big.Int)
@@ -775,7 +775,7 @@ func (r *ChainReader) GetSlashableShares(
 		slashableShareStrategyMap[strat] = slashableShares[0][i]
 	}
 
-	return GetSlashableSharesResponse{SlashableShares: slashableShareStrategyMap}, nil
+	return SlashableSharesResponse{SlashableShares: slashableShareStrategyMap}, nil
 }
 
 // GetSlashableSharesForOperatorSets returns the strategies the operatorSets take into account, their
@@ -783,15 +783,15 @@ func (r *ChainReader) GetSlashableShares(
 // Not supported for M2 AVSs
 func (r *ChainReader) GetSlashableSharesForOperatorSets(
 	ctx context.Context,
-	request GetSlashableSharesForOperatorSetsRequest,
-) (GetSlashableSharesForOperatorSetsResponse, error) {
+	request SlashableSharesForOperatorSetsRequest,
+) (SlashableSharesForOperatorSetsResponse, error) {
 	currentBlock, err := r.ethClient.BlockNumber(ctx)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return GetSlashableSharesForOperatorSetsResponse{}, err
+		return SlashableSharesForOperatorSetsResponse{}, err
 	}
 
-	requestBefore := GetSlashableSharesForOperatorSetsBeforeRequest{
+	requestBefore := SlashableSharesForOperatorSetsBeforeRequest{
 		blockNumber:  request.blockNumber,
 		OperatorSets: request.OperatorSets,
 		FutureBlock:  uint32(currentBlock),
@@ -799,13 +799,13 @@ func (r *ChainReader) GetSlashableSharesForOperatorSets(
 
 	resp, err := r.GetSlashableSharesForOperatorSetsBefore(ctx, requestBefore)
 	if err != nil {
-		return GetSlashableSharesForOperatorSetsResponse{}, utils.WrapError(
+		return SlashableSharesForOperatorSetsResponse{}, utils.WrapError(
 			"failed to get slashable shares for operator sets",
 			err,
 		)
 	}
 
-	return GetSlashableSharesForOperatorSetsResponse{OperatorSetStakes: resp.OperatorSetStakes}, nil
+	return SlashableSharesForOperatorSetsResponse{OperatorSetStakes: resp.OperatorSetStakes}, nil
 }
 
 // GetSlashableSharesForOperatorSetsBefore returns the strategies the operatorSets take into account, their
@@ -815,30 +815,30 @@ func (r *ChainReader) GetSlashableSharesForOperatorSets(
 // Not supported for M2 AVSs
 func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 	ctx context.Context,
-	request GetSlashableSharesForOperatorSetsBeforeRequest,
-) (GetSlashableSharesForOperatorSetsBeforeResponse, error) {
+	request SlashableSharesForOperatorSetsBeforeRequest,
+) (SlashableSharesForOperatorSetsBeforeResponse, error) {
 	operatorSetStakes := make([]OperatorSetStakes, len(request.OperatorSets))
 	for i, operatorSet := range request.OperatorSets {
-		requestOperator := GetOperatorsForOperatorSetRequest{
+		requestOperator := OperatorsForOperatorSetRequest{
 			blockNumber: request.blockNumber,
 			OperatorSet: operatorSet,
 		}
 		responseOperators, err := r.GetOperatorsForOperatorSet(ctx, requestOperator)
 		if err != nil {
-			return GetSlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
+			return SlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
 				"failed to get operators for operator set",
 				err,
 			)
 		}
 
-		requestStrategies := GetStrategiesForOperatorSetRequest{
+		requestStrategies := StrategiesForOperatorSetRequest{
 			blockNumber: request.blockNumber,
 			OperatorSet: operatorSet,
 		}
 		responseStrategies, err := r.GetStrategiesForOperatorSet(ctx, requestStrategies)
 		// If operator setId is 0 will fail on if above
 		if err != nil {
-			return GetSlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
+			return SlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
 				"failed to get strategies for operator set",
 				err,
 			)
@@ -856,7 +856,7 @@ func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 		)
 		// This call should not fail since it's a getter
 		if err != nil {
-			return GetSlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
+			return SlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
 				"failed to get minimum slashable stake",
 				err,
 			)
@@ -870,15 +870,15 @@ func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 		}
 	}
 
-	return GetSlashableSharesForOperatorSetsBeforeResponse{OperatorSetStakes: operatorSetStakes}, nil
+	return SlashableSharesForOperatorSetsBeforeResponse{OperatorSetStakes: operatorSetStakes}, nil
 }
 
 func (r *ChainReader) GetAllocationDelay(
 	ctx context.Context,
-	request GetAllocationDelayRequest,
-) (GetAllocationDelayResponse, error) {
+	request AllocationDelayRequest,
+) (AllocationDelayResponse, error) {
 	if r.allocationManager == nil {
-		return GetAllocationDelayResponse{}, errors.New("AllocationManager contract not provided")
+		return AllocationDelayResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	isSet, delay, err := r.allocationManager.GetAllocationDelay(
 		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
@@ -886,30 +886,30 @@ func (r *ChainReader) GetAllocationDelay(
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return GetAllocationDelayResponse{}, utils.WrapError("failed to get allocation delay", err)
+		return AllocationDelayResponse{}, utils.WrapError("failed to get allocation delay", err)
 	}
 	if !isSet {
-		return GetAllocationDelayResponse{}, errors.New("allocation delay not set")
+		return AllocationDelayResponse{}, errors.New("allocation delay not set")
 	}
-	return GetAllocationDelayResponse{AllocationDelay: delay}, nil
+	return AllocationDelayResponse{AllocationDelay: delay}, nil
 }
 
 func (r *ChainReader) GetRegisteredSets(
 	ctx context.Context,
-	request GetRegisteredSetsRequest,
-) (GetRegisteredSetsResponse, error) {
+	request RegisteredSetsRequest,
+) (RegisteredSetsResponse, error) {
 	if r.allocationManager == nil {
-		return GetRegisteredSetsResponse{}, errors.New("AllocationManager contract not provided")
+		return RegisteredSetsResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	reigsteredSets, err := r.allocationManager.GetRegisteredSets(
 		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
-		return GetRegisteredSetsResponse{}, utils.WrapError("failed to get registered sets", err)
+		return RegisteredSetsResponse{}, utils.WrapError("failed to get registered sets", err)
 	}
 
-	return GetRegisteredSetsResponse{OperatorSets: reigsteredSets}, nil
+	return RegisteredSetsResponse{OperatorSets: reigsteredSets}, nil
 }
 
 func (r *ChainReader) CanCall(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -92,7 +92,6 @@ func NewReaderFromConfig(
 
 func (r *ChainReader) IsOperatorRegistered(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request IsOperatorRegisteredRequest,
 ) (IsOperatorRegisteredResponse, error) {
 	if r.delegationManager == nil {
@@ -100,7 +99,7 @@ func (r *ChainReader) IsOperatorRegistered(
 	}
 
 	isOperatorRegistered, err := r.delegationManager.IsOperator(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -114,7 +113,6 @@ func (r *ChainReader) IsOperatorRegistered(
 // shares
 func (r *ChainReader) GetStakerShares(
 	ctx context.Context,
-	blockNumer *big.Int,
 	request GetStakerSharesRequest,
 ) (GetStakerSharesResponse, error) {
 	if r.delegationManager == nil {
@@ -122,7 +120,7 @@ func (r *ChainReader) GetStakerShares(
 	}
 
 	strategies, shares, err := r.delegationManager.GetDepositedShares(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumer},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.StakerAddress,
 	)
 	if err != nil {
@@ -135,7 +133,6 @@ func (r *ChainReader) GetStakerShares(
 // GetDelegatedOperator returns the operator that a staker has delegated to
 func (r *ChainReader) GetDelegatedOperator(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetDelegatedOperatorRequest,
 ) (GetDelegatedOperatorResponse, error) {
 	if r.delegationManager == nil {
@@ -143,7 +140,7 @@ func (r *ChainReader) GetDelegatedOperator(
 	}
 
 	operator, err := r.delegationManager.DelegatedTo(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.StakerAddress,
 	)
 	if err != nil {
@@ -153,10 +150,8 @@ func (r *ChainReader) GetDelegatedOperator(
 	return GetDelegatedOperatorResponse{OperatorAddress: operator}, nil
 }
 
-// TODO: This return type should be types.Operator or GetOperatorDetailsResponse?
 func (r *ChainReader) GetOperatorDetails(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetOperatorDetailsRequest,
 ) (GetOperatorDetailsResponse, error) {
 	if r.delegationManager == nil {
@@ -164,7 +159,7 @@ func (r *ChainReader) GetOperatorDetails(
 	}
 
 	delegationManagerAddress, err := r.delegationManager.DelegationApprover(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	// This call should not fail since it's a getter
@@ -175,7 +170,7 @@ func (r *ChainReader) GetOperatorDetails(
 	isSet, delay, err := r.allocationManager.GetAllocationDelay(
 		&bind.CallOpts{
 			Context:     ctx,
-			BlockNumber: blockNumber,
+			BlockNumber: request.blockNumber,
 		},
 		request.OperatorAddress,
 	)
@@ -201,7 +196,6 @@ func (r *ChainReader) GetOperatorDetails(
 // GetStrategyAndUnderlyingToken returns the strategy contract and the underlying token address
 func (r *ChainReader) GetStrategyAndUnderlyingToken(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetStrategyAndUnderlyingTokenRequest,
 ) (GetStrategyAndUnderlyingTokenResponse, error) {
 	contractStrategy, err := strategy.NewContractIStrategy(request.StrategyAddress, r.ethClient)
@@ -209,7 +203,9 @@ func (r *ChainReader) GetStrategyAndUnderlyingToken(
 	if err != nil {
 		return GetStrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
 	}
-	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(&bind.CallOpts{Context: ctx, BlockNumber: blockNumber})
+	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+	)
 	if err != nil {
 		return GetStrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
 	}
@@ -223,7 +219,6 @@ func (r *ChainReader) GetStrategyAndUnderlyingToken(
 // and the underlying token address
 func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetStrategyAndUnderlyingERC20TokenRequest,
 ) (GetStrategyAndUnderlyingERC20TokenResponse, error) {
 	contractStrategy, err := strategy.NewContractIStrategy(request.StrategyAddress, r.ethClient)
@@ -231,7 +226,9 @@ func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 	if err != nil {
 		return GetStrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
 	}
-	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(&bind.CallOpts{Context: ctx, BlockNumber: blockNumber})
+	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
+	)
 	if err != nil {
 		return GetStrategyAndUnderlyingERC20TokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
 	}
@@ -249,7 +246,6 @@ func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 
 func (r *ChainReader) GetOperatorSharesInStrategy(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetOperatorSharesInStrategyRequest,
 ) (GetOperatorSharesInStrategyResponse, error) {
 	if r.delegationManager == nil {
@@ -257,7 +253,7 @@ func (r *ChainReader) GetOperatorSharesInStrategy(
 	}
 
 	shares, err := r.delegationManager.OperatorShares(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 		request.StrategyAddress,
 	)
@@ -270,7 +266,6 @@ func (r *ChainReader) GetOperatorSharesInStrategy(
 
 func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request CalculateDelegationApprovalDigestHashRequest,
 ) (CalculateDelegationApprovalDigestHashResponse, error) {
 	if r.delegationManager == nil {
@@ -278,7 +273,7 @@ func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 	}
 
 	digestHash, err := r.delegationManager.CalculateDelegationApprovalDigestHash(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.StakerAddress,
 		request.OperatorAddress,
 		request.ApproverAddress,
@@ -297,7 +292,6 @@ func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 
 func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request CalculateOperatorAVSRegistrationDigestHashRequest,
 ) (CalculateOperatorAVSRegistrationDigestHashResponse, error) {
 	if r.avsDirectory == nil {
@@ -305,7 +299,7 @@ func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	}
 
 	digestHash, err := r.avsDirectory.CalculateOperatorAVSRegistrationDigestHash(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 		request.AVSAddress,
 		request.Salt,
@@ -323,14 +317,14 @@ func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 
 func (r *ChainReader) GetDistributionRootsLength(
 	ctx context.Context,
-	blockNumber *big.Int,
+	request GetDistributionRootsLengthRequest,
 ) (GetDistributionRootsLengthResponse, error) {
 	if r.rewardsCoordinator == nil {
 		return GetDistributionRootsLengthResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
 	rootLength, err := r.rewardsCoordinator.GetDistributionRootsLength(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 	)
 	if err != nil {
 		return GetDistributionRootsLengthResponse{}, utils.WrapError("failed to get distribution roots length", err)
@@ -341,14 +335,14 @@ func (r *ChainReader) GetDistributionRootsLength(
 
 func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 	ctx context.Context,
-	blockNumber *big.Int,
+	request CurrRewardsCalculationEndTimestampRequest,
 ) (CurrRewardsCalculationEndTimestampResponse, error) {
 	if r.rewardsCoordinator == nil {
 		return CurrRewardsCalculationEndTimestampResponse{}, errors.New("RewardsCoordinator contract not provided")
 	}
 
 	timestamp, err := r.rewardsCoordinator.CurrRewardsCalculationEndTimestamp(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 	)
 	if err != nil {
 		return CurrRewardsCalculationEndTimestampResponse{}, utils.WrapError(
@@ -362,7 +356,7 @@ func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 
 func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	ctx context.Context,
-	blockNumber *big.Int,
+	request GetCurrentClaimableDistributionRootRequest,
 ) (GetCurrentClaimableDistributionRootResponse, error) {
 	if r.rewardsCoordinator == nil {
 		return GetCurrentClaimableDistributionRootResponse{}, errors.New(
@@ -371,7 +365,7 @@ func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	}
 
 	root, err := r.rewardsCoordinator.GetCurrentClaimableDistributionRoot(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 	)
 	if err != nil {
 		return GetCurrentClaimableDistributionRootResponse{}, utils.WrapError(
@@ -385,7 +379,6 @@ func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 
 func (r *ChainReader) GetRootIndexFromHash(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetRootIndexFromHashRequest,
 ) (GetRootIndexFromHashResponse, error) {
 	if r.rewardsCoordinator == nil {
@@ -393,7 +386,7 @@ func (r *ChainReader) GetRootIndexFromHash(
 	}
 
 	rootIndex, err := r.rewardsCoordinator.GetRootIndexFromHash(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.RootHash,
 	)
 	if err != nil {
@@ -405,7 +398,6 @@ func (r *ChainReader) GetRootIndexFromHash(
 
 func (r *ChainReader) GetCumulativeClaimed(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetCumulativeClaimedRequest,
 ) (GetCumulativeClaimedResponse, error) {
 	if r.rewardsCoordinator == nil {
@@ -413,7 +405,7 @@ func (r *ChainReader) GetCumulativeClaimed(
 	}
 
 	cumulativeClaimed, err := r.rewardsCoordinator.CumulativeClaimed(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.ClaimerAddress,
 		request.TokenAddress,
 	)
@@ -426,7 +418,6 @@ func (r *ChainReader) GetCumulativeClaimed(
 
 func (r *ChainReader) CheckClaim(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request CheckClaimRequest,
 ) (CheckClaimResponse, error) {
 	if r.rewardsCoordinator == nil {
@@ -434,7 +425,7 @@ func (r *ChainReader) CheckClaim(
 	}
 
 	isClaimed, err := r.rewardsCoordinator.CheckClaim(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.Claim,
 	)
 	if err != nil {
@@ -446,7 +437,6 @@ func (r *ChainReader) CheckClaim(
 
 func (r *ChainReader) GetOperatorAVSSplit(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetOperatorAVSSplitRequest,
 ) (GetOperatorAVSSplitResponse, error) {
 	if r.rewardsCoordinator == nil {
@@ -454,7 +444,7 @@ func (r *ChainReader) GetOperatorAVSSplit(
 	}
 
 	split, err := r.rewardsCoordinator.GetOperatorAVSSplit(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 		request.AvsAddress,
 	)
@@ -467,7 +457,6 @@ func (r *ChainReader) GetOperatorAVSSplit(
 
 func (r *ChainReader) GetOperatorPISplit(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetOperatorPISplitRequest,
 ) (GetOperatorPISplitResponse, error) {
 	if r.rewardsCoordinator == nil {
@@ -475,7 +464,7 @@ func (r *ChainReader) GetOperatorPISplit(
 	}
 
 	split, err := r.rewardsCoordinator.GetOperatorPISplit(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -487,7 +476,6 @@ func (r *ChainReader) GetOperatorPISplit(
 
 func (r *ChainReader) GetAllocatableMagnitude(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetAllocatableMagnitudeRequest,
 ) (GetAllocatableMagnitudeResponse, error) {
 	if r.allocationManager == nil {
@@ -495,7 +483,7 @@ func (r *ChainReader) GetAllocatableMagnitude(
 	}
 
 	magnitude, err := r.allocationManager.GetAllocatableMagnitude(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 		request.StrategyAddress,
 	)
@@ -508,7 +496,6 @@ func (r *ChainReader) GetAllocatableMagnitude(
 
 func (r *ChainReader) GetMaxMagnitudes(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetMaxMagnitudes0Request,
 ) (GetMaxMagnitudes0Response, error) {
 	if r.allocationManager == nil {
@@ -516,7 +503,7 @@ func (r *ChainReader) GetMaxMagnitudes(
 	}
 
 	maxMagnitudes, err := r.allocationManager.GetMaxMagnitudes0(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 		request.StrategiesAddresses,
 	)
@@ -529,7 +516,6 @@ func (r *ChainReader) GetMaxMagnitudes(
 
 func (r *ChainReader) GetAllocationInfo(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetAllocationInfoRequest,
 ) (GetAllocationInfoResponse, error) {
 	if r.allocationManager == nil {
@@ -537,7 +523,7 @@ func (r *ChainReader) GetAllocationInfo(
 	}
 
 	opSets, allocationInfo, err := r.allocationManager.GetStrategyAllocations(
-		&bind.CallOpts{Context: ctx},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 		request.StrategyAddress,
 	)
@@ -562,7 +548,6 @@ func (r *ChainReader) GetAllocationInfo(
 
 func (r *ChainReader) GetOperatorShares(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetOperatorSharesRequest,
 ) (GetOperatorSharesResponse, error) {
 	if r.delegationManager == nil {
@@ -570,7 +555,7 @@ func (r *ChainReader) GetOperatorShares(
 	}
 
 	shares, err := r.delegationManager.GetOperatorShares(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 		request.StrategiesAddresses)
 	if err != nil {
@@ -582,7 +567,6 @@ func (r *ChainReader) GetOperatorShares(
 
 func (r *ChainReader) GetOperatorsShares(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetOperatorsSharesRequest,
 ) (GetOperatorsSharesResponse, error) {
 	if r.delegationManager == nil {
@@ -590,7 +574,7 @@ func (r *ChainReader) GetOperatorsShares(
 	}
 
 	shares, err := r.delegationManager.GetOperatorsShares(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorsAddresses,
 		request.StrategiesAddresses,
 	)
@@ -605,14 +589,13 @@ func (r *ChainReader) GetOperatorsShares(
 // Doesn't include M2 AVSs
 func (r *ChainReader) GetNumOperatorSetsForOperator(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetNumOperatorSetsForOperatorRequest,
 ) (GetNumOperatorSetsForOperatorResponse, error) {
 	if r.allocationManager == nil {
 		return GetNumOperatorSetsForOperatorResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	opSets, err := r.allocationManager.GetAllocatedSets(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -625,7 +608,6 @@ func (r *ChainReader) GetNumOperatorSetsForOperator(
 // Doesn't include M2 AVSs
 func (r *ChainReader) GetOperatorSetsForOperator(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetOperatorSetsForOperatorRequest,
 ) (GetOperatorSetsForOperatorResponse, error) {
 	if r.allocationManager == nil {
@@ -634,7 +616,7 @@ func (r *ChainReader) GetOperatorSetsForOperator(
 	// TODO: we're fetching max int64 operatorSets here. What's the practical limit for timeout by RPC? do we need to
 	// paginate?
 	opSets, err := r.allocationManager.GetAllocatedSets(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -647,7 +629,6 @@ func (r *ChainReader) GetOperatorSetsForOperator(
 // IsOperatorRegisteredWithOperatorSet returns if an operator is registered with a specific operator set
 func (r *ChainReader) IsOperatorRegisteredWithOperatorSet(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request IsOperatorRegisteredWithOperatorSetRequest,
 ) (IsOperatorRegisteredResponse, error) {
 	if request.OperatorSet.Id == 0 {
@@ -657,7 +638,7 @@ func (r *ChainReader) IsOperatorRegisteredWithOperatorSet(
 		}
 
 		status, err := r.avsDirectory.AvsOperatorStatus(
-			&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+			&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 			request.OperatorSet.Avs,
 			request.OperatorAddress,
 		)
@@ -676,7 +657,7 @@ func (r *ChainReader) IsOperatorRegisteredWithOperatorSet(
 		if r.allocationManager == nil {
 			return IsOperatorRegisteredResponse{IsRegistered: false}, errors.New("AllocationManager contract not provided")
 		}
-		registeredOperatorSets, err := r.allocationManager.GetRegisteredSets(&bind.CallOpts{Context: ctx, BlockNumber: blockNumber}, request.OperatorAddress)
+		registeredOperatorSets, err := r.allocationManager.GetRegisteredSets(&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber}, request.OperatorAddress)
 		// This call should not fail since it's a getter
 		if err != nil {
 			return IsOperatorRegisteredResponse{IsRegistered: false}, utils.WrapError("failed to get registered operator sets", err)
@@ -695,7 +676,6 @@ func (r *ChainReader) IsOperatorRegisteredWithOperatorSet(
 // Not supported for M2 AVSs
 func (r *ChainReader) GetOperatorsForOperatorSet(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetOperatorsForOperatorSetRequest,
 ) (GetOperatorsForOperatorSetResponse, error) {
 	if request.OperatorSet.Id == 0 {
@@ -704,7 +684,7 @@ func (r *ChainReader) GetOperatorsForOperatorSet(
 		if r.allocationManager == nil {
 			return GetOperatorsForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
 		}
-		members, err := r.allocationManager.GetMembers(&bind.CallOpts{Context: ctx, BlockNumber: blockNumber}, request.OperatorSet)
+		members, err := r.allocationManager.GetMembers(&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber}, request.OperatorSet)
 		if err != nil {
 			return GetOperatorsForOperatorSetResponse{}, utils.WrapError("failed to get members", err)
 		}
@@ -716,7 +696,6 @@ func (r *ChainReader) GetOperatorsForOperatorSet(
 // GetNumOperatorsForOperatorSet returns the number of operators in a specific operator set
 func (r *ChainReader) GetNumOperatorsForOperatorSet(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetNumOperatorsForOperatorSetRequest,
 ) (GetNumOperatorsForOperatorSetResponse, error) {
 	if request.OperatorSet.Id == 0 {
@@ -726,7 +705,7 @@ func (r *ChainReader) GetNumOperatorsForOperatorSet(
 			return GetNumOperatorsForOperatorSetResponse{}, errors.New("AllocationManager contract not provided")
 		}
 
-		memberCount, err := r.allocationManager.GetMemberCount(&bind.CallOpts{Context: ctx, BlockNumber: blockNumber}, request.OperatorSet)
+		memberCount, err := r.allocationManager.GetMemberCount(&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber}, request.OperatorSet)
 		if err != nil {
 			return GetNumOperatorsForOperatorSetResponse{}, utils.WrapError("failed to get member count", err)
 		}
@@ -739,7 +718,6 @@ func (r *ChainReader) GetNumOperatorsForOperatorSet(
 // Not supported for M2 AVSs
 func (r *ChainReader) GetStrategiesForOperatorSet(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetStrategiesForOperatorSetRequest,
 ) (GetStrategiesForOperatorSetResponse, error) {
 	if request.OperatorSet.Id == 0 {
@@ -750,7 +728,7 @@ func (r *ChainReader) GetStrategiesForOperatorSet(
 		}
 
 		strategies, err := r.allocationManager.GetStrategiesInOperatorSet(
-			&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+			&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 			request.OperatorSet,
 		)
 		if err != nil {
@@ -763,7 +741,6 @@ func (r *ChainReader) GetStrategiesForOperatorSet(
 
 func (r *ChainReader) GetSlashableShares(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetSlashableSharesRequest,
 ) (GetSlashableSharesResponse, error) {
 	if r.allocationManager == nil {
@@ -771,18 +748,18 @@ func (r *ChainReader) GetSlashableShares(
 	}
 
 	// TODO: Is necessary to get the block number here? Or should we use the one passed as argument?
-	// currentBlock, err := r.ethClient.BlockNumber(ctx)
+	currentBlock, err := r.ethClient.BlockNumber(ctx)
 	// This call should not fail since it's a getter
-	// if err != nil {
-	// 	return GetSlashableSharesResponse{}, err
-	// }
+	if err != nil {
+		return GetSlashableSharesResponse{}, err
+	}
 
 	slashableShares, err := r.allocationManager.GetMinimumSlashableStake(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorSet,
 		[]gethcommon.Address{request.OperatorAddress},
 		request.StrategiesAddresses,
-		uint32(blockNumber.Uint64()),
+		uint32(currentBlock),
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
@@ -804,19 +781,31 @@ func (r *ChainReader) GetSlashableShares(
 // GetSlashableSharesForOperatorSets returns the strategies the operatorSets take into account, their
 // operators, and the minimum amount of shares that are slashable by the operatorSets.
 // Not supported for M2 AVSs
-// VOY X ACAAAA
 func (r *ChainReader) GetSlashableSharesForOperatorSets(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetSlashableSharesForOperatorSetsRequest,
 ) (GetSlashableSharesForOperatorSetsResponse, error) {
-	// TODO: Is necessary to get the block number here? Or should we use the one passed as argument?
-	// currentBlock, err := r.ethClient.BlockNumber(ctx)
-	// // This call should not fail since it's a getter
-	// if err != nil {
-	// 	return nil, err
-	// }
-	return r.GetSlashableSharesForOperatorSetsBefore(ctx, uint32(blockNumber.Uint64()), request)
+	currentBlock, err := r.ethClient.BlockNumber(ctx)
+	// This call should not fail since it's a getter
+	if err != nil {
+		return GetSlashableSharesForOperatorSetsResponse{}, err
+	}
+
+	requestBefore := GetSlashableSharesForOperatorSetsBeforeRequest{
+		blockNumber:  request.blockNumber,
+		OperatorSets: request.OperatorSets,
+		FutureBlock:  uint32(currentBlock),
+	}
+
+	resp, err := r.GetSlashableSharesForOperatorSetsBefore(ctx, requestBefore)
+	if err != nil {
+		return GetSlashableSharesForOperatorSetsResponse{}, utils.WrapError(
+			"failed to get slashable shares for operator sets",
+			err,
+		)
+	}
+
+	return GetSlashableSharesForOperatorSetsResponse{OperatorSetStakes: resp.OperatorSetStakes}, nil
 }
 
 // GetSlashableSharesForOperatorSetsBefore returns the strategies the operatorSets take into account, their
@@ -824,52 +813,50 @@ func (r *ChainReader) GetSlashableSharesForOperatorSets(
 // operatorSets before a given timestamp.
 // Timestamp must be in the future. Used to underestimate future slashable stake.
 // Not supported for M2 AVSs
-
-// TODO: Should we use the block number instead of the futureBlock?
 func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 	ctx context.Context,
-	futureBlock uint32,
-	request GetSlashableSharesForOperatorSetsRequest,
-) (GetSlashableSharesForOperatorSetsResponse, error) {
+	request GetSlashableSharesForOperatorSetsBeforeRequest,
+) (GetSlashableSharesForOperatorSetsBeforeResponse, error) {
 	operatorSetStakes := make([]OperatorSetStakes, len(request.OperatorSets))
 	for i, operatorSet := range request.OperatorSets {
 		requestOperator := GetOperatorsForOperatorSetRequest{
+			blockNumber: request.blockNumber,
 			OperatorSet: operatorSet,
 		}
-		responseOperators, err := r.GetOperatorsForOperatorSet(ctx, nil, requestOperator)
+		responseOperators, err := r.GetOperatorsForOperatorSet(ctx, requestOperator)
 		if err != nil {
-			return GetSlashableSharesForOperatorSetsResponse{}, utils.WrapError(
+			return GetSlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
 				"failed to get operators for operator set",
 				err,
 			)
 		}
 
 		requestStrategies := GetStrategiesForOperatorSetRequest{
+			blockNumber: request.blockNumber,
 			OperatorSet: operatorSet,
 		}
-		// blockNumber should be nil or futureBlock?
-		responseStrategies, err := r.GetStrategiesForOperatorSet(ctx, nil, requestStrategies)
+		responseStrategies, err := r.GetStrategiesForOperatorSet(ctx, requestStrategies)
 		// If operator setId is 0 will fail on if above
 		if err != nil {
-			return GetSlashableSharesForOperatorSetsResponse{}, utils.WrapError(
+			return GetSlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
 				"failed to get strategies for operator set",
 				err,
 			)
 		}
 
 		slashableShares, err := r.allocationManager.GetMinimumSlashableStake(
-			&bind.CallOpts{Context: ctx},
+			&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 			allocationmanager.OperatorSet{
 				Id:  operatorSet.Id,
 				Avs: operatorSet.Avs,
 			},
 			responseOperators.Operators,
 			responseStrategies.StrategiesAddresses,
-			futureBlock,
+			request.FutureBlock,
 		)
 		// This call should not fail since it's a getter
 		if err != nil {
-			return GetSlashableSharesForOperatorSetsResponse{}, utils.WrapError(
+			return GetSlashableSharesForOperatorSetsBeforeResponse{}, utils.WrapError(
 				"failed to get minimum slashable stake",
 				err,
 			)
@@ -883,19 +870,18 @@ func (r *ChainReader) GetSlashableSharesForOperatorSetsBefore(
 		}
 	}
 
-	return GetSlashableSharesForOperatorSetsResponse{OperatorSetStakes: operatorSetStakes}, nil
+	return GetSlashableSharesForOperatorSetsBeforeResponse{OperatorSetStakes: operatorSetStakes}, nil
 }
 
 func (r *ChainReader) GetAllocationDelay(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetAllocationDelayRequest,
 ) (GetAllocationDelayResponse, error) {
 	if r.allocationManager == nil {
 		return GetAllocationDelayResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	isSet, delay, err := r.allocationManager.GetAllocationDelay(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	// This call should not fail since it's a getter
@@ -910,14 +896,13 @@ func (r *ChainReader) GetAllocationDelay(
 
 func (r *ChainReader) GetRegisteredSets(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request GetRegisteredSetsRequest,
 ) (GetRegisteredSetsResponse, error) {
 	if r.allocationManager == nil {
 		return GetRegisteredSetsResponse{}, errors.New("AllocationManager contract not provided")
 	}
 	reigsteredSets, err := r.allocationManager.GetRegisteredSets(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.OperatorAddress,
 	)
 	if err != nil {
@@ -929,7 +914,6 @@ func (r *ChainReader) GetRegisteredSets(
 
 func (r *ChainReader) CanCall(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request CanCallRequest,
 ) (CanCallResponse, error) {
 	if r.permissionController == nil {
@@ -937,7 +921,7 @@ func (r *ChainReader) CanCall(
 	}
 
 	canCall, err := r.permissionController.CanCall(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.AccountAddress,
 		request.AppointeeAddress,
 		request.Target,
@@ -952,7 +936,6 @@ func (r *ChainReader) CanCall(
 
 func (r *ChainReader) ListAppointees(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request ListAppointeesRequest,
 ) (ListAppointeesResponse, error) {
 	if r.permissionController == nil {
@@ -960,7 +943,7 @@ func (r *ChainReader) ListAppointees(
 	}
 
 	appointees, err := r.permissionController.GetAppointees(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.AccountAddress,
 		request.Target,
 		request.Select,
@@ -974,7 +957,6 @@ func (r *ChainReader) ListAppointees(
 
 func (r *ChainReader) ListAppointeePermissions(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request ListAppointeePermissionsRequest,
 ) (ListAppointeePermissionsResponse, error) {
 	if r.permissionController == nil {
@@ -982,7 +964,7 @@ func (r *ChainReader) ListAppointeePermissions(
 	}
 
 	targets, selectors, err := r.permissionController.GetAppointeePermissions(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.AccountAddress,
 		request.AppointeeAddress,
 	)
@@ -995,7 +977,6 @@ func (r *ChainReader) ListAppointeePermissions(
 
 func (r *ChainReader) ListPendingAdmins(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request ListPendingAdminsRequest,
 ) (ListPendingAdminsResponse, error) {
 	if r.permissionController == nil {
@@ -1003,7 +984,7 @@ func (r *ChainReader) ListPendingAdmins(
 	}
 
 	pendingAdmins, err := r.permissionController.GetPendingAdmins(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.AccountAddress,
 	)
 	// This call should not fail since it's a getter
@@ -1016,7 +997,6 @@ func (r *ChainReader) ListPendingAdmins(
 
 func (r *ChainReader) ListAdmins(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request ListAdminsRequest,
 ) (ListAdminsResponse, error) {
 	if r.permissionController == nil {
@@ -1024,7 +1004,7 @@ func (r *ChainReader) ListAdmins(
 	}
 
 	admins, err := r.permissionController.GetAdmins(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.AccountAddress,
 	)
 	// This call should not fail since it's a getter
@@ -1036,7 +1016,6 @@ func (r *ChainReader) ListAdmins(
 
 func (r *ChainReader) IsPendingAdmin(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request IsPendingAdminRequest,
 ) (IsPendingAdminResponse, error) {
 	if r.permissionController == nil {
@@ -1044,7 +1023,7 @@ func (r *ChainReader) IsPendingAdmin(
 	}
 
 	isPendingAdmin, err := r.permissionController.IsPendingAdmin(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.AccountAddress,
 		request.PendingAdminAddress,
 	)
@@ -1057,7 +1036,6 @@ func (r *ChainReader) IsPendingAdmin(
 
 func (r *ChainReader) IsAdmin(
 	ctx context.Context,
-	blockNumber *big.Int,
 	request IsAdminRequest,
 ) (IsAdminResponse, error) {
 	if r.permissionController == nil {
@@ -1065,7 +1043,7 @@ func (r *ChainReader) IsAdmin(
 	}
 
 	isAdmin, err := r.permissionController.IsAdmin(
-		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
+		&bind.CallOpts{Context: ctx, BlockNumber: request.blockNumber},
 		request.AccountAddress,
 		request.AdminAddress,
 	)

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -511,21 +511,21 @@ func (r *ChainReader) GetMaxMagnitudes(
 
 func (r *ChainReader) GetAllocationInfo(
 	ctx context.Context,
-	operatorAddress gethcommon.Address,
-	strategyAddress gethcommon.Address,
-) ([]AllocationInfo, error) {
+	blockNumber *big.Int,
+	request GetAllocationInfoRequest,
+) (GetAllocationInfoResponse, error) {
 	if r.allocationManager == nil {
-		return nil, errors.New("AllocationManager contract not provided")
+		return GetAllocationInfoResponse{}, errors.New("AllocationManager contract not provided")
 	}
 
 	opSets, allocationInfo, err := r.allocationManager.GetStrategyAllocations(
 		&bind.CallOpts{Context: ctx},
-		operatorAddress,
-		strategyAddress,
+		request.OperatorAddress,
+		request.StrategyAddress,
 	)
 	// This call should not fail since it's a getter
 	if err != nil {
-		return nil, err
+		return GetAllocationInfoResponse{}, err
 	}
 
 	allocationsInfo := make([]AllocationInfo, len(opSets))
@@ -539,7 +539,7 @@ func (r *ChainReader) GetAllocationInfo(
 		}
 	}
 
-	return allocationsInfo, nil
+	return GetAllocationInfoResponse{AllocationInfo: allocationsInfo}, nil
 }
 
 func (r *ChainReader) GetOperatorShares(

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -202,18 +202,22 @@ func (r *ChainReader) GetOperatorDetails(
 // GetStrategyAndUnderlyingToken returns the strategy contract and the underlying token address
 func (r *ChainReader) GetStrategyAndUnderlyingToken(
 	ctx context.Context,
-	strategyAddr gethcommon.Address,
-) (*strategy.ContractIStrategy, gethcommon.Address, error) {
-	contractStrategy, err := strategy.NewContractIStrategy(strategyAddr, r.ethClient)
+	blockNumber *big.Int,
+	request GetStrategyAndUnderlyingTokenRequest,
+) (GetStrategyAndUnderlyingTokenResponse, error) {
+	contractStrategy, err := strategy.NewContractIStrategy(request.StrategyAddress, r.ethClient)
 	// This call should not fail since it's an init
 	if err != nil {
-		return nil, gethcommon.Address{}, utils.WrapError("Failed to fetch strategy contract", err)
+		return GetStrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
 	}
 	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(&bind.CallOpts{Context: ctx})
 	if err != nil {
-		return nil, gethcommon.Address{}, utils.WrapError("Failed to fetch token contract", err)
+		return GetStrategyAndUnderlyingTokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
 	}
-	return contractStrategy, underlyingTokenAddr, nil
+	return GetStrategyAndUnderlyingTokenResponse{
+		StrategyContract:       contractStrategy,
+		UnderlyingTokenAddress: underlyingTokenAddr,
+	}, nil
 }
 
 // GetStrategyAndUnderlyingERC20Token returns the strategy contract, the erc20 bindings for the underlying token

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -638,7 +638,8 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	testutils.AdvanceChainByNBlocksExecInContainer(context.Background(), allocationConfigurationDelay+1, anvilC)
 
 	// Check that Allocation delay has been applied
-	_, err = chainReader.GetAllocationDelay(context.Background(), operatorAddr)
+	requestDelay := elcontracts.GetAllocationDelayRequest{OperatorAddress: operatorAddr}
+	_, err = chainReader.GetAllocationDelay(context.Background(), nil, requestDelay)
 	require.NoError(t, err)
 
 	err = createOperatorSet(anvilHttpEndpoint, privateKeyHex, testAddr, operatorSetId, strategyAddr)
@@ -1026,7 +1027,7 @@ func TestInvalidConfig(t *testing.T) {
 		_, err = chainReader.GetAllocationInfo(context.Background(), nil, elcontracts.GetAllocationInfoRequest{})
 		require.Error(t, err)
 
-		_, err = chainReader.GetAllocationDelay(context.Background(), common.HexToAddress(operatorAddr))
+		_, err = chainReader.GetAllocationDelay(context.Background(), nil, elcontracts.GetAllocationDelayRequest{})
 		require.Error(t, err)
 
 		_, err = chainReader.CheckClaim(

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -90,13 +90,17 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get operator shares in strategy", func(t *testing.T) {
-		shares, err := read_clients.ElChainReader.GetOperatorSharesInStrategy(
+		request := elcontracts.GetOperatorSharesInStrategyRequest{
+			OperatorAddress: operatorAddrHex,
+			StrategyAddress: contractAddrs.Erc20MockStrategy,
+		}
+		response, err := read_clients.ElChainReader.GetOperatorSharesInStrategy(
 			ctx,
-			common.HexToAddress(operator.Address),
-			contractAddrs.Erc20MockStrategy,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.NotZero(t, shares)
+		assert.NotZero(t, response.Shares)
 	})
 
 	t.Run("calculate delegation approval digest hash", func(t *testing.T) {
@@ -864,8 +868,13 @@ func TestInvalidConfig(t *testing.T) {
 		strategyAddr := common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
 		operatorAddr := common.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
 
+		requestShares := elcontracts.GetOperatorSharesInStrategyRequest{
+			OperatorAddress: operatorAddr,
+			StrategyAddress: strategyAddr,
+		}
+
 		// GetOperatorSharesInStrategy needs a correct DelegationManagerAddress
-		_, err := chainReader.GetOperatorSharesInStrategy(context.Background(), operatorAddr, strategyAddr)
+		_, err := chainReader.GetOperatorSharesInStrategy(context.Background(), nil, requestShares)
 		require.Error(t, err)
 
 		// GetStrategyAndUnderlyingToken needs a correct StrategyAddress

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -613,10 +613,14 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert that at the beginning, Allocatable Magnitude is Max allocatable magnitude
-	allocable, err := chainReader.GetAllocatableMagnitude(ctx, testAddr, strategyAddr)
+	requestMag := elcontracts.GetAllocatableMagnitudeRequest{
+		OperatorAddress: testAddr,
+		StrategyAddress: strategyAddr,
+	}
+	responseMag, err := chainReader.GetAllocatableMagnitude(ctx, nil, requestMag)
 	assert.NoError(t, err)
 
-	assert.Equal(t, response.MaxMagnitudes[0], allocable)
+	assert.Equal(t, response.MaxMagnitudes[0], responseMag.AllocatableMagnitude)
 
 	// Reduce allocatable magnitude for testAddr
 	privateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
@@ -658,9 +662,10 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
 	// Assert that after stake reduction, Allocatable Magnitude + reduction ammount equals Max allocatable magnitude
-	allocable, err = chainReader.GetAllocatableMagnitude(ctx, testAddr, strategyAddr)
+
+	responseMag, err = chainReader.GetAllocatableMagnitude(ctx, nil, requestMag)
 	assert.NoError(t, err)
-	assert.Equal(t, response.MaxMagnitudes[0], allocable+allocatable_reduction)
+	assert.Equal(t, response.MaxMagnitudes[0], responseMag.AllocatableMagnitude+allocatable_reduction)
 
 	// Check that the new allocationDelay is equal to delay
 	requestOp := elcontracts.GetOperatorDetailsRequest{OperatorAddress: operatorAddr}
@@ -991,8 +996,8 @@ func TestInvalidConfig(t *testing.T) {
 	})
 
 	t.Run("get magnitudes, rewards and claims with invalid config", func(t *testing.T) {
-		contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
-		strategyAddr := contractAddrs.Erc20MockStrategy
+		// contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
+		// strategyAddr := contractAddrs.Erc20MockStrategy
 
 		_, err = chainReader.GetCurrentClaimableDistributionRoot(context.Background(), nil)
 		require.Error(t, err)
@@ -1013,8 +1018,8 @@ func TestInvalidConfig(t *testing.T) {
 
 		_, err = chainReader.GetAllocatableMagnitude(
 			context.Background(),
-			common.HexToAddress(operatorAddr),
-			strategyAddr,
+			nil,
+			elcontracts.GetAllocatableMagnitudeRequest{},
 		)
 		require.Error(t, err)
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -130,15 +130,19 @@ func TestChainReader(t *testing.T) {
 		avs := common.Address{0x0}
 		salt := [32]byte{}
 		expiry := big.NewInt(0)
-		digest, err := read_clients.ElChainReader.CalculateOperatorAVSRegistrationDigestHash(
+		request := elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest{
+			OperatorAddress: common.HexToAddress(operator.Address),
+			AVSAddress:      avs,
+			Salt:            salt,
+			Expiry:          expiry,
+		}
+		response, err := read_clients.ElChainReader.CalculateOperatorAVSRegistrationDigestHash(
 			ctx,
-			common.HexToAddress(operator.Address),
-			avs,
-			salt,
-			expiry,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, digest)
+		assert.NotEmpty(t, response.DigestHash)
 	})
 
 	t.Run("get staker shares", func(t *testing.T) {
@@ -922,9 +926,9 @@ func TestInvalidConfig(t *testing.T) {
 
 		// CalculateOperatorAVSRegistrationDigestHash needs a correct AvsDirectoryAddress
 		_, err = chainReader.CalculateOperatorAVSRegistrationDigestHash(context.Background(),
-			common.HexToAddress(operatorAddr),
-			staker,
-			approverSalt, expiry)
+			nil,
+			elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest{},
+		)
 		require.Error(t, err)
 	})
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -476,11 +476,13 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 	assert.NotEqual(t, common.Address{}, response.UnderlyingTokenAddress)
 	assert.NotNil(t, response.ERC20Bindings)
 
-	anvil_address := common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
-
 	// This tests that without claims result is zero
-	claimed, err := chainReader.GetCumulativeClaimed(ctx, anvil_address, response.UnderlyingTokenAddress)
-	assert.Zero(t, claimed.Cmp(big.NewInt(0)))
+	requestClaimed := elcontracts.GetCumulativeClaimedRequest{
+		ClaimerAddress: common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS),
+		TokenAddress:   response.UnderlyingTokenAddress,
+	}
+	responseClaimed, err := chainReader.GetCumulativeClaimed(ctx, nil, requestClaimed)
+	assert.Zero(t, responseClaimed.CumulativeClaimed.Cmp(big.NewInt(0)))
 	assert.NoError(t, err)
 
 	cumulativeEarnings := int64(45)
@@ -492,8 +494,8 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 	require.True(t, receipt.Status == gethtypes.ReceiptStatusSuccessful)
 
 	// This tests that with a claim result is cumulativeEarnings
-	claimed, err = chainReader.GetCumulativeClaimed(ctx, anvil_address, response.UnderlyingTokenAddress)
-	assert.Equal(t, claimed, big.NewInt(cumulativeEarnings))
+	responseClaimed, err = chainReader.GetCumulativeClaimed(ctx, nil, requestClaimed)
+	assert.Equal(t, responseClaimed.CumulativeClaimed, big.NewInt(cumulativeEarnings))
 	assert.NoError(t, err)
 }
 
@@ -962,8 +964,8 @@ func TestInvalidConfig(t *testing.T) {
 
 		_, err := chainReader.GetCumulativeClaimed(
 			context.Background(),
-			common.HexToAddress(testutils.ANVIL_THIRD_ADDRESS),
-			common.HexToAddress(testutils.ANVIL_SECOND_ADDRESS),
+			nil,
+			elcontracts.GetCumulativeClaimedRequest{},
 		)
 		require.Error(t, err)
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -1052,7 +1052,11 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("try to get the number of operator sets for an operator with invalid config", func(t *testing.T) {
 		// GetNumOperatorSetsForOperator needs a correct AllocationManagerAddress
-		_, err := chainReader.GetNumOperatorSetsForOperator(context.Background(), common.HexToAddress(operator.Address))
+		_, err := chainReader.GetNumOperatorSetsForOperator(
+			context.Background(),
+			nil,
+			elcontracts.GetNumOperatorSetsForOperatorRequest{},
+		)
 		require.Error(t, err)
 	})
 
@@ -1262,12 +1266,16 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get amount operatorSets for operator", func(t *testing.T) {
-			opSetsCount, err := chainReader.GetNumOperatorSetsForOperator(
+			request := elcontracts.GetNumOperatorSetsForOperatorRequest{
+				OperatorAddress: operatorAddr,
+			}
+			response, err := chainReader.GetNumOperatorSetsForOperator(
 				context.Background(),
-				operatorAddr,
+				nil,
+				request,
 			)
 			require.NoError(t, err)
-			require.NotZero(t, opSetsCount)
+			require.NotZero(t, response.NumOperatorSets)
 		})
 
 		t.Run("get operator for operatorsets", func(t *testing.T) {

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -381,12 +381,12 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	// Check that if there is no root submitted the result is an InvalidRoot error
 	root_index, err := chainReader.GetRootIndexFromHash(
 		ctx,
-		root,
+		nil,
+		elcontracts.GetRootIndexFromHashRequest{
+			RootHash: root,
+		},
 	)
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "execution reverted: custom error 0x504570e3",
-		"GetRootIndexFromHash should return an InvalidRoot() error",
-	)
 	assert.Zero(t, root_index)
 
 	response, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
@@ -415,20 +415,26 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the first root inserted is the first indexed (zero)
-	root_index, err = chainReader.GetRootIndexFromHash(
+	responseHash, err := chainReader.GetRootIndexFromHash(
 		ctx,
-		root,
+		nil,
+		elcontracts.GetRootIndexFromHashRequest{
+			RootHash: root,
+		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, root_index, uint32(0))
+	assert.Equal(t, responseHash.RootIndex, uint32(0))
 
 	// Check that the second root inserted is the second indexed (zero)
-	root_index, err = chainReader.GetRootIndexFromHash(
+	responseHash, err = chainReader.GetRootIndexFromHash(
 		ctx,
-		root2,
+		nil,
+		elcontracts.GetRootIndexFromHashRequest{
+			RootHash: root2,
+		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, root_index, uint32(1))
+	assert.Equal(t, responseHash.RootIndex, uint32(1))
 }
 
 func TestGetCumulativeClaimedRewards(t *testing.T) {
@@ -940,7 +946,7 @@ func TestInvalidConfig(t *testing.T) {
 		require.Error(t, err)
 
 		// GetRootIndexFromHash needs a correct RewardsCoordinatorAddress
-		_, err = chainReader.GetRootIndexFromHash(context.Background(), [32]byte{})
+		_, err = chainReader.GetRootIndexFromHash(context.Background(), nil, elcontracts.GetRootIndexFromHashRequest{})
 		require.Error(t, err)
 
 		_, err = chainReader.GetCurrentClaimableDistributionRoot(context.Background(), nil)

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -990,7 +990,7 @@ func TestInvalidConfig(t *testing.T) {
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.GetAllocationInfo(context.Background(), common.HexToAddress(operatorAddr), strategyAddr)
+		_, err = chainReader.GetAllocationInfo(context.Background(), nil, elcontracts.GetAllocationInfoRequest{})
 		require.Error(t, err)
 
 		_, err = chainReader.GetAllocationDelay(context.Background(), common.HexToAddress(operatorAddr))

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -145,16 +145,17 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get delegated operator", func(t *testing.T) {
-		blockNumber := big.NewInt(0)
-		address, err := read_clients.ElChainReader.GetDelegatedOperator(
+		request := elcontracts.GetDelegatedOperatorRequest{StakerAddress: common.HexToAddress(operator.Address)}
+		t.Logf("Request: %+v", request)
+		response, err := read_clients.ElChainReader.GetDelegatedOperator(
 			ctx,
-			common.HexToAddress(operator.Address),
-			blockNumber,
+			nil,
+			request,
 		)
 
 		assert.NoError(t, err)
 		// The delegated operator of an operator is the operator itself
-		assert.Equal(t, address.String(), operator.Address)
+		assert.Equal(t, response.OperatorAddress.String(), operator.Address)
 	})
 
 	t.Run("GetOperatorShares", func(t *testing.T) {
@@ -951,8 +952,8 @@ func TestInvalidConfig(t *testing.T) {
 		// GetDelegatedOperator needs a correct DelegationManagerAddress
 		_, err := chainReader.GetDelegatedOperator(
 			context.Background(),
-			common.HexToAddress(operator.Address),
 			big.NewInt(0),
+			elcontracts.GetDelegatedOperatorRequest{},
 		)
 		require.Error(t, err)
 	})

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -1351,22 +1351,29 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get slashable shares for multiple operatorSets", func(t *testing.T) {
-			shares, err := chainReader.GetSlashableSharesForOperatorSets(
+			request := elcontracts.GetSlashableSharesForOperatorSetsRequest{
+				OperatorSets: []allocationmanager.OperatorSet{operatorSet},
+			}
+			response, err := chainReader.GetSlashableSharesForOperatorSets(
 				context.Background(),
-				[]allocationmanager.OperatorSet{operatorSet},
+				receipt.BlockNumber,
+				request,
 			)
 			require.NoError(t, err)
-			require.NotEmpty(t, shares)
+			require.NotEmpty(t, response.OperatorSetStakes)
 		})
 
 		t.Run("get slashable shares before specific block", func(t *testing.T) {
-			shares, err := chainReader.GetSlashableSharesForOperatorSetsBefore(
+			request := elcontracts.GetSlashableSharesForOperatorSetsRequest{
+				OperatorSets: []allocationmanager.OperatorSet{operatorSet},
+			}
+			response, err := chainReader.GetSlashableSharesForOperatorSetsBefore(
 				context.Background(),
-				[]allocationmanager.OperatorSet{operatorSet},
 				2,
+				request,
 			)
 			require.NoError(t, err)
-			require.NotEmpty(t, shares)
+			require.NotEmpty(t, response.OperatorSetStakes)
 		})
 	})
 }
@@ -1429,8 +1436,11 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 		require.NoError(t, err)
 
 		operatorSets := []allocationmanager.OperatorSet{operatorSet}
+		request := elcontracts.GetSlashableSharesForOperatorSetsRequest{
+			OperatorSets: operatorSets,
+		}
 
-		_, err = chainReader.GetSlashableSharesForOperatorSetsBefore(context.Background(), operatorSets, 10)
+		_, err = chainReader.GetSlashableSharesForOperatorSetsBefore(context.Background(), 10, request)
 		require.Error(t, err)
 	})
 }

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -1122,9 +1122,13 @@ func TestInvalidConfig(t *testing.T) {
 				Avs: testAddr,
 				Id:  operatorSetId,
 			}
+			request := elcontracts.GetOperatorsForOperatorSetRequest{
+				OperatorSet: operatorSet,
+			}
 			_, err := chainReader.GetOperatorsForOperatorSet(
 				context.Background(),
-				operatorSet,
+				nil,
+				request,
 			)
 			require.Error(t, err)
 		},
@@ -1293,9 +1297,12 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get operator for operatorsets", func(t *testing.T) {
-			operators, err := chainReader.GetOperatorsForOperatorSet(context.Background(), operatorSet)
+			request := elcontracts.GetOperatorsForOperatorSetRequest{
+				OperatorSet: operatorSet,
+			}
+			response, err := chainReader.GetOperatorsForOperatorSet(context.Background(), nil, request)
 			require.NoError(t, err)
-			require.NotEmpty(t, operators)
+			require.NotEmpty(t, response.Operators)
 		})
 
 		t.Run("get amount of operators for operatorsets", func(t *testing.T) {
@@ -1355,7 +1362,10 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("test operator set with invalid id", func(t *testing.T) {
-		_, err := chainReader.GetOperatorsForOperatorSet(ctx, operatorSet)
+		request := elcontracts.GetOperatorsForOperatorSetRequest{
+			OperatorSet: operatorSet,
+		}
+		_, err := chainReader.GetOperatorsForOperatorSet(ctx, nil, request)
 		require.Error(t, err)
 
 		_, err = chainReader.GetNumOperatorsForOperatorSet(ctx, operatorSet)

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -903,14 +903,18 @@ func TestInvalidConfig(t *testing.T) {
 	})
 
 	t.Run("get operator avs", func(t *testing.T) {
+		request := elcontracts.GetOperatorAVSSplitRequest{
+			OperatorAddress: common.HexToAddress(operatorAddr),
+			AvsAddress:      common.MaxAddress,
+		}
 		_, err = chainReader.GetOperatorAVSSplit(
 			context.Background(),
-			common.HexToAddress(operatorAddr),
-			common.MaxAddress,
+			nil,
+			request,
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.GetOperatorPISplit(context.Background(), nil, elcontracts.GetOperatorAVSSplitRequest{})
+		_, err = chainReader.GetOperatorPISplit(context.Background(), nil, elcontracts.GetOperatorPISplitRequest{})
 		require.Error(t, err)
 	})
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -762,11 +762,14 @@ func TestAdminFunctions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 
-		listAdmins, err := chainReader.ListAdmins(context.Background(), operatorAddr)
+		requestAdmin := elcontracts.ListAdminsRequest{
+			AccountAddress: operatorAddr,
+		}
+		response, err := chainReader.ListAdmins(context.Background(), nil, requestAdmin)
 		assert.NoError(t, err)
-		assert.Len(t, listAdmins, 1)
+		assert.Len(t, response.Admins, 1)
 
-		admin := listAdmins[0]
+		admin := response.Admins[0]
 		isAdmin, err := chainReader.IsAdmin(context.Background(), operatorAddr, admin)
 		assert.NoError(t, err)
 		assert.True(t, isAdmin)

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -838,13 +838,17 @@ func TestAppointeesFunctions(t *testing.T) {
 	})
 
 	t.Run("list appointees permissions", func(t *testing.T) {
-		appointeesPermission, _, err := chainReader.ListAppointeePermissions(
+		request := elcontracts.ListAppointeePermissionsRequest{
+			AccountAddress:   accountAddress,
+			AppointeeAddress: appointeeAddress,
+		}
+		response, err := chainReader.ListAppointeePermissions(
 			context.Background(),
-			accountAddress,
-			appointeeAddress,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, appointeesPermission)
+		assert.NotEmpty(t, response.AppinteeAddress)
 	})
 }
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -1062,7 +1062,10 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("try to get the operator sets for an operator with invalid config", func(t *testing.T) {
 		// GetOperatorSetsForOperator needs a correct AllocationManagerAddress
-		_, err := chainReader.GetOperatorSetsForOperator(context.Background(), common.HexToAddress(operator.Address))
+		request := elcontracts.GetOperatorSetsForOperatorRequest{
+			OperatorAddress: common.HexToAddress(operatorAddr),
+		}
+		_, err := chainReader.GetOperatorSetsForOperator(context.Background(), nil, request)
 		require.Error(t, err)
 	})
 
@@ -1075,10 +1078,14 @@ func TestInvalidConfig(t *testing.T) {
 				Avs: testAddr,
 				Id:  operatorSetId,
 			}
+			request := elcontracts.IsOperatorRegisteredWithOperatorSetRequest{
+				OperatorAddress: common.HexToAddress(operator.Address),
+				OperatorSet:     operatorSet,
+			}
 			_, err := chainReader.IsOperatorRegisteredWithOperatorSet(
 				context.Background(),
-				common.HexToAddress(operator.Address),
-				operatorSet,
+				nil,
+				request,
 			)
 			require.Error(t, err)
 		},
@@ -1093,10 +1100,14 @@ func TestInvalidConfig(t *testing.T) {
 				Avs: testAddr,
 				Id:  operatorSetId,
 			}
+			request := elcontracts.IsOperatorRegisteredWithOperatorSetRequest{
+				OperatorAddress: common.HexToAddress(operator.Address),
+				OperatorSet:     operatorSet,
+			}
 			_, err := chainReader.IsOperatorRegisteredWithOperatorSet(
 				context.Background(),
-				common.HexToAddress(operator.Address),
-				operatorSet,
+				nil,
+				request,
 			)
 			require.Error(t, err)
 		},
@@ -1260,9 +1271,12 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get operator sets for operator", func(t *testing.T) {
-			opSets, err := chainReader.GetOperatorSetsForOperator(context.Background(), operatorAddr)
+			request := elcontracts.GetOperatorSetsForOperatorRequest{
+				OperatorAddress: operatorAddr,
+			}
+			response, err := chainReader.GetOperatorSetsForOperator(context.Background(), nil, request)
 			require.NoError(t, err)
-			require.NotEmpty(t, opSets)
+			require.NotEmpty(t, response.OperatorSets)
 		})
 
 		t.Run("get amount operatorSets for operator", func(t *testing.T) {

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -546,9 +546,12 @@ func TestCheckClaim(t *testing.T) {
 	assert.NotEqual(t, common.Address{}, response.UnderlyingTokenAddress)
 	assert.NotNil(t, response.ERC20Bindings)
 
-	checked, err := chainReader.CheckClaim(ctx, *claim)
+	requestClaim := elcontracts.CheckClaimRequest{
+		Claim: *claim,
+	}
+	responseClaim, err := chainReader.CheckClaim(ctx, nil, requestClaim)
 	require.NoError(t, err)
-	assert.True(t, checked)
+	assert.True(t, responseClaim.IsValid)
 }
 
 func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
@@ -991,7 +994,8 @@ func TestInvalidConfig(t *testing.T) {
 
 		_, err = chainReader.CheckClaim(
 			context.Background(),
-			rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim{},
+			nil,
+			elcontracts.CheckClaimRequest{},
 		)
 		require.Error(t, err)
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -715,9 +715,12 @@ func TestAdminFunctions(t *testing.T) {
 	})
 
 	t.Run("list pending admins when empty", func(t *testing.T) {
-		listPendingAdmins, err := chainReader.ListPendingAdmins(context.Background(), operatorAddr)
+		request := elcontracts.ListPendingAdminsRequest{
+			AccountAddress: operatorAddr,
+		}
+		response, err := chainReader.ListPendingAdmins(context.Background(), nil, request)
 		assert.NoError(t, err)
-		assert.Empty(t, listPendingAdmins)
+		assert.Empty(t, response.PendingAdmins)
 	})
 
 	t.Run("add pending admin and list", func(t *testing.T) {
@@ -735,9 +738,12 @@ func TestAdminFunctions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, isPendingAdmin)
 
-		listPendingAdmins, err := chainReader.ListPendingAdmins(context.Background(), operatorAddr)
+		requestListPending := elcontracts.ListPendingAdminsRequest{
+			AccountAddress: operatorAddr,
+		}
+		responseList, err := chainReader.ListPendingAdmins(context.Background(), nil, requestListPending)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, listPendingAdmins)
+		assert.NotEmpty(t, responseList.PendingAdmins)
 	})
 
 	t.Run("non-existent admin", func(t *testing.T) {
@@ -848,7 +854,7 @@ func TestAppointeesFunctions(t *testing.T) {
 			request,
 		)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, response.AppinteeAddress)
+		assert.NotEmpty(t, response.AppointeeAddress)
 	})
 }
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -125,14 +125,23 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get staker shares", func(t *testing.T) {
-		strategies, shares, err := read_clients.ElChainReader.GetStakerShares(
+		request := elcontracts.GetStakerSharesRequest{
+			StakerAddress: common.HexToAddress(operator.Address),
+		}
+		response, err := read_clients.ElChainReader.GetStakerShares(
 			ctx,
-			common.HexToAddress(operator.Address),
+			nil,
+			request,
 		)
-		assert.NotZero(t, len(strategies), "Strategies has at least one element")
-		assert.NotZero(t, len(shares), "Shares has at least one element")
-		assert.Equal(t, len(strategies), len(shares), "Strategies has the same ammount of elements as shares")
 		assert.NoError(t, err)
+		assert.NotZero(t, len(response.StrategiesAddresses), "Strategies has at least one element")
+		assert.NotZero(t, len(response.Shares), "Shares has at least one element")
+		assert.Equal(
+			t,
+			len(response.StrategiesAddresses),
+			len(response.Shares),
+			"Strategies has the same ammount of elements as shares",
+		)
 	})
 
 	t.Run("get delegated operator", func(t *testing.T) {
@@ -931,7 +940,10 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("try to get a staker shares with invalid config", func(t *testing.T) {
 		// GetStakerShares needs a correct DelegationManagerAddress
-		_, _, err := chainReader.GetStakerShares(context.Background(), common.HexToAddress(operator.Address))
+		request := elcontracts.GetStakerSharesRequest{
+			StakerAddress: common.HexToAddress(operator.Address),
+		}
+		_, err := chainReader.GetStakerShares(context.Background(), nil, request)
 		require.Error(t, err)
 	})
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -709,9 +709,13 @@ func TestAdminFunctions(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("non-existent pending admin", func(t *testing.T) {
-		isPendingAdmin, err := chainReader.IsPendingAdmin(context.Background(), operatorAddr, pendingAdminAddr)
+		request := elcontracts.IsPendingAdminRequest{
+			AccountAddress:      operatorAddr,
+			PendingAdminAddress: pendingAdminAddr,
+		}
+		response, err := chainReader.IsPendingAdmin(context.Background(), nil, request)
 		assert.NoError(t, err)
-		assert.False(t, isPendingAdmin)
+		assert.False(t, response.IsPendingAdmin)
 	})
 
 	t.Run("list pending admins when empty", func(t *testing.T) {
@@ -734,9 +738,13 @@ func TestAdminFunctions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 
-		isPendingAdmin, err := chainReader.IsPendingAdmin(context.Background(), operatorAddr, pendingAdminAddr)
+		requestPending := elcontracts.IsPendingAdminRequest{
+			AccountAddress:      operatorAddr,
+			PendingAdminAddress: pendingAdminAddr,
+		}
+		responsePending, err := chainReader.IsPendingAdmin(context.Background(), nil, requestPending)
 		assert.NoError(t, err)
-		assert.True(t, isPendingAdmin)
+		assert.True(t, responsePending.IsPendingAdmin)
 
 		requestListPending := elcontracts.ListPendingAdminsRequest{
 			AccountAddress: operatorAddr,

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -182,23 +182,31 @@ func TestChainReader(t *testing.T) {
 	t.Run("GetOperatorShares", func(t *testing.T) {
 		strategyAddr := contractAddrs.Erc20MockStrategy
 		strategies := []common.Address{strategyAddr}
-		shares, err := read_clients.ElChainReader.GetOperatorShares(
+		request := elcontracts.GetOperatorSharesRequest{
+			OperatorAddress:     operatorAddrHex,
+			StrategiesAddresses: strategies,
+		}
+		response, err := read_clients.ElChainReader.GetOperatorShares(
 			ctx,
-			common.HexToAddress(operator.Address),
-			strategies,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, shares, 1)
+		assert.Len(t, response.Shares, 1)
 
 		// with n strategies, response's list length is n
 		strategies = []common.Address{strategyAddr, strategyAddr, strategyAddr}
-		shares, err = read_clients.ElChainReader.GetOperatorShares(
+		request = elcontracts.GetOperatorSharesRequest{
+			OperatorAddress:     operatorAddrHex,
+			StrategiesAddresses: strategies,
+		}
+		response, err = read_clients.ElChainReader.GetOperatorShares(
 			ctx,
-			common.HexToAddress(operator.Address),
-			strategies,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, shares, 3)
+		assert.Len(t, response.Shares, 3)
 
 		// We could test modify the shares and verify the diff is the expected
 	})

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -303,27 +303,29 @@ func TestGetCurrentClaimableDistributionRoot(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that if there is no root submitted the result is zero
-	distr_root, err := chainReader.GetCurrentClaimableDistributionRoot(
+	response, err := chainReader.GetCurrentClaimableDistributionRoot(
 		ctx,
+		nil,
 	)
 	assert.NoError(t, err)
-	assert.Zero(t, distr_root.Root)
+	assert.Zero(t, response.DistributionRoot.Root)
 
-	response, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
+	responseTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
 	require.NoError(t, err)
 
-	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, response.Timestamp+1)
+	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, responseTimestamp.Timestamp+1)
 	require.NoError(t, err)
 
 	_, err = txManager.Send(context.Background(), tx, waitForReceipt)
 	require.NoError(t, err)
 
 	// Check that if there is a root submitted the result is that root
-	distr_root, err = chainReader.GetCurrentClaimableDistributionRoot(
+	response, err = chainReader.GetCurrentClaimableDistributionRoot(
 		ctx,
+		nil,
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, distr_root.Root, root)
+	assert.Equal(t, response.DistributionRoot.Root, root)
 }
 
 func TestGetRootIndexFromRootHash(t *testing.T) {
@@ -941,7 +943,7 @@ func TestInvalidConfig(t *testing.T) {
 		_, err = chainReader.GetRootIndexFromHash(context.Background(), [32]byte{})
 		require.Error(t, err)
 
-		_, err = chainReader.GetCurrentClaimableDistributionRoot(context.Background())
+		_, err = chainReader.GetCurrentClaimableDistributionRoot(context.Background(), nil)
 		require.Error(t, err)
 	})
 
@@ -949,7 +951,7 @@ func TestInvalidConfig(t *testing.T) {
 		contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
 		strategyAddr := contractAddrs.Erc20MockStrategy
 
-		_, err = chainReader.GetCurrentClaimableDistributionRoot(context.Background())
+		_, err = chainReader.GetCurrentClaimableDistributionRoot(context.Background(), nil)
 		require.Error(t, err)
 
 		_, err := chainReader.GetCumulativeClaimed(

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -1160,9 +1160,12 @@ func TestInvalidConfig(t *testing.T) {
 				Avs: testAddr,
 				Id:  operatorSetId,
 			}
+			request := elcontracts.GetStrategiesForOperatorSetRequest{
+				OperatorSet: operatorSet,
+			}
 			_, err := chainReader.GetStrategiesForOperatorSet(
 				context.Background(),
-				operatorSet,
+				nil, request,
 			)
 			require.Error(t, err)
 		},
@@ -1262,10 +1265,13 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 
 	t.Run("get operators and operator sets", func(t *testing.T) {
 		t.Run("validate strategies for operatorSet", func(t *testing.T) {
-			strats, err := chainReader.GetStrategiesForOperatorSet(context.Background(), operatorSet)
+			request := elcontracts.GetStrategiesForOperatorSetRequest{
+				OperatorSet: operatorSet,
+			}
+			response, err := chainReader.GetStrategiesForOperatorSet(context.Background(), nil, request)
 			require.NoError(t, err)
-			require.Len(t, strats, 1)
-			require.Equal(t, strats[0].Hex(), strategyAddr.Hex())
+			require.Len(t, response.StrategiesAddresses, 1)
+			require.Equal(t, response.StrategiesAddresses[0].Hex(), strategyAddr.Hex())
 		})
 
 		t.Run("get registered sets", func(t *testing.T) {
@@ -1371,7 +1377,10 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 		_, err = chainReader.GetNumOperatorsForOperatorSet(ctx, operatorSet)
 		require.Error(t, err)
 
-		_, err = chainReader.GetStrategiesForOperatorSet(ctx, operatorSet)
+		requestStr := elcontracts.GetStrategiesForOperatorSetRequest{
+			OperatorSet: operatorSet,
+		}
+		_, err = chainReader.GetStrategiesForOperatorSet(ctx, nil, requestStr)
 		require.Error(t, err)
 
 		strategies := []common.Address{contractAddrs.Erc20MockStrategy}

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -794,9 +794,14 @@ func TestAppointeesFunctions(t *testing.T) {
 	selector := [4]byte{0, 1, 2, 3}
 
 	t.Run("list appointees when empty", func(t *testing.T) {
-		appointees, err := chainReader.ListAppointees(context.Background(), accountAddress, target, selector)
+		request := elcontracts.ListAppointeesRequest{
+			AccountAddress: accountAddress,
+			Target:         target,
+			Select:         selector,
+		}
+		response, err := chainReader.ListAppointees(context.Background(), nil, request)
 		assert.NoError(t, err)
-		assert.Empty(t, appointees)
+		assert.Empty(t, response.Appointees)
 	})
 
 	t.Run("list appointees", func(t *testing.T) {
@@ -822,9 +827,14 @@ func TestAppointeesFunctions(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, response.CanCall)
 
-		appointees, err := chainReader.ListAppointees(context.Background(), accountAddress, target, selector)
+		requestAppointees := elcontracts.ListAppointeesRequest{
+			AccountAddress: accountAddress,
+			Target:         target,
+			Select:         selector,
+		}
+		responseAppointees, err := chainReader.ListAppointees(context.Background(), nil, requestAppointees)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, appointees)
+		assert.NotEmpty(t, responseAppointees.Appointees)
 	})
 
 	t.Run("list appointees permissions", func(t *testing.T) {

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -812,9 +812,15 @@ func TestAppointeesFunctions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 
-		canCall, err := chainReader.CanCall(context.Background(), accountAddress, appointeeAddress, target, selector)
+		request := elcontracts.CanCallRequest{
+			AccountAddress:   accountAddress,
+			AppointeeAddress: appointeeAddress,
+			Target:           target,
+			Selector:         selector,
+		}
+		response, err := chainReader.CanCall(context.Background(), nil, request)
 		require.NoError(t, err)
-		require.True(t, canCall)
+		require.True(t, response.CanCall)
 
 		appointees, err := chainReader.ListAppointees(context.Background(), accountAddress, target, selector)
 		assert.NoError(t, err)

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -882,7 +882,7 @@ func TestInvalidConfig(t *testing.T) {
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.GetOperatorPISplit(context.Background(), common.HexToAddress(operatorAddr))
+		_, err = chainReader.GetOperatorPISplit(context.Background(), nil, elcontracts.GetOperatorAVSSplitRequest{})
 		require.Error(t, err)
 	})
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -108,16 +108,22 @@ func TestChainReader(t *testing.T) {
 		delegationApprover := common.Address{0x0}
 		approverSalt := [32]byte{}
 		expiry := big.NewInt(0)
-		digest, err := read_clients.ElChainReader.CalculateDelegationApprovalDigestHash(
+
+		request := elcontracts.CalculateDelegationApprovalDigestHashRequest{
+			StakerAddress:   staker,
+			OperatorAddress: common.HexToAddress(operator.Address),
+			ApproverAddress: delegationApprover,
+			ApproverSalt:    approverSalt,
+			Expiry:          expiry,
+		}
+
+		response, err := read_clients.ElChainReader.CalculateDelegationApprovalDigestHash(
 			ctx,
-			staker,
-			common.HexToAddress(operator.Address),
-			delegationApprover,
-			approverSalt,
-			expiry,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, digest)
+		assert.NotEmpty(t, response.DigestHash)
 	})
 
 	t.Run("calculate operator AVS registration digest hash", func(t *testing.T) {
@@ -898,14 +904,19 @@ func TestInvalidConfig(t *testing.T) {
 		approverSalt := [32]byte{}
 		expiry := big.NewInt(0)
 
+		request := elcontracts.CalculateDelegationApprovalDigestHashRequest{
+			StakerAddress:   staker,
+			OperatorAddress: common.HexToAddress(operatorAddr),
+			ApproverAddress: delegationApprover,
+			ApproverSalt:    approverSalt,
+			Expiry:          expiry,
+		}
+
 		// CalculateDelegationApprovalDigestHash needs a correct DelegationManagerAddress
 		_, err := chainReader.CalculateDelegationApprovalDigestHash(
 			context.Background(),
-			staker,
-			common.HexToAddress(operatorAddr),
-			delegationApprover,
-			approverSalt,
-			expiry,
+			nil,
+			request,
 		)
 		require.Error(t, err)
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -38,14 +38,14 @@ func TestChainReader(t *testing.T) {
 		operatorRequest := elcontracts.IsOperatorRegisteredRequest{
 			OperatorAddress: operatorAddrHex,
 		}
-		response, err := read_clients.ElChainReader.IsOperatorRegistered(ctx, nil, operatorRequest)
+		response, err := read_clients.ElChainReader.IsOperatorRegistered(ctx, operatorRequest)
 		assert.NoError(t, err)
 		assert.Equal(t, response.IsRegistered, true)
 	})
 
 	t.Run("get operator details", func(t *testing.T) {
 		request := elcontracts.GetOperatorDetailsRequest{OperatorAddress: operatorAddrHex}
-		response, err := read_clients.ElChainReader.GetOperatorDetails(ctx, nil, request)
+		response, err := read_clients.ElChainReader.GetOperatorDetails(ctx, request)
 		assert.NoError(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, operator.Address, response.OperatorAddress.String())
@@ -55,7 +55,6 @@ func TestChainReader(t *testing.T) {
 		request := elcontracts.GetStrategyAndUnderlyingTokenRequest{StrategyAddress: contractAddrs.Erc20MockStrategy}
 		response, err := read_clients.ElChainReader.GetStrategyAndUnderlyingToken(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -76,7 +75,6 @@ func TestChainReader(t *testing.T) {
 		}
 		response, err := read_clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -96,7 +94,6 @@ func TestChainReader(t *testing.T) {
 		}
 		response, err := read_clients.ElChainReader.GetOperatorSharesInStrategy(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -119,7 +116,6 @@ func TestChainReader(t *testing.T) {
 
 		response, err := read_clients.ElChainReader.CalculateDelegationApprovalDigestHash(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -138,7 +134,6 @@ func TestChainReader(t *testing.T) {
 		}
 		response, err := read_clients.ElChainReader.CalculateOperatorAVSRegistrationDigestHash(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -151,7 +146,6 @@ func TestChainReader(t *testing.T) {
 		}
 		response, err := read_clients.ElChainReader.GetStakerShares(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -170,7 +164,6 @@ func TestChainReader(t *testing.T) {
 		t.Logf("Request: %+v", request)
 		response, err := read_clients.ElChainReader.GetDelegatedOperator(
 			ctx,
-			nil,
 			request,
 		)
 
@@ -188,7 +181,6 @@ func TestChainReader(t *testing.T) {
 		}
 		response, err := read_clients.ElChainReader.GetOperatorShares(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -202,7 +194,6 @@ func TestChainReader(t *testing.T) {
 		}
 		response, err = read_clients.ElChainReader.GetOperatorShares(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -222,7 +213,6 @@ func TestChainReader(t *testing.T) {
 		}
 		response, err := read_clients.ElChainReader.GetOperatorsShares(
 			ctx,
-			nil,
 			request,
 		)
 		assert.NoError(t, err)
@@ -235,9 +225,7 @@ func TestChainReader(t *testing.T) {
 			StrategiesAddresses: mult_strategies,
 		}
 		response, err = read_clients.ElChainReader.GetOperatorsShares(
-			ctx,
-			nil,
-			request,
+			ctx, request,
 		)
 		assert.NoError(t, err)
 		assert.Len(t, response.Shares, 1)
@@ -250,9 +238,7 @@ func TestChainReader(t *testing.T) {
 			StrategiesAddresses: strategies,
 		}
 		response, err = read_clients.ElChainReader.GetOperatorsShares(
-			ctx,
-			nil,
-			request,
+			ctx, request,
 		)
 		assert.NoError(t, err)
 		assert.Len(t, response.Shares, 3)
@@ -264,9 +250,7 @@ func TestChainReader(t *testing.T) {
 			StrategiesAddresses: mult_strategies,
 		}
 		response, err = read_clients.ElChainReader.GetOperatorsShares(
-			ctx,
-			nil,
-			request,
+			ctx, request,
 		)
 		assert.NoError(t, err)
 		assert.Len(t, response.Shares, 3)
@@ -328,13 +312,15 @@ func TestGetCurrentClaimableDistributionRoot(t *testing.T) {
 
 	// Check that if there is no root submitted the result is zero
 	response, err := chainReader.GetCurrentClaimableDistributionRoot(
-		ctx,
-		nil,
+		ctx, elcontracts.GetCurrentClaimableDistributionRootRequest{},
 	)
 	assert.NoError(t, err)
 	assert.Zero(t, response.DistributionRoot.Root)
 
-	responseTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
+	responseTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(
+		context.Background(),
+		elcontracts.CurrRewardsCalculationEndTimestampRequest{},
+	)
 	require.NoError(t, err)
 
 	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, responseTimestamp.Timestamp+1)
@@ -346,7 +332,7 @@ func TestGetCurrentClaimableDistributionRoot(t *testing.T) {
 	// Check that if there is a root submitted the result is that root
 	response, err = chainReader.GetCurrentClaimableDistributionRoot(
 		ctx,
-		nil,
+		elcontracts.GetCurrentClaimableDistributionRootRequest{},
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, response.DistributionRoot.Root, root)
@@ -405,7 +391,7 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	// Check that if there is no root submitted the result is an InvalidRoot error
 	root_index, err := chainReader.GetRootIndexFromHash(
 		ctx,
-		nil,
+
 		elcontracts.GetRootIndexFromHashRequest{
 			RootHash: root,
 		},
@@ -413,7 +399,10 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	assert.Error(t, err)
 	assert.Zero(t, root_index)
 
-	response, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
+	response, err := chainReader.CurrRewardsCalculationEndTimestamp(
+		context.Background(),
+		elcontracts.CurrRewardsCalculationEndTimestampRequest{},
+	)
 	require.NoError(t, err)
 
 	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, response.Timestamp+1)
@@ -429,7 +418,10 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 		0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
 	}
 
-	response2, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
+	response2, err := chainReader.CurrRewardsCalculationEndTimestamp(
+		context.Background(),
+		elcontracts.CurrRewardsCalculationEndTimestampRequest{},
+	)
 	require.NoError(t, err)
 
 	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root2, response2.Timestamp+1)
@@ -441,7 +433,7 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	// Check that the first root inserted is the first indexed (zero)
 	responseHash, err := chainReader.GetRootIndexFromHash(
 		ctx,
-		nil,
+
 		elcontracts.GetRootIndexFromHashRequest{
 			RootHash: root,
 		},
@@ -452,7 +444,7 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	// Check that the second root inserted is the second indexed (zero)
 	responseHash, err = chainReader.GetRootIndexFromHash(
 		ctx,
-		nil,
+
 		elcontracts.GetRootIndexFromHashRequest{
 			RootHash: root2,
 		},
@@ -492,7 +484,7 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 	}
 	response, err := clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
 		ctx,
-		nil,
+
 		request,
 	)
 	assert.NoError(t, err)
@@ -505,7 +497,7 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 		ClaimerAddress: common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS),
 		TokenAddress:   response.UnderlyingTokenAddress,
 	}
-	responseClaimed, err := chainReader.GetCumulativeClaimed(ctx, nil, requestClaimed)
+	responseClaimed, err := chainReader.GetCumulativeClaimed(ctx, requestClaimed)
 	assert.Zero(t, responseClaimed.CumulativeClaimed.Cmp(big.NewInt(0)))
 	assert.NoError(t, err)
 
@@ -518,7 +510,7 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 	require.True(t, receipt.Status == gethtypes.ReceiptStatusSuccessful)
 
 	// This tests that with a claim result is cumulativeEarnings
-	responseClaimed, err = chainReader.GetCumulativeClaimed(ctx, nil, requestClaimed)
+	responseClaimed, err = chainReader.GetCumulativeClaimed(ctx, requestClaimed)
 	assert.Equal(t, responseClaimed.CumulativeClaimed, big.NewInt(cumulativeEarnings))
 	assert.NoError(t, err)
 }
@@ -562,7 +554,7 @@ func TestCheckClaim(t *testing.T) {
 	}
 	response, err := clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
 		ctx,
-		nil,
+
 		request,
 	)
 	assert.NoError(t, err)
@@ -573,7 +565,7 @@ func TestCheckClaim(t *testing.T) {
 	requestClaim := elcontracts.CheckClaimRequest{
 		Claim: *claim,
 	}
-	responseClaim, err := chainReader.CheckClaim(ctx, nil, requestClaim)
+	responseClaim, err := chainReader.CheckClaim(ctx, requestClaim)
 	require.NoError(t, err)
 	assert.True(t, responseClaim.IsValid)
 }
@@ -609,7 +601,7 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 		OperatorAddress:     operatorAddr,
 		StrategiesAddresses: strategies,
 	}
-	response, err := chainReader.GetMaxMagnitudes(ctx, nil, request)
+	response, err := chainReader.GetMaxMagnitudes(ctx, request)
 	assert.NoError(t, err)
 
 	// Assert that at the beginning, Allocatable Magnitude is Max allocatable magnitude
@@ -617,7 +609,7 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 		OperatorAddress: testAddr,
 		StrategyAddress: strategyAddr,
 	}
-	responseMag, err := chainReader.GetAllocatableMagnitude(ctx, nil, requestMag)
+	responseMag, err := chainReader.GetAllocatableMagnitude(ctx, requestMag)
 	assert.NoError(t, err)
 
 	assert.Equal(t, response.MaxMagnitudes[0], responseMag.AllocatableMagnitude)
@@ -639,7 +631,7 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 
 	// Check that Allocation delay has been applied
 	requestDelay := elcontracts.GetAllocationDelayRequest{OperatorAddress: operatorAddr}
-	_, err = chainReader.GetAllocationDelay(context.Background(), nil, requestDelay)
+	_, err = chainReader.GetAllocationDelay(context.Background(), requestDelay)
 	require.NoError(t, err)
 
 	err = createOperatorSet(anvilHttpEndpoint, privateKeyHex, testAddr, operatorSetId, strategyAddr)
@@ -664,14 +656,14 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 
 	// Assert that after stake reduction, Allocatable Magnitude + reduction ammount equals Max allocatable magnitude
 
-	responseMag, err = chainReader.GetAllocatableMagnitude(ctx, nil, requestMag)
+	responseMag, err = chainReader.GetAllocatableMagnitude(ctx, requestMag)
 	assert.NoError(t, err)
 	assert.Equal(t, response.MaxMagnitudes[0], responseMag.AllocatableMagnitude+allocatable_reduction)
 
 	// Check that the new allocationDelay is equal to delay
 	requestOp := elcontracts.GetOperatorDetailsRequest{OperatorAddress: operatorAddr}
 
-	responseOp, err := chainReader.GetOperatorDetails(ctx, nil, requestOp)
+	responseOp, err := chainReader.GetOperatorDetails(ctx, requestOp)
 	assert.NoError(t, err)
 	assert.NotNil(t, responseOp)
 	assert.Equal(t, request.OperatorAddress, responseOp.OperatorAddress)
@@ -713,7 +705,7 @@ func TestAdminFunctions(t *testing.T) {
 			AccountAddress:      operatorAddr,
 			PendingAdminAddress: pendingAdminAddr,
 		}
-		response, err := chainReader.IsPendingAdmin(context.Background(), nil, request)
+		response, err := chainReader.IsPendingAdmin(context.Background(), request)
 		assert.NoError(t, err)
 		assert.False(t, response.IsPendingAdmin)
 	})
@@ -722,7 +714,7 @@ func TestAdminFunctions(t *testing.T) {
 		request := elcontracts.ListPendingAdminsRequest{
 			AccountAddress: operatorAddr,
 		}
-		response, err := chainReader.ListPendingAdmins(context.Background(), nil, request)
+		response, err := chainReader.ListPendingAdmins(context.Background(), request)
 		assert.NoError(t, err)
 		assert.Empty(t, response.PendingAdmins)
 	})
@@ -742,14 +734,14 @@ func TestAdminFunctions(t *testing.T) {
 			AccountAddress:      operatorAddr,
 			PendingAdminAddress: pendingAdminAddr,
 		}
-		responsePending, err := chainReader.IsPendingAdmin(context.Background(), nil, requestPending)
+		responsePending, err := chainReader.IsPendingAdmin(context.Background(), requestPending)
 		assert.NoError(t, err)
 		assert.True(t, responsePending.IsPendingAdmin)
 
 		requestListPending := elcontracts.ListPendingAdminsRequest{
 			AccountAddress: operatorAddr,
 		}
-		responseList, err := chainReader.ListPendingAdmins(context.Background(), nil, requestListPending)
+		responseList, err := chainReader.ListPendingAdmins(context.Background(), requestListPending)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, responseList.PendingAdmins)
 	})
@@ -759,7 +751,7 @@ func TestAdminFunctions(t *testing.T) {
 			AccountAddress: operatorAddr,
 			AdminAddress:   pendingAdminAddr,
 		}
-		response, err := chainReader.IsAdmin(context.Background(), nil, request)
+		response, err := chainReader.IsAdmin(context.Background(), request)
 		assert.NoError(t, err)
 		assert.False(t, response.IsAdmin)
 	})
@@ -777,7 +769,7 @@ func TestAdminFunctions(t *testing.T) {
 		requestListAdmin := elcontracts.ListAdminsRequest{
 			AccountAddress: operatorAddr,
 		}
-		response, err := chainReader.ListAdmins(context.Background(), nil, requestListAdmin)
+		response, err := chainReader.ListAdmins(context.Background(), requestListAdmin)
 		assert.NoError(t, err)
 		assert.Len(t, response.Admins, 1)
 
@@ -786,7 +778,7 @@ func TestAdminFunctions(t *testing.T) {
 			AccountAddress: operatorAddr,
 			AdminAddress:   admin,
 		}
-		responseAdmin, err := chainReader.IsAdmin(context.Background(), nil, requestAdmin)
+		responseAdmin, err := chainReader.IsAdmin(context.Background(), requestAdmin)
 		assert.NoError(t, err)
 		assert.True(t, responseAdmin.IsAdmin)
 	})
@@ -824,7 +816,7 @@ func TestAppointeesFunctions(t *testing.T) {
 			Target:         target,
 			Select:         selector,
 		}
-		response, err := chainReader.ListAppointees(context.Background(), nil, request)
+		response, err := chainReader.ListAppointees(context.Background(), request)
 		assert.NoError(t, err)
 		assert.Empty(t, response.Appointees)
 	})
@@ -848,7 +840,7 @@ func TestAppointeesFunctions(t *testing.T) {
 			Target:           target,
 			Selector:         selector,
 		}
-		response, err := chainReader.CanCall(context.Background(), nil, request)
+		response, err := chainReader.CanCall(context.Background(), request)
 		require.NoError(t, err)
 		require.True(t, response.CanCall)
 
@@ -857,7 +849,7 @@ func TestAppointeesFunctions(t *testing.T) {
 			Target:         target,
 			Select:         selector,
 		}
-		responseAppointees, err := chainReader.ListAppointees(context.Background(), nil, requestAppointees)
+		responseAppointees, err := chainReader.ListAppointees(context.Background(), requestAppointees)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, responseAppointees.Appointees)
 	})
@@ -868,9 +860,7 @@ func TestAppointeesFunctions(t *testing.T) {
 			AppointeeAddress: appointeeAddress,
 		}
 		response, err := chainReader.ListAppointeePermissions(
-			context.Background(),
-			nil,
-			request,
+			context.Background(), request,
 		)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, response.AppointeeAddress)
@@ -900,9 +890,7 @@ func TestContractErrorCases(t *testing.T) {
 
 	t.Run("GetStrategyAndUnderlyingToken", func(t *testing.T) {
 		_, err := chainReader.GetStrategyAndUnderlyingToken(
-			ctx,
-			nil,
-			elcontracts.GetStrategyAndUnderlyingTokenRequest{},
+			ctx, elcontracts.GetStrategyAndUnderlyingTokenRequest{},
 		)
 		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "Failed to fetch token contract: no contract code at given address")
@@ -910,9 +898,7 @@ func TestContractErrorCases(t *testing.T) {
 
 	t.Run("GetStrategyAndUnderlyingERC20Token", func(t *testing.T) {
 		_, err := chainReader.GetStrategyAndUnderlyingERC20Token(
-			ctx,
-			nil,
-			elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{StrategyAddress: strategyAddr},
+			ctx, elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{StrategyAddress: strategyAddr},
 		)
 		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "Failed to fetch token contract: no contract code at given address")
@@ -943,13 +929,13 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("try to check if operator is registered with invalid config", func(t *testing.T) {
 		// IsOperatorRegistered needs a correct DelegationManagerAddress
-		_, err := chainReader.IsOperatorRegistered(context.Background(), nil, operatorRequest)
+		_, err := chainReader.IsOperatorRegistered(context.Background(), operatorRequest)
 		require.Error(t, err)
 	})
 
 	t.Run("get operator details with invalid config", func(t *testing.T) {
 		// GetOperatorDetails needs a correct DelegationManagerAddress
-		_, err := chainReader.GetOperatorDetails(context.Background(), nil, elcontracts.GetOperatorDetailsRequest{})
+		_, err := chainReader.GetOperatorDetails(context.Background(), elcontracts.GetOperatorDetailsRequest{})
 		require.Error(t, err)
 	})
 
@@ -959,13 +945,11 @@ func TestInvalidConfig(t *testing.T) {
 			AvsAddress:      common.MaxAddress,
 		}
 		_, err = chainReader.GetOperatorAVSSplit(
-			context.Background(),
-			nil,
-			request,
+			context.Background(), request,
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.GetOperatorPISplit(context.Background(), nil, elcontracts.GetOperatorPISplitRequest{})
+		_, err = chainReader.GetOperatorPISplit(context.Background(), elcontracts.GetOperatorPISplitRequest{})
 		require.Error(t, err)
 	})
 
@@ -980,20 +964,18 @@ func TestInvalidConfig(t *testing.T) {
 		}
 
 		// GetOperatorSharesInStrategy needs a correct DelegationManagerAddress
-		_, err := chainReader.GetOperatorSharesInStrategy(context.Background(), nil, requestShares)
+		_, err := chainReader.GetOperatorSharesInStrategy(context.Background(), requestShares)
 		require.Error(t, err)
 
 		// GetStrategyAndUnderlyingToken needs a correct StrategyAddress
 		request := elcontracts.GetStrategyAndUnderlyingTokenRequest{
 			StrategyAddress: strategyAddr,
 		}
-		_, err = chainReader.GetStrategyAndUnderlyingToken(context.Background(), nil, request)
+		_, err = chainReader.GetStrategyAndUnderlyingToken(context.Background(), request)
 		require.Error(t, err)
 
 		_, err = chainReader.GetStrategyAndUnderlyingERC20Token(
-			context.Background(),
-			nil,
-			elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{StrategyAddress: strategyAddr},
+			context.Background(), elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{StrategyAddress: strategyAddr},
 		)
 		require.Error(t, err)
 	})
@@ -1014,15 +996,13 @@ func TestInvalidConfig(t *testing.T) {
 
 		// CalculateDelegationApprovalDigestHash needs a correct DelegationManagerAddress
 		_, err := chainReader.CalculateDelegationApprovalDigestHash(
-			context.Background(),
-			nil,
-			request,
+			context.Background(), request,
 		)
 		require.Error(t, err)
 
 		// CalculateOperatorAVSRegistrationDigestHash needs a correct AvsDirectoryAddress
-		_, err = chainReader.CalculateOperatorAVSRegistrationDigestHash(context.Background(),
-			nil,
+		_, err = chainReader.CalculateOperatorAVSRegistrationDigestHash(
+			context.Background(),
 			elcontracts.CalculateOperatorAVSRegistrationDigestHashRequest{},
 		)
 		require.Error(t, err)
@@ -1030,14 +1010,20 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("get root with invalid config", func(t *testing.T) {
 		// GetDistributionRootsLength needs a correct RewardsCoordinatorAddress
-		_, err := chainReader.GetDistributionRootsLength(context.Background(), nil)
+		_, err := chainReader.GetDistributionRootsLength(
+			context.Background(),
+			elcontracts.GetDistributionRootsLengthRequest{},
+		)
 		require.Error(t, err)
 
 		// GetRootIndexFromHash needs a correct RewardsCoordinatorAddress
-		_, err = chainReader.GetRootIndexFromHash(context.Background(), nil, elcontracts.GetRootIndexFromHashRequest{})
+		_, err = chainReader.GetRootIndexFromHash(context.Background(), elcontracts.GetRootIndexFromHashRequest{})
 		require.Error(t, err)
 
-		_, err = chainReader.GetCurrentClaimableDistributionRoot(context.Background(), nil)
+		_, err = chainReader.GetCurrentClaimableDistributionRoot(
+			context.Background(),
+			elcontracts.GetCurrentClaimableDistributionRootRequest{},
+		)
 		require.Error(t, err)
 	})
 
@@ -1045,44 +1031,42 @@ func TestInvalidConfig(t *testing.T) {
 		// contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
 		// strategyAddr := contractAddrs.Erc20MockStrategy
 
-		_, err = chainReader.GetCurrentClaimableDistributionRoot(context.Background(), nil)
+		_, err = chainReader.GetCurrentClaimableDistributionRoot(
+			context.Background(),
+			elcontracts.GetCurrentClaimableDistributionRootRequest{},
+		)
 		require.Error(t, err)
 
 		_, err := chainReader.GetCumulativeClaimed(
-			context.Background(),
-			nil,
-			elcontracts.GetCumulativeClaimedRequest{},
+			context.Background(), elcontracts.GetCumulativeClaimedRequest{},
 		)
 		require.Error(t, err)
 
 		_, err = chainReader.GetMaxMagnitudes(
-			context.Background(),
-			nil,
-			elcontracts.GetMaxMagnitudes0Request{},
+			context.Background(), elcontracts.GetMaxMagnitudes0Request{},
 		)
 		require.Error(t, err)
 
 		_, err = chainReader.GetAllocatableMagnitude(
-			context.Background(),
-			nil,
-			elcontracts.GetAllocatableMagnitudeRequest{},
+			context.Background(), elcontracts.GetAllocatableMagnitudeRequest{},
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.GetAllocationInfo(context.Background(), nil, elcontracts.GetAllocationInfoRequest{})
+		_, err = chainReader.GetAllocationInfo(context.Background(), elcontracts.GetAllocationInfoRequest{})
 		require.Error(t, err)
 
-		_, err = chainReader.GetAllocationDelay(context.Background(), nil, elcontracts.GetAllocationDelayRequest{})
+		_, err = chainReader.GetAllocationDelay(context.Background(), elcontracts.GetAllocationDelayRequest{})
 		require.Error(t, err)
 
 		_, err = chainReader.CheckClaim(
-			context.Background(),
-			nil,
-			elcontracts.CheckClaimRequest{},
+			context.Background(), elcontracts.CheckClaimRequest{},
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
+		_, err = chainReader.CurrRewardsCalculationEndTimestamp(
+			context.Background(),
+			elcontracts.CurrRewardsCalculationEndTimestampRequest{},
+		)
 		require.Error(t, err)
 	})
 
@@ -1091,7 +1075,7 @@ func TestInvalidConfig(t *testing.T) {
 		request := elcontracts.GetStakerSharesRequest{
 			StakerAddress: common.HexToAddress(operator.Address),
 		}
-		_, err := chainReader.GetStakerShares(context.Background(), nil, request)
+		_, err := chainReader.GetStakerShares(context.Background(), request)
 		require.Error(t, err)
 	})
 
@@ -1099,7 +1083,6 @@ func TestInvalidConfig(t *testing.T) {
 		// GetDelegatedOperator needs a correct DelegationManagerAddress
 		_, err := chainReader.GetDelegatedOperator(
 			context.Background(),
-			big.NewInt(0),
 			elcontracts.GetDelegatedOperatorRequest{},
 		)
 		require.Error(t, err)
@@ -1108,9 +1091,7 @@ func TestInvalidConfig(t *testing.T) {
 	t.Run("try to get the number of operator sets for an operator with invalid config", func(t *testing.T) {
 		// GetNumOperatorSetsForOperator needs a correct AllocationManagerAddress
 		_, err := chainReader.GetNumOperatorSetsForOperator(
-			context.Background(),
-			nil,
-			elcontracts.GetNumOperatorSetsForOperatorRequest{},
+			context.Background(), elcontracts.GetNumOperatorSetsForOperatorRequest{},
 		)
 		require.Error(t, err)
 	})
@@ -1120,7 +1101,7 @@ func TestInvalidConfig(t *testing.T) {
 		request := elcontracts.GetOperatorSetsForOperatorRequest{
 			OperatorAddress: common.HexToAddress(operatorAddr),
 		}
-		_, err := chainReader.GetOperatorSetsForOperator(context.Background(), nil, request)
+		_, err := chainReader.GetOperatorSetsForOperator(context.Background(), request)
 		require.Error(t, err)
 	})
 
@@ -1139,7 +1120,7 @@ func TestInvalidConfig(t *testing.T) {
 			}
 			_, err := chainReader.IsOperatorRegisteredWithOperatorSet(
 				context.Background(),
-				nil,
+
 				request,
 			)
 			require.Error(t, err)
@@ -1161,7 +1142,7 @@ func TestInvalidConfig(t *testing.T) {
 			}
 			_, err := chainReader.IsOperatorRegisteredWithOperatorSet(
 				context.Background(),
-				nil,
+
 				request,
 			)
 			require.Error(t, err)
@@ -1182,7 +1163,7 @@ func TestInvalidConfig(t *testing.T) {
 			}
 			_, err := chainReader.GetOperatorsForOperatorSet(
 				context.Background(),
-				nil,
+
 				request,
 			)
 			require.Error(t, err)
@@ -1203,7 +1184,7 @@ func TestInvalidConfig(t *testing.T) {
 			}
 			_, err := chainReader.GetNumOperatorsForOperatorSet(
 				context.Background(),
-				nil,
+
 				request,
 			)
 			require.Error(t, err)
@@ -1224,7 +1205,7 @@ func TestInvalidConfig(t *testing.T) {
 			}
 			_, err := chainReader.GetStrategiesForOperatorSet(
 				context.Background(),
-				nil, request,
+				request,
 			)
 			require.Error(t, err)
 		},
@@ -1327,7 +1308,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 			request := elcontracts.GetStrategiesForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
-			response, err := chainReader.GetStrategiesForOperatorSet(context.Background(), nil, request)
+			response, err := chainReader.GetStrategiesForOperatorSet(context.Background(), request)
 			require.NoError(t, err)
 			require.Len(t, response.StrategiesAddresses, 1)
 			require.Equal(t, response.StrategiesAddresses[0].Hex(), strategyAddr.Hex())
@@ -1337,7 +1318,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 			request := elcontracts.GetRegisteredSetsRequest{
 				OperatorAddress: operatorAddr,
 			}
-			response, err := chainReader.GetRegisteredSets(context.Background(), nil, request)
+			response, err := chainReader.GetRegisteredSets(context.Background(), request)
 			require.NoError(t, err)
 			require.NotEmpty(t, response.OperatorSets)
 		})
@@ -1346,7 +1327,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 			request := elcontracts.GetOperatorSetsForOperatorRequest{
 				OperatorAddress: operatorAddr,
 			}
-			response, err := chainReader.GetOperatorSetsForOperator(context.Background(), nil, request)
+			response, err := chainReader.GetOperatorSetsForOperator(context.Background(), request)
 			require.NoError(t, err)
 			require.NotEmpty(t, response.OperatorSets)
 		})
@@ -1357,7 +1338,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 			}
 			response, err := chainReader.GetNumOperatorSetsForOperator(
 				context.Background(),
-				nil,
+
 				request,
 			)
 			require.NoError(t, err)
@@ -1368,7 +1349,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 			request := elcontracts.GetOperatorsForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
-			response, err := chainReader.GetOperatorsForOperatorSet(context.Background(), nil, request)
+			response, err := chainReader.GetOperatorsForOperatorSet(context.Background(), request)
 			require.NoError(t, err)
 			require.NotEmpty(t, response.Operators)
 		})
@@ -1377,7 +1358,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 			request := elcontracts.GetNumOperatorsForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
-			response, err := chainReader.GetNumOperatorsForOperatorSet(context.Background(), nil, request)
+			response, err := chainReader.GetNumOperatorsForOperatorSet(context.Background(), request)
 			require.NoError(t, err)
 			require.NotZero(t, response.NumOperators)
 		})
@@ -1392,7 +1373,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		t.Run("get slashable shares for single operator", func(t *testing.T) {
 			shares, err := chainReader.GetSlashableShares(
 				context.Background(),
-				receipt.BlockNumber,
+				// receipt.BlockNumber,
 				request,
 			)
 			require.NoError(t, err)
@@ -1405,7 +1386,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 			}
 			response, err := chainReader.GetSlashableSharesForOperatorSets(
 				context.Background(),
-				receipt.BlockNumber,
+				// receipt.BlockNumber,
 				request,
 			)
 			require.NoError(t, err)
@@ -1413,12 +1394,12 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get slashable shares before specific block", func(t *testing.T) {
-			request := elcontracts.GetSlashableSharesForOperatorSetsRequest{
+			request := elcontracts.GetSlashableSharesForOperatorSetsBeforeRequest{
 				OperatorSets: []allocationmanager.OperatorSet{operatorSet},
 			}
 			response, err := chainReader.GetSlashableSharesForOperatorSetsBefore(
 				context.Background(),
-				2,
+				// 2,
 				request,
 			)
 			require.NoError(t, err)
@@ -1447,19 +1428,19 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 		request := elcontracts.GetOperatorsForOperatorSetRequest{
 			OperatorSet: operatorSet,
 		}
-		_, err := chainReader.GetOperatorsForOperatorSet(ctx, nil, request)
+		_, err := chainReader.GetOperatorsForOperatorSet(ctx, request)
 		require.Error(t, err)
 
 		requestNumOps := elcontracts.GetNumOperatorsForOperatorSetRequest{
 			OperatorSet: operatorSet,
 		}
-		_, err = chainReader.GetNumOperatorsForOperatorSet(ctx, nil, requestNumOps)
+		_, err = chainReader.GetNumOperatorsForOperatorSet(ctx, requestNumOps)
 		require.Error(t, err)
 
 		requestStr := elcontracts.GetStrategiesForOperatorSetRequest{
 			OperatorSet: operatorSet,
 		}
-		_, err = chainReader.GetStrategiesForOperatorSet(ctx, nil, requestStr)
+		_, err = chainReader.GetStrategiesForOperatorSet(ctx, requestStr)
 		require.Error(t, err)
 
 		strategies := []common.Address{contractAddrs.Erc20MockStrategy}
@@ -1469,9 +1450,7 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 			StrategiesAddresses: strategies,
 		}
 		_, err = chainReader.GetSlashableShares(
-			ctx,
-			nil,
-			requestSlashable,
+			ctx, requestSlashable,
 		)
 		require.Error(t, err)
 	})
@@ -1485,11 +1464,11 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 		require.NoError(t, err)
 
 		operatorSets := []allocationmanager.OperatorSet{operatorSet}
-		request := elcontracts.GetSlashableSharesForOperatorSetsRequest{
+		request := elcontracts.GetSlashableSharesForOperatorSetsBeforeRequest{
 			OperatorSets: operatorSets,
 		}
 
-		_, err = chainReader.GetSlashableSharesForOperatorSetsBefore(context.Background(), 10, request)
+		_, err = chainReader.GetSlashableSharesForOperatorSetsBefore(context.Background(), request)
 		require.Error(t, err)
 	})
 }

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -44,7 +44,7 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get operator details", func(t *testing.T) {
-		request := elcontracts.GetOperatorDetailsRequest{OperatorAddress: operatorAddrHex}
+		request := elcontracts.OperatorDetailsRequest{OperatorAddress: operatorAddrHex}
 		response, err := read_clients.ElChainReader.GetOperatorDetails(ctx, request)
 		assert.NoError(t, err)
 		assert.NotNil(t, response)
@@ -52,7 +52,7 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get strategy and underlying token", func(t *testing.T) {
-		request := elcontracts.GetStrategyAndUnderlyingTokenRequest{StrategyAddress: contractAddrs.Erc20MockStrategy}
+		request := elcontracts.StrategyAndUnderlyingTokenRequest{StrategyAddress: contractAddrs.Erc20MockStrategy}
 		response, err := read_clients.ElChainReader.GetStrategyAndUnderlyingToken(
 			ctx,
 			request,
@@ -70,7 +70,7 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get strategy and underlying ERC20 token", func(t *testing.T) {
-		request := elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{
+		request := elcontracts.StrategyAndUnderlyingERC20TokenRequest{
 			StrategyAddress: contractAddrs.Erc20MockStrategy,
 		}
 		response, err := read_clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
@@ -88,7 +88,7 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get operator shares in strategy", func(t *testing.T) {
-		request := elcontracts.GetOperatorSharesInStrategyRequest{
+		request := elcontracts.OperatorSharesInStrategyRequest{
 			OperatorAddress: operatorAddrHex,
 			StrategyAddress: contractAddrs.Erc20MockStrategy,
 		}
@@ -141,7 +141,7 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get staker shares", func(t *testing.T) {
-		request := elcontracts.GetStakerSharesRequest{
+		request := elcontracts.StakerSharesRequest{
 			StakerAddress: common.HexToAddress(operator.Address),
 		}
 		response, err := read_clients.ElChainReader.GetStakerShares(
@@ -160,7 +160,7 @@ func TestChainReader(t *testing.T) {
 	})
 
 	t.Run("get delegated operator", func(t *testing.T) {
-		request := elcontracts.GetDelegatedOperatorRequest{StakerAddress: common.HexToAddress(operator.Address)}
+		request := elcontracts.DelegatedOperatorRequest{StakerAddress: common.HexToAddress(operator.Address)}
 		t.Logf("Request: %+v", request)
 		response, err := read_clients.ElChainReader.GetDelegatedOperator(
 			ctx,
@@ -175,7 +175,7 @@ func TestChainReader(t *testing.T) {
 	t.Run("GetOperatorShares", func(t *testing.T) {
 		strategyAddr := contractAddrs.Erc20MockStrategy
 		strategies := []common.Address{strategyAddr}
-		request := elcontracts.GetOperatorSharesRequest{
+		request := elcontracts.OperatorSharesRequest{
 			OperatorAddress:     operatorAddrHex,
 			StrategiesAddresses: strategies,
 		}
@@ -188,7 +188,7 @@ func TestChainReader(t *testing.T) {
 
 		// with n strategies, response's list length is n
 		strategies = []common.Address{strategyAddr, strategyAddr, strategyAddr}
-		request = elcontracts.GetOperatorSharesRequest{
+		request = elcontracts.OperatorSharesRequest{
 			OperatorAddress:     operatorAddrHex,
 			StrategiesAddresses: strategies,
 		}
@@ -207,7 +207,7 @@ func TestChainReader(t *testing.T) {
 		operators := []common.Address{operatorAddr}
 		strategyAddr := contractAddrs.Erc20MockStrategy
 		strategies := []common.Address{strategyAddr}
-		request := elcontracts.GetOperatorsSharesRequest{
+		request := elcontracts.OperatorsSharesRequest{
 			OperatorsAddresses:  operators,
 			StrategiesAddresses: strategies,
 		}
@@ -220,7 +220,7 @@ func TestChainReader(t *testing.T) {
 
 		// with n strategies, response's list length is [1][n]
 		mult_strategies := []common.Address{strategyAddr, strategyAddr, strategyAddr}
-		request = elcontracts.GetOperatorsSharesRequest{
+		request = elcontracts.OperatorsSharesRequest{
 			OperatorsAddresses:  operators,
 			StrategiesAddresses: mult_strategies,
 		}
@@ -233,7 +233,7 @@ func TestChainReader(t *testing.T) {
 
 		// with n strategies, response's list length is [n][1]
 		mult_operators := []common.Address{operatorAddr, operatorAddr, operatorAddr}
-		request = elcontracts.GetOperatorsSharesRequest{
+		request = elcontracts.OperatorsSharesRequest{
 			OperatorsAddresses:  mult_operators,
 			StrategiesAddresses: strategies,
 		}
@@ -245,7 +245,7 @@ func TestChainReader(t *testing.T) {
 		assert.Len(t, response.Shares[0], 1)
 
 		// with n strategies and n operators, response's list length is [n][n]
-		request = elcontracts.GetOperatorsSharesRequest{
+		request = elcontracts.OperatorsSharesRequest{
 			OperatorsAddresses:  mult_operators,
 			StrategiesAddresses: mult_strategies,
 		}
@@ -312,7 +312,7 @@ func TestGetCurrentClaimableDistributionRoot(t *testing.T) {
 
 	// Check that if there is no root submitted the result is zero
 	response, err := chainReader.GetCurrentClaimableDistributionRoot(
-		ctx, elcontracts.GetCurrentClaimableDistributionRootRequest{},
+		ctx, elcontracts.CurrentClaimableDistributionRootRequest{},
 	)
 	assert.NoError(t, err)
 	assert.Zero(t, response.DistributionRoot.Root)
@@ -332,7 +332,7 @@ func TestGetCurrentClaimableDistributionRoot(t *testing.T) {
 	// Check that if there is a root submitted the result is that root
 	response, err = chainReader.GetCurrentClaimableDistributionRoot(
 		ctx,
-		elcontracts.GetCurrentClaimableDistributionRootRequest{},
+		elcontracts.CurrentClaimableDistributionRootRequest{},
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, response.DistributionRoot.Root, root)
@@ -392,7 +392,7 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	root_index, err := chainReader.GetRootIndexFromHash(
 		ctx,
 
-		elcontracts.GetRootIndexFromHashRequest{
+		elcontracts.RootIndexFromHashRequest{
 			RootHash: root,
 		},
 	)
@@ -434,7 +434,7 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	responseHash, err := chainReader.GetRootIndexFromHash(
 		ctx,
 
-		elcontracts.GetRootIndexFromHashRequest{
+		elcontracts.RootIndexFromHashRequest{
 			RootHash: root,
 		},
 	)
@@ -445,7 +445,7 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	responseHash, err = chainReader.GetRootIndexFromHash(
 		ctx,
 
-		elcontracts.GetRootIndexFromHashRequest{
+		elcontracts.RootIndexFromHashRequest{
 			RootHash: root2,
 		},
 	)
@@ -479,7 +479,7 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, receipt.Status == gethtypes.ReceiptStatusSuccessful)
 
-	request := elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{
+	request := elcontracts.StrategyAndUnderlyingERC20TokenRequest{
 		StrategyAddress: contractAddrs.Erc20MockStrategy,
 	}
 	response, err := clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
@@ -493,7 +493,7 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 	assert.NotNil(t, response.ERC20Bindings)
 
 	// This tests that without claims result is zero
-	requestClaimed := elcontracts.GetCumulativeClaimedRequest{
+	requestClaimed := elcontracts.CumulativeClaimedRequest{
 		ClaimerAddress: common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS),
 		TokenAddress:   response.UnderlyingTokenAddress,
 	}
@@ -549,7 +549,7 @@ func TestCheckClaim(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, receipt.Status == gethtypes.ReceiptStatusSuccessful)
 
-	request := elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{
+	request := elcontracts.StrategyAndUnderlyingERC20TokenRequest{
 		StrategyAddress: contractAddrs.Erc20MockStrategy,
 	}
 	response, err := clients.ElChainReader.GetStrategyAndUnderlyingERC20Token(
@@ -597,7 +597,7 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	operatorSetId := uint32(1)
 
 	strategies := []common.Address{strategyAddr}
-	request := elcontracts.GetMaxMagnitudes0Request{
+	request := elcontracts.MaxMagnitudes0Request{
 		OperatorAddress:     operatorAddr,
 		StrategiesAddresses: strategies,
 	}
@@ -605,7 +605,7 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert that at the beginning, Allocatable Magnitude is Max allocatable magnitude
-	requestMag := elcontracts.GetAllocatableMagnitudeRequest{
+	requestMag := elcontracts.AllocatableMagnitudeRequest{
 		OperatorAddress: testAddr,
 		StrategyAddress: strategyAddr,
 	}
@@ -630,7 +630,7 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	testutils.AdvanceChainByNBlocksExecInContainer(context.Background(), allocationConfigurationDelay+1, anvilC)
 
 	// Check that Allocation delay has been applied
-	requestDelay := elcontracts.GetAllocationDelayRequest{OperatorAddress: operatorAddr}
+	requestDelay := elcontracts.AllocationDelayRequest{OperatorAddress: operatorAddr}
 	_, err = chainReader.GetAllocationDelay(context.Background(), requestDelay)
 	require.NoError(t, err)
 
@@ -661,7 +661,7 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	assert.Equal(t, response.MaxMagnitudes[0], responseMag.AllocatableMagnitude+allocatable_reduction)
 
 	// Check that the new allocationDelay is equal to delay
-	requestOp := elcontracts.GetOperatorDetailsRequest{OperatorAddress: operatorAddr}
+	requestOp := elcontracts.OperatorDetailsRequest{OperatorAddress: operatorAddr}
 
 	responseOp, err := chainReader.GetOperatorDetails(ctx, requestOp)
 	assert.NoError(t, err)
@@ -890,7 +890,7 @@ func TestContractErrorCases(t *testing.T) {
 
 	t.Run("GetStrategyAndUnderlyingToken", func(t *testing.T) {
 		_, err := chainReader.GetStrategyAndUnderlyingToken(
-			ctx, elcontracts.GetStrategyAndUnderlyingTokenRequest{},
+			ctx, elcontracts.StrategyAndUnderlyingTokenRequest{},
 		)
 		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "Failed to fetch token contract: no contract code at given address")
@@ -898,7 +898,7 @@ func TestContractErrorCases(t *testing.T) {
 
 	t.Run("GetStrategyAndUnderlyingERC20Token", func(t *testing.T) {
 		_, err := chainReader.GetStrategyAndUnderlyingERC20Token(
-			ctx, elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{StrategyAddress: strategyAddr},
+			ctx, elcontracts.StrategyAndUnderlyingERC20TokenRequest{StrategyAddress: strategyAddr},
 		)
 		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "Failed to fetch token contract: no contract code at given address")
@@ -935,12 +935,12 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("get operator details with invalid config", func(t *testing.T) {
 		// GetOperatorDetails needs a correct DelegationManagerAddress
-		_, err := chainReader.GetOperatorDetails(context.Background(), elcontracts.GetOperatorDetailsRequest{})
+		_, err := chainReader.GetOperatorDetails(context.Background(), elcontracts.OperatorDetailsRequest{})
 		require.Error(t, err)
 	})
 
 	t.Run("get operator avs", func(t *testing.T) {
-		request := elcontracts.GetOperatorAVSSplitRequest{
+		request := elcontracts.OperatorAVSSplitRequest{
 			OperatorAddress: common.HexToAddress(operatorAddr),
 			AvsAddress:      common.MaxAddress,
 		}
@@ -949,7 +949,7 @@ func TestInvalidConfig(t *testing.T) {
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.GetOperatorPISplit(context.Background(), elcontracts.GetOperatorPISplitRequest{})
+		_, err = chainReader.GetOperatorPISplit(context.Background(), elcontracts.OperatorPISplitRequest{})
 		require.Error(t, err)
 	})
 
@@ -958,7 +958,7 @@ func TestInvalidConfig(t *testing.T) {
 		strategyAddr := common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
 		operatorAddr := common.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
 
-		requestShares := elcontracts.GetOperatorSharesInStrategyRequest{
+		requestShares := elcontracts.OperatorSharesInStrategyRequest{
 			OperatorAddress: operatorAddr,
 			StrategyAddress: strategyAddr,
 		}
@@ -968,14 +968,14 @@ func TestInvalidConfig(t *testing.T) {
 		require.Error(t, err)
 
 		// GetStrategyAndUnderlyingToken needs a correct StrategyAddress
-		request := elcontracts.GetStrategyAndUnderlyingTokenRequest{
+		request := elcontracts.StrategyAndUnderlyingTokenRequest{
 			StrategyAddress: strategyAddr,
 		}
 		_, err = chainReader.GetStrategyAndUnderlyingToken(context.Background(), request)
 		require.Error(t, err)
 
 		_, err = chainReader.GetStrategyAndUnderlyingERC20Token(
-			context.Background(), elcontracts.GetStrategyAndUnderlyingERC20TokenRequest{StrategyAddress: strategyAddr},
+			context.Background(), elcontracts.StrategyAndUnderlyingERC20TokenRequest{StrategyAddress: strategyAddr},
 		)
 		require.Error(t, err)
 	})
@@ -1012,17 +1012,17 @@ func TestInvalidConfig(t *testing.T) {
 		// GetDistributionRootsLength needs a correct RewardsCoordinatorAddress
 		_, err := chainReader.GetDistributionRootsLength(
 			context.Background(),
-			elcontracts.GetDistributionRootsLengthRequest{},
+			elcontracts.DistributionRootsLengthRequest{},
 		)
 		require.Error(t, err)
 
 		// GetRootIndexFromHash needs a correct RewardsCoordinatorAddress
-		_, err = chainReader.GetRootIndexFromHash(context.Background(), elcontracts.GetRootIndexFromHashRequest{})
+		_, err = chainReader.GetRootIndexFromHash(context.Background(), elcontracts.RootIndexFromHashRequest{})
 		require.Error(t, err)
 
 		_, err = chainReader.GetCurrentClaimableDistributionRoot(
 			context.Background(),
-			elcontracts.GetCurrentClaimableDistributionRootRequest{},
+			elcontracts.CurrentClaimableDistributionRootRequest{},
 		)
 		require.Error(t, err)
 	})
@@ -1033,29 +1033,29 @@ func TestInvalidConfig(t *testing.T) {
 
 		_, err = chainReader.GetCurrentClaimableDistributionRoot(
 			context.Background(),
-			elcontracts.GetCurrentClaimableDistributionRootRequest{},
+			elcontracts.CurrentClaimableDistributionRootRequest{},
 		)
 		require.Error(t, err)
 
 		_, err := chainReader.GetCumulativeClaimed(
-			context.Background(), elcontracts.GetCumulativeClaimedRequest{},
+			context.Background(), elcontracts.CumulativeClaimedRequest{},
 		)
 		require.Error(t, err)
 
 		_, err = chainReader.GetMaxMagnitudes(
-			context.Background(), elcontracts.GetMaxMagnitudes0Request{},
+			context.Background(), elcontracts.MaxMagnitudes0Request{},
 		)
 		require.Error(t, err)
 
 		_, err = chainReader.GetAllocatableMagnitude(
-			context.Background(), elcontracts.GetAllocatableMagnitudeRequest{},
+			context.Background(), elcontracts.AllocatableMagnitudeRequest{},
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.GetAllocationInfo(context.Background(), elcontracts.GetAllocationInfoRequest{})
+		_, err = chainReader.GetAllocationInfo(context.Background(), elcontracts.AllocationInfoRequest{})
 		require.Error(t, err)
 
-		_, err = chainReader.GetAllocationDelay(context.Background(), elcontracts.GetAllocationDelayRequest{})
+		_, err = chainReader.GetAllocationDelay(context.Background(), elcontracts.AllocationDelayRequest{})
 		require.Error(t, err)
 
 		_, err = chainReader.CheckClaim(
@@ -1072,7 +1072,7 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("try to get a staker shares with invalid config", func(t *testing.T) {
 		// GetStakerShares needs a correct DelegationManagerAddress
-		request := elcontracts.GetStakerSharesRequest{
+		request := elcontracts.StakerSharesRequest{
 			StakerAddress: common.HexToAddress(operator.Address),
 		}
 		_, err := chainReader.GetStakerShares(context.Background(), request)
@@ -1083,7 +1083,7 @@ func TestInvalidConfig(t *testing.T) {
 		// GetDelegatedOperator needs a correct DelegationManagerAddress
 		_, err := chainReader.GetDelegatedOperator(
 			context.Background(),
-			elcontracts.GetDelegatedOperatorRequest{},
+			elcontracts.DelegatedOperatorRequest{},
 		)
 		require.Error(t, err)
 	})
@@ -1091,14 +1091,14 @@ func TestInvalidConfig(t *testing.T) {
 	t.Run("try to get the number of operator sets for an operator with invalid config", func(t *testing.T) {
 		// GetNumOperatorSetsForOperator needs a correct AllocationManagerAddress
 		_, err := chainReader.GetNumOperatorSetsForOperator(
-			context.Background(), elcontracts.GetNumOperatorSetsForOperatorRequest{},
+			context.Background(), elcontracts.NumOperatorSetsForOperatorRequest{},
 		)
 		require.Error(t, err)
 	})
 
 	t.Run("try to get the operator sets for an operator with invalid config", func(t *testing.T) {
 		// GetOperatorSetsForOperator needs a correct AllocationManagerAddress
-		request := elcontracts.GetOperatorSetsForOperatorRequest{
+		request := elcontracts.OperatorSetsForOperatorRequest{
 			OperatorAddress: common.HexToAddress(operatorAddr),
 		}
 		_, err := chainReader.GetOperatorSetsForOperator(context.Background(), request)
@@ -1158,7 +1158,7 @@ func TestInvalidConfig(t *testing.T) {
 				Avs: testAddr,
 				Id:  operatorSetId,
 			}
-			request := elcontracts.GetOperatorsForOperatorSetRequest{
+			request := elcontracts.OperatorsForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
 			_, err := chainReader.GetOperatorsForOperatorSet(
@@ -1179,7 +1179,7 @@ func TestInvalidConfig(t *testing.T) {
 				Avs: testAddr,
 				Id:  operatorSetId,
 			}
-			request := elcontracts.GetNumOperatorsForOperatorSetRequest{
+			request := elcontracts.NumOperatorsForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
 			_, err := chainReader.GetNumOperatorsForOperatorSet(
@@ -1200,7 +1200,7 @@ func TestInvalidConfig(t *testing.T) {
 				Avs: testAddr,
 				Id:  operatorSetId,
 			}
-			request := elcontracts.GetStrategiesForOperatorSetRequest{
+			request := elcontracts.StrategiesForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
 			_, err := chainReader.GetStrategiesForOperatorSet(
@@ -1305,7 +1305,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 
 	t.Run("get operators and operator sets", func(t *testing.T) {
 		t.Run("validate strategies for operatorSet", func(t *testing.T) {
-			request := elcontracts.GetStrategiesForOperatorSetRequest{
+			request := elcontracts.StrategiesForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
 			response, err := chainReader.GetStrategiesForOperatorSet(context.Background(), request)
@@ -1315,7 +1315,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get registered sets", func(t *testing.T) {
-			request := elcontracts.GetRegisteredSetsRequest{
+			request := elcontracts.RegisteredSetsRequest{
 				OperatorAddress: operatorAddr,
 			}
 			response, err := chainReader.GetRegisteredSets(context.Background(), request)
@@ -1324,7 +1324,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get operator sets for operator", func(t *testing.T) {
-			request := elcontracts.GetOperatorSetsForOperatorRequest{
+			request := elcontracts.OperatorSetsForOperatorRequest{
 				OperatorAddress: operatorAddr,
 			}
 			response, err := chainReader.GetOperatorSetsForOperator(context.Background(), request)
@@ -1333,7 +1333,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get amount operatorSets for operator", func(t *testing.T) {
-			request := elcontracts.GetNumOperatorSetsForOperatorRequest{
+			request := elcontracts.NumOperatorSetsForOperatorRequest{
 				OperatorAddress: operatorAddr,
 			}
 			response, err := chainReader.GetNumOperatorSetsForOperator(
@@ -1346,7 +1346,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get operator for operatorsets", func(t *testing.T) {
-			request := elcontracts.GetOperatorsForOperatorSetRequest{
+			request := elcontracts.OperatorsForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
 			response, err := chainReader.GetOperatorsForOperatorSet(context.Background(), request)
@@ -1355,7 +1355,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get amount of operators for operatorsets", func(t *testing.T) {
-			request := elcontracts.GetNumOperatorsForOperatorSetRequest{
+			request := elcontracts.NumOperatorsForOperatorSetRequest{
 				OperatorSet: operatorSet,
 			}
 			response, err := chainReader.GetNumOperatorsForOperatorSet(context.Background(), request)
@@ -1365,7 +1365,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 	})
 
 	t.Run("slashable shares tests", func(t *testing.T) {
-		request := elcontracts.GetSlashableSharesRequest{
+		request := elcontracts.SlashableSharesRequest{
 			OperatorAddress:     operatorAddr,
 			OperatorSet:         operatorSet,
 			StrategiesAddresses: strategies,
@@ -1381,7 +1381,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get slashable shares for multiple operatorSets", func(t *testing.T) {
-			request := elcontracts.GetSlashableSharesForOperatorSetsRequest{
+			request := elcontracts.SlashableSharesForOperatorSetsRequest{
 				OperatorSets: []allocationmanager.OperatorSet{operatorSet},
 			}
 			response, err := chainReader.GetSlashableSharesForOperatorSets(
@@ -1394,7 +1394,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get slashable shares before specific block", func(t *testing.T) {
-			request := elcontracts.GetSlashableSharesForOperatorSetsBeforeRequest{
+			request := elcontracts.SlashableSharesForOperatorSetsBeforeRequest{
 				OperatorSets: []allocationmanager.OperatorSet{operatorSet},
 			}
 			response, err := chainReader.GetSlashableSharesForOperatorSetsBefore(
@@ -1425,26 +1425,26 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("test operator set with invalid id", func(t *testing.T) {
-		request := elcontracts.GetOperatorsForOperatorSetRequest{
+		request := elcontracts.OperatorsForOperatorSetRequest{
 			OperatorSet: operatorSet,
 		}
 		_, err := chainReader.GetOperatorsForOperatorSet(ctx, request)
 		require.Error(t, err)
 
-		requestNumOps := elcontracts.GetNumOperatorsForOperatorSetRequest{
+		requestNumOps := elcontracts.NumOperatorsForOperatorSetRequest{
 			OperatorSet: operatorSet,
 		}
 		_, err = chainReader.GetNumOperatorsForOperatorSet(ctx, requestNumOps)
 		require.Error(t, err)
 
-		requestStr := elcontracts.GetStrategiesForOperatorSetRequest{
+		requestStr := elcontracts.StrategiesForOperatorSetRequest{
 			OperatorSet: operatorSet,
 		}
 		_, err = chainReader.GetStrategiesForOperatorSet(ctx, requestStr)
 		require.Error(t, err)
 
 		strategies := []common.Address{contractAddrs.Erc20MockStrategy}
-		requestSlashable := elcontracts.GetSlashableSharesRequest{
+		requestSlashable := elcontracts.SlashableSharesRequest{
 			OperatorAddress:     operatorAddr,
 			OperatorSet:         operatorSet,
 			StrategiesAddresses: strategies,
@@ -1464,7 +1464,7 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 		require.NoError(t, err)
 
 		operatorSets := []allocationmanager.OperatorSet{operatorSet}
-		request := elcontracts.GetSlashableSharesForOperatorSetsBeforeRequest{
+		request := elcontracts.SlashableSharesForOperatorSetsBeforeRequest{
 			OperatorSets: operatorSets,
 		}
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -1289,9 +1289,12 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get registered sets", func(t *testing.T) {
-			registeredSets, err := chainReader.GetRegisteredSets(context.Background(), operatorAddr)
+			request := elcontracts.GetRegisteredSetsRequest{
+				OperatorAddress: operatorAddr,
+			}
+			response, err := chainReader.GetRegisteredSets(context.Background(), nil, request)
 			require.NoError(t, err)
-			require.NotEmpty(t, registeredSets)
+			require.NotEmpty(t, response.OperatorSets)
 		})
 
 		t.Run("get operator sets for operator", func(t *testing.T) {

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -216,45 +216,61 @@ func TestChainReader(t *testing.T) {
 		operators := []common.Address{operatorAddr}
 		strategyAddr := contractAddrs.Erc20MockStrategy
 		strategies := []common.Address{strategyAddr}
-		shares, err := read_clients.ElChainReader.GetOperatorsShares(
+		request := elcontracts.GetOperatorsSharesRequest{
+			OperatorsAddresses:  operators,
+			StrategiesAddresses: strategies,
+		}
+		response, err := read_clients.ElChainReader.GetOperatorsShares(
 			ctx,
-			operators,
-			strategies,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, shares, 1)
+		assert.Len(t, response.Shares, 1)
 
 		// with n strategies, response's list length is [1][n]
 		mult_strategies := []common.Address{strategyAddr, strategyAddr, strategyAddr}
-		shares, err = read_clients.ElChainReader.GetOperatorsShares(
+		request = elcontracts.GetOperatorsSharesRequest{
+			OperatorsAddresses:  operators,
+			StrategiesAddresses: mult_strategies,
+		}
+		response, err = read_clients.ElChainReader.GetOperatorsShares(
 			ctx,
-			operators,
-			mult_strategies,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, shares, 1)
-		assert.Len(t, shares[0], 3)
+		assert.Len(t, response.Shares, 1)
+		assert.Len(t, response.Shares[0], 3)
 
 		// with n strategies, response's list length is [n][1]
 		mult_operators := []common.Address{operatorAddr, operatorAddr, operatorAddr}
-		shares, err = read_clients.ElChainReader.GetOperatorsShares(
+		request = elcontracts.GetOperatorsSharesRequest{
+			OperatorsAddresses:  mult_operators,
+			StrategiesAddresses: strategies,
+		}
+		response, err = read_clients.ElChainReader.GetOperatorsShares(
 			ctx,
-			mult_operators,
-			strategies,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, shares, 3)
-		assert.Len(t, shares[0], 1)
+		assert.Len(t, response.Shares, 3)
+		assert.Len(t, response.Shares[0], 1)
 
 		// with n strategies and n operators, response's list length is [n][n]
-		shares, err = read_clients.ElChainReader.GetOperatorsShares(
+		request = elcontracts.GetOperatorsSharesRequest{
+			OperatorsAddresses:  mult_operators,
+			StrategiesAddresses: mult_strategies,
+		}
+		response, err = read_clients.ElChainReader.GetOperatorsShares(
 			ctx,
-			mult_operators,
-			mult_strategies,
+			nil,
+			request,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, shares, 3)
-		assert.Len(t, shares[2], 3)
+		assert.Len(t, response.Shares, 3)
+		assert.Len(t, response.Shares[2], 3)
 	})
 }
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -934,7 +934,7 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("get root with invalid config", func(t *testing.T) {
 		// GetDistributionRootsLength needs a correct RewardsCoordinatorAddress
-		_, err := chainReader.GetDistributionRootsLength(context.Background())
+		_, err := chainReader.GetDistributionRootsLength(context.Background(), nil)
 		require.Error(t, err)
 
 		// GetRootIndexFromHash needs a correct RewardsCoordinatorAddress

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -581,14 +581,18 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	operatorSetId := uint32(1)
 
 	strategies := []common.Address{strategyAddr}
-	maxMagnitudes, err := chainReader.GetMaxMagnitudes(ctx, testAddr, strategies)
+	request := elcontracts.GetMaxMagnitudes0Request{
+		OperatorAddress:     operatorAddr,
+		StrategiesAddresses: strategies,
+	}
+	response, err := chainReader.GetMaxMagnitudes(ctx, nil, request)
 	assert.NoError(t, err)
 
 	// Assert that at the beginning, Allocatable Magnitude is Max allocatable magnitude
 	allocable, err := chainReader.GetAllocatableMagnitude(ctx, testAddr, strategyAddr)
 	assert.NoError(t, err)
 
-	assert.Equal(t, maxMagnitudes[0], allocable)
+	assert.Equal(t, response.MaxMagnitudes[0], allocable)
 
 	// Reduce allocatable magnitude for testAddr
 	privateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
@@ -632,16 +636,16 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	// Assert that after stake reduction, Allocatable Magnitude + reduction ammount equals Max allocatable magnitude
 	allocable, err = chainReader.GetAllocatableMagnitude(ctx, testAddr, strategyAddr)
 	assert.NoError(t, err)
-	assert.Equal(t, maxMagnitudes[0], allocable+allocatable_reduction)
+	assert.Equal(t, response.MaxMagnitudes[0], allocable+allocatable_reduction)
 
 	// Check that the new allocationDelay is equal to delay
-	request := elcontracts.GetOperatorDetailsRequest{OperatorAddress: operatorAddr}
+	requestOp := elcontracts.GetOperatorDetailsRequest{OperatorAddress: operatorAddr}
 
-	response, err := chainReader.GetOperatorDetails(ctx, nil, request)
+	responseOp, err := chainReader.GetOperatorDetails(ctx, nil, requestOp)
 	assert.NoError(t, err)
-	assert.NotNil(t, response)
-	assert.Equal(t, request.OperatorAddress, response.OperatorAddress)
-	assert.Equal(t, delay, response.AllocationDelay)
+	assert.NotNil(t, responseOp)
+	assert.Equal(t, request.OperatorAddress, responseOp.OperatorAddress)
+	assert.Equal(t, delay, responseOp.AllocationDelay)
 }
 
 func TestAdminFunctions(t *testing.T) {
@@ -974,8 +978,8 @@ func TestInvalidConfig(t *testing.T) {
 
 		_, err = chainReader.GetMaxMagnitudes(
 			context.Background(),
-			common.HexToAddress(operatorAddr),
-			[]common.Address{strategyAddr},
+			nil,
+			elcontracts.GetMaxMagnitudes0Request{},
 		)
 		require.Error(t, err)
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -31,11 +31,14 @@ func TestChainReader(t *testing.T) {
 	operator := types.Operator{
 		Address: testutils.ANVIL_FIRST_ADDRESS,
 	}
+	operatorRequest := elcontracts.IsOperatorRegisteredRequest{
+		OperatorAddress: common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS),
+	}
 
 	t.Run("is operator registered", func(t *testing.T) {
-		isOperator, err := read_clients.ElChainReader.IsOperatorRegistered(ctx, operator)
+		response, err := read_clients.ElChainReader.IsOperatorRegistered(ctx, nil, operatorRequest)
 		assert.NoError(t, err)
-		assert.Equal(t, isOperator, true)
+		assert.Equal(t, response.IsRegistered, true)
 	})
 
 	t.Run("get operator details", func(t *testing.T) {
@@ -795,6 +798,9 @@ func TestInvalidConfig(t *testing.T) {
 	operator := types.Operator{
 		Address: operatorAddr,
 	}
+	operatorRequest := elcontracts.IsOperatorRegisteredRequest{
+		OperatorAddress: common.HexToAddress(operatorAddr),
+	}
 
 	config := elcontracts.Config{}
 	chainReader, err := testclients.NewTestChainReaderFromConfig(anvilHttpEndpoint, config)
@@ -802,7 +808,7 @@ func TestInvalidConfig(t *testing.T) {
 
 	t.Run("try to check if operator is registered with invalid config", func(t *testing.T) {
 		// IsOperatorRegistered needs a correct DelegationManagerAddress
-		_, err := chainReader.IsOperatorRegistered(context.Background(), operator)
+		_, err := chainReader.IsOperatorRegistered(context.Background(), nil, operatorRequest)
 		require.Error(t, err)
 	})
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -755,9 +755,13 @@ func TestAdminFunctions(t *testing.T) {
 	})
 
 	t.Run("non-existent admin", func(t *testing.T) {
-		isAdmin, err := chainReader.IsAdmin(context.Background(), operatorAddr, pendingAdminAddr)
+		request := elcontracts.IsAdminRequest{
+			AccountAddress: operatorAddr,
+			AdminAddress:   pendingAdminAddr,
+		}
+		response, err := chainReader.IsAdmin(context.Background(), nil, request)
 		assert.NoError(t, err)
-		assert.False(t, isAdmin)
+		assert.False(t, response.IsAdmin)
 	})
 
 	t.Run("list admins", func(t *testing.T) {
@@ -770,17 +774,21 @@ func TestAdminFunctions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 
-		requestAdmin := elcontracts.ListAdminsRequest{
+		requestListAdmin := elcontracts.ListAdminsRequest{
 			AccountAddress: operatorAddr,
 		}
-		response, err := chainReader.ListAdmins(context.Background(), nil, requestAdmin)
+		response, err := chainReader.ListAdmins(context.Background(), nil, requestListAdmin)
 		assert.NoError(t, err)
 		assert.Len(t, response.Admins, 1)
 
 		admin := response.Admins[0]
-		isAdmin, err := chainReader.IsAdmin(context.Background(), operatorAddr, admin)
+		requestAdmin := elcontracts.IsAdminRequest{
+			AccountAddress: operatorAddr,
+			AdminAddress:   admin,
+		}
+		responseAdmin, err := chainReader.IsAdmin(context.Background(), nil, requestAdmin)
 		assert.NoError(t, err)
-		assert.True(t, isAdmin)
+		assert.True(t, responseAdmin.IsAdmin)
 	})
 }
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -309,10 +309,10 @@ func TestGetCurrentClaimableDistributionRoot(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Zero(t, distr_root.Root)
 
-	currRewardsCalculationEndTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background())
+	response, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
 	require.NoError(t, err)
 
-	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, currRewardsCalculationEndTimestamp+1)
+	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, response.Timestamp+1)
 	require.NoError(t, err)
 
 	_, err = txManager.Send(context.Background(), tx, waitForReceipt)
@@ -387,10 +387,10 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 	)
 	assert.Zero(t, root_index)
 
-	currRewardsCalculationEndTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background())
+	response, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
 	require.NoError(t, err)
 
-	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, currRewardsCalculationEndTimestamp+1)
+	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, response.Timestamp+1)
 	require.NoError(t, err)
 
 	_, err = txManager.Send(context.Background(), tx, waitForReceipt)
@@ -403,10 +403,10 @@ func TestGetRootIndexFromRootHash(t *testing.T) {
 		0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
 	}
 
-	currRewardsCalculationEndTimestamp2, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background())
+	response2, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
 	require.NoError(t, err)
 
-	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root2, currRewardsCalculationEndTimestamp2+1)
+	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root2, response2.Timestamp+1)
 	require.NoError(t, err)
 
 	_, err = txManager.Send(context.Background(), tx, waitForReceipt)
@@ -985,7 +985,7 @@ func TestInvalidConfig(t *testing.T) {
 		)
 		require.Error(t, err)
 
-		_, err = chainReader.CurrRewardsCalculationEndTimestamp(context.Background())
+		_, err = chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
 		require.Error(t, err)
 	})
 

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -1143,9 +1143,13 @@ func TestInvalidConfig(t *testing.T) {
 				Avs: testAddr,
 				Id:  operatorSetId,
 			}
+			request := elcontracts.GetNumOperatorsForOperatorSetRequest{
+				OperatorSet: operatorSet,
+			}
 			_, err := chainReader.GetNumOperatorsForOperatorSet(
 				context.Background(),
-				operatorSet,
+				nil,
+				request,
 			)
 			require.Error(t, err)
 		},
@@ -1312,19 +1316,26 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		})
 
 		t.Run("get amount of operators for operatorsets", func(t *testing.T) {
-			operatorsCount, err := chainReader.GetNumOperatorsForOperatorSet(context.Background(), operatorSet)
+			request := elcontracts.GetNumOperatorsForOperatorSetRequest{
+				OperatorSet: operatorSet,
+			}
+			response, err := chainReader.GetNumOperatorsForOperatorSet(context.Background(), nil, request)
 			require.NoError(t, err)
-			require.NotZero(t, operatorsCount)
+			require.NotZero(t, response.NumOperators)
 		})
 	})
 
 	t.Run("slashable shares tests", func(t *testing.T) {
+		request := elcontracts.GetSlashableSharesRequest{
+			OperatorAddress:     operatorAddr,
+			OperatorSet:         operatorSet,
+			StrategiesAddresses: strategies,
+		}
 		t.Run("get slashable shares for single operator", func(t *testing.T) {
 			shares, err := chainReader.GetSlashableShares(
 				context.Background(),
-				operatorAddr,
-				operatorSet,
-				strategies,
+				receipt.BlockNumber,
+				request,
 			)
 			require.NoError(t, err)
 			require.NotEmpty(t, shares)
@@ -1374,7 +1385,10 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 		_, err := chainReader.GetOperatorsForOperatorSet(ctx, nil, request)
 		require.Error(t, err)
 
-		_, err = chainReader.GetNumOperatorsForOperatorSet(ctx, operatorSet)
+		requestNumOps := elcontracts.GetNumOperatorsForOperatorSetRequest{
+			OperatorSet: operatorSet,
+		}
+		_, err = chainReader.GetNumOperatorsForOperatorSet(ctx, nil, requestNumOps)
 		require.Error(t, err)
 
 		requestStr := elcontracts.GetStrategiesForOperatorSetRequest{
@@ -1384,12 +1398,15 @@ func TestOperatorSetsWithWrongInput(t *testing.T) {
 		require.Error(t, err)
 
 		strategies := []common.Address{contractAddrs.Erc20MockStrategy}
-
+		requestSlashable := elcontracts.GetSlashableSharesRequest{
+			OperatorAddress:     operatorAddr,
+			OperatorSet:         operatorSet,
+			StrategiesAddresses: strategies,
+		}
 		_, err = chainReader.GetSlashableShares(
 			ctx,
-			operatorAddr,
-			operatorSet,
-			strategies,
+			nil,
+			requestSlashable,
 		)
 		require.Error(t, err)
 	})

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -260,3 +260,20 @@ type GetNumOperatorSetsForOperatorRequest struct {
 type GetNumOperatorSetsForOperatorResponse struct {
 	NumOperatorSets *big.Int
 }
+
+type GetOperatorSetsForOperatorRequest struct {
+	OperatorAddress common.Address
+}
+
+type GetOperatorSetsForOperatorResponse struct {
+	OperatorSets []allocationmanager.OperatorSet
+}
+
+type IsOperatorRegisteredWithOperatorSetRequest struct {
+	OperatorAddress common.Address
+	OperatorSet     allocationmanager.OperatorSet
+}
+
+type IsOperatorRegisteredWithOperatorSetResponse struct {
+	IsRegistered bool
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -320,3 +320,12 @@ type GetSlashableSharesRequest struct {
 type GetSlashableSharesResponse struct {
 	SlashableShares map[common.Address]*big.Int
 }
+
+type GetAllocatableMagnitudeRequest struct {
+	OperatorAddress common.Address
+	StrategyAddress common.Address
+}
+
+type GetAllocatableMagnitudeResponse struct {
+	AllocatableMagnitude uint64
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -410,3 +410,12 @@ type IsPendingAdminRequest struct {
 type IsPendingAdminResponse struct {
 	IsPendingAdmin bool
 }
+
+type IsAdminRequest struct {
+	AccountAddress common.Address
+	AdminAddress   common.Address
+}
+
+type IsAdminResponse struct {
+	IsAdmin bool
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -183,3 +183,11 @@ type CurrRewardsCalculationEndTimestampResponse struct {
 type GetCurrentClaimableDistributionRootResponse struct {
 	DistributionRoot rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot
 }
+
+type GetRootIndexFromHashRequest struct {
+	RootHash [32]byte
+}
+
+type GetRootIndexFromHashResponse struct {
+	RootIndex uint32
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -277,3 +277,11 @@ type IsOperatorRegisteredWithOperatorSetRequest struct {
 type IsOperatorRegisteredWithOperatorSetResponse struct {
 	IsRegistered bool
 }
+
+type GetOperatorsForOperatorSetRequest struct {
+	OperatorSet allocationmanager.OperatorSet
+}
+
+type GetOperatorsForOperatorSetResponse struct {
+	Operators []common.Address
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -87,7 +87,7 @@ type RemovePendingAdminRequest struct {
 
 // Reader structs
 type IsOperatorRegisteredRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -96,7 +96,7 @@ type IsOperatorRegisteredResponse struct {
 }
 
 type StakerSharesRequest struct {
-	blockNumber   *big.Int
+	BlockNumber   *big.Int
 	StakerAddress common.Address
 }
 
@@ -106,7 +106,7 @@ type StakerSharesResponse struct {
 }
 
 type DelegatedOperatorRequest struct {
-	blockNumber   *big.Int
+	BlockNumber   *big.Int
 	StakerAddress common.Address
 }
 
@@ -115,7 +115,7 @@ type DelegatedOperatorResponse struct {
 }
 
 type OperatorDetailsRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -126,7 +126,7 @@ type OperatorDetailsResponse struct {
 }
 
 type StrategyAndUnderlyingTokenRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	StrategyAddress common.Address
 }
 
@@ -136,7 +136,7 @@ type StrategyAndUnderlyingTokenResponse struct {
 }
 
 type StrategyAndUnderlyingERC20TokenRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	StrategyAddress common.Address
 }
 
@@ -147,7 +147,7 @@ type StrategyAndUnderlyingERC20TokenResponse struct {
 }
 
 type OperatorSharesInStrategyRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
@@ -157,7 +157,7 @@ type OperatorSharesInStrategyResponse struct {
 }
 
 type CalculateDelegationApprovalDigestHashRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	StakerAddress   common.Address
 	ApproverAddress common.Address
@@ -170,7 +170,7 @@ type CalculateDelegationApprovalDigestHashResponse struct {
 }
 
 type CalculateOperatorAVSRegistrationDigestHashRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	AVSAddress      common.Address
 	Salt            [32]byte
@@ -182,7 +182,7 @@ type CalculateOperatorAVSRegistrationDigestHashResponse struct {
 }
 
 type DistributionRootsLengthRequest struct {
-	blockNumber *big.Int
+	BlockNumber *big.Int
 }
 
 type DistributionRootsLengthResponse struct {
@@ -190,7 +190,7 @@ type DistributionRootsLengthResponse struct {
 }
 
 type CurrRewardsCalculationEndTimestampRequest struct {
-	blockNumber *big.Int
+	BlockNumber *big.Int
 }
 
 type CurrRewardsCalculationEndTimestampResponse struct {
@@ -198,7 +198,7 @@ type CurrRewardsCalculationEndTimestampResponse struct {
 }
 
 type CurrentClaimableDistributionRootRequest struct {
-	blockNumber *big.Int
+	BlockNumber *big.Int
 }
 
 type CurrentClaimableDistributionRootResponse struct {
@@ -206,7 +206,7 @@ type CurrentClaimableDistributionRootResponse struct {
 }
 
 type RootIndexFromHashRequest struct {
-	blockNumber *big.Int
+	BlockNumber *big.Int
 	RootHash    [32]byte
 }
 
@@ -215,7 +215,7 @@ type RootIndexFromHashResponse struct {
 }
 
 type CumulativeClaimedRequest struct {
-	blockNumber    *big.Int
+	BlockNumber    *big.Int
 	ClaimerAddress common.Address
 	TokenAddress   common.Address
 }
@@ -225,7 +225,7 @@ type CumulativeClaimedResponse struct {
 }
 
 type CheckClaimRequest struct {
-	blockNumber *big.Int
+	BlockNumber *big.Int
 	Claim       rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
 }
 
@@ -234,7 +234,7 @@ type CheckClaimResponse struct {
 }
 
 type OperatorAVSSplitRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	AvsAddress      common.Address
 }
@@ -244,7 +244,7 @@ type OperatorAVSSplitResponse struct {
 }
 
 type OperatorPISplitRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -253,7 +253,7 @@ type OperatorPISplitResponse struct {
 }
 
 type MaxMagnitudes0Request struct {
-	blockNumber         *big.Int
+	BlockNumber         *big.Int
 	OperatorAddress     common.Address
 	StrategiesAddresses []common.Address
 }
@@ -263,7 +263,7 @@ type MaxMagnitudes0Response struct {
 }
 
 type AllocationInfoRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
@@ -273,7 +273,7 @@ type AllocationInfoResponse struct {
 }
 
 type OperatorSharesRequest struct {
-	blockNumber         *big.Int
+	BlockNumber         *big.Int
 	OperatorAddress     common.Address
 	StrategiesAddresses []common.Address
 }
@@ -283,7 +283,7 @@ type OperatorSharesResponse struct {
 }
 
 type OperatorsSharesRequest struct {
-	blockNumber         *big.Int
+	BlockNumber         *big.Int
 	OperatorsAddresses  []common.Address
 	StrategiesAddresses []common.Address
 }
@@ -293,7 +293,7 @@ type OperatorsSharesResponse struct {
 }
 
 type NumOperatorSetsForOperatorRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -302,7 +302,7 @@ type NumOperatorSetsForOperatorResponse struct {
 }
 
 type OperatorSetsForOperatorRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -311,7 +311,7 @@ type OperatorSetsForOperatorResponse struct {
 }
 
 type IsOperatorRegisteredWithOperatorSetRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	OperatorSet     allocationmanager.OperatorSet
 }
@@ -321,7 +321,7 @@ type IsOperatorRegisteredWithOperatorSetResponse struct {
 }
 
 type OperatorsForOperatorSetRequest struct {
-	blockNumber *big.Int
+	BlockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
@@ -330,7 +330,7 @@ type OperatorsForOperatorSetResponse struct {
 }
 
 type NumOperatorsForOperatorSetRequest struct {
-	blockNumber *big.Int
+	BlockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
@@ -339,7 +339,7 @@ type NumOperatorsForOperatorSetResponse struct {
 }
 
 type StrategiesForOperatorSetRequest struct {
-	blockNumber *big.Int
+	BlockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
@@ -348,7 +348,7 @@ type StrategiesForOperatorSetResponse struct {
 }
 
 type SlashableSharesRequest struct {
-	blockNumber         *big.Int
+	BlockNumber         *big.Int
 	OperatorAddress     common.Address
 	OperatorSet         allocationmanager.OperatorSet
 	StrategiesAddresses []common.Address
@@ -359,7 +359,7 @@ type SlashableSharesResponse struct {
 }
 
 type AllocatableMagnitudeRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
@@ -369,7 +369,7 @@ type AllocatableMagnitudeResponse struct {
 }
 
 type SlashableSharesForOperatorSetsRequest struct {
-	blockNumber  *big.Int
+	BlockNumber  *big.Int
 	OperatorSets []allocationmanager.OperatorSet
 }
 
@@ -378,7 +378,7 @@ type SlashableSharesForOperatorSetsResponse struct {
 }
 
 type SlashableSharesForOperatorSetsBeforeRequest struct {
-	blockNumber  *big.Int
+	BlockNumber  *big.Int
 	OperatorSets []allocationmanager.OperatorSet
 	FutureBlock  uint32
 }
@@ -388,7 +388,7 @@ type SlashableSharesForOperatorSetsBeforeResponse struct {
 }
 
 type AllocationDelayRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -397,7 +397,7 @@ type AllocationDelayResponse struct {
 }
 
 type RegisteredSetsRequest struct {
-	blockNumber     *big.Int
+	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -406,7 +406,7 @@ type RegisteredSetsResponse struct {
 }
 
 type CanCallRequest struct {
-	blockNumber      *big.Int
+	BlockNumber      *big.Int
 	AccountAddress   common.Address
 	AppointeeAddress common.Address
 	Target           common.Address
@@ -418,7 +418,7 @@ type CanCallResponse struct {
 }
 
 type ListAppointeesRequest struct {
-	blockNumber    *big.Int
+	BlockNumber    *big.Int
 	AccountAddress common.Address
 	Target         common.Address
 	Select         [4]byte
@@ -429,7 +429,7 @@ type ListAppointeesResponse struct {
 }
 
 type ListAppointeePermissionsRequest struct {
-	blockNumber      *big.Int
+	BlockNumber      *big.Int
 	AccountAddress   common.Address
 	AppointeeAddress common.Address
 }
@@ -440,7 +440,7 @@ type ListAppointeePermissionsResponse struct {
 }
 
 type ListPendingAdminsRequest struct {
-	blockNumber    *big.Int
+	BlockNumber    *big.Int
 	AccountAddress common.Address
 }
 
@@ -449,7 +449,7 @@ type ListPendingAdminsResponse struct {
 }
 
 type ListAdminsRequest struct {
-	blockNumber    *big.Int
+	BlockNumber    *big.Int
 	AccountAddress common.Address
 }
 
@@ -458,7 +458,7 @@ type ListAdminsResponse struct {
 }
 
 type IsPendingAdminRequest struct {
-	blockNumber         *big.Int
+	BlockNumber         *big.Int
 	AccountAddress      common.Address
 	PendingAdminAddress common.Address
 }
@@ -468,7 +468,7 @@ type IsPendingAdminResponse struct {
 }
 
 type IsAdminRequest struct {
-	blockNumber    *big.Int
+	BlockNumber    *big.Int
 	AccountAddress common.Address
 	AdminAddress   common.Address
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
+	strategy "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IStrategy"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -116,4 +117,13 @@ type GetOperatorDetailsResponse struct {
 	OperatorAddress           common.Address
 	DelegationApproverAddress common.Address
 	AllocationDelay           uint32
+}
+
+type GetStrategyAndUnderlyingTokenRequest struct {
+	StrategyAddress common.Address
+}
+
+type GetStrategyAndUnderlyingTokenResponse struct {
+	StrategyContract       *strategy.ContractIStrategy
+	UnderlyingTokenAddress common.Address
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -285,3 +285,11 @@ type GetOperatorsForOperatorSetRequest struct {
 type GetOperatorsForOperatorSetResponse struct {
 	Operators []common.Address
 }
+
+type GetStrategiesForOperatorSetRequest struct {
+	OperatorSet allocationmanager.OperatorSet
+}
+
+type GetStrategiesForOperatorSetResponse struct {
+	StrategiesAddresses []common.Address
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -286,10 +286,28 @@ type GetOperatorsForOperatorSetResponse struct {
 	Operators []common.Address
 }
 
+type GetNumOperatorsForOperatorSetRequest struct {
+	OperatorSet allocationmanager.OperatorSet
+}
+
+type GetNumOperatorsForOperatorSetResponse struct {
+	NumOperators *big.Int
+}
+
 type GetStrategiesForOperatorSetRequest struct {
 	OperatorSet allocationmanager.OperatorSet
 }
 
 type GetStrategiesForOperatorSetResponse struct {
 	StrategiesAddresses []common.Address
+}
+
+type GetSlashableSharesRequest struct {
+	OperatorAddress     common.Address
+	OperatorSet         allocationmanager.OperatorSet
+	StrategiesAddresses []common.Address
+}
+
+type GetSlashableSharesResponse struct {
+	SlashableShares map[common.Address]*big.Int
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -365,3 +365,13 @@ type CanCallRequest struct {
 type CanCallResponse struct {
 	CanCall bool
 }
+
+type ListAppointeesRequest struct {
+	AccountAddress common.Address
+	Target         common.Address
+	Select         [4]byte
+}
+
+type ListAppointeesResponse struct {
+	Appointees []common.Address
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
+	erc20 "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IERC20"
 	strategy "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IStrategy"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
@@ -125,5 +126,15 @@ type GetStrategyAndUnderlyingTokenRequest struct {
 
 type GetStrategyAndUnderlyingTokenResponse struct {
 	StrategyContract       *strategy.ContractIStrategy
+	UnderlyingTokenAddress common.Address
+}
+
+type GetStrategyAndUnderlyingERC20TokenRequest struct {
+	StrategyAddress common.Address
+}
+
+type GetStrategyAndUnderlyingERC20TokenResponse struct {
+	StrategyContract       *strategy.ContractIStrategy
+	ERC20Bindings          erc20.ContractIERC20Methods
 	UnderlyingTokenAddress common.Address
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -338,3 +338,11 @@ type GetSlashableSharesForOperatorSetsRequest struct {
 type GetSlashableSharesForOperatorSetsResponse struct {
 	OperatorSetStakes []OperatorSetStakes
 }
+
+type GetAllocationDelayRequest struct {
+	OperatorAddress common.Address
+}
+
+type GetAllocationDelayResponse struct {
+	AllocationDelay uint32
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -234,3 +234,12 @@ type GetAllocationInfoRequest struct {
 type GetAllocationInfoResponse struct {
 	AllocationInfo []AllocationInfo
 }
+
+type GetOperatorSharesRequest struct {
+	OperatorAddress     common.Address
+	StrategiesAddresses []common.Address
+}
+
+type GetOperatorSharesResponse struct {
+	Shares []*big.Int
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -138,3 +138,12 @@ type GetStrategyAndUnderlyingERC20TokenResponse struct {
 	ERC20Bindings          erc20.ContractIERC20Methods
 	UnderlyingTokenAddress common.Address
 }
+
+type GetOperatorSharesInStrategyRequest struct {
+	OperatorAddress common.Address
+	StrategyAddress common.Address
+}
+
+type GetOperatorSharesInStrategyResponse struct {
+	Shares *big.Int
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -174,3 +174,7 @@ type CalculateOperatorAVSRegistrationDigestHashResponse struct {
 type GetDistributionRootsLengthResponse struct {
 	Length *big.Int
 }
+
+type CurrRewardsCalculationEndTimestampResponse struct {
+	Timestamp uint32
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -393,3 +393,11 @@ type ListPendingAdminsRequest struct {
 type ListPendingAdminsResponse struct {
 	PendingAdmins []common.Address
 }
+
+type ListAdminsRequest struct {
+	AccountAddress common.Address
+}
+
+type ListAdminsResponse struct {
+	Admins []common.Address
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -200,3 +200,11 @@ type GetCumulativeClaimedRequest struct {
 type GetCumulativeClaimedResponse struct {
 	CumulativeClaimed *big.Int
 }
+
+type CheckClaimRequest struct {
+	Claim rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
+}
+
+type CheckClaimResponse struct {
+	IsValid bool
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -5,6 +5,7 @@ import (
 
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
 	erc20 "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IERC20"
+	rewardscoordinator "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IRewardsCoordinator"
 	strategy "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IStrategy"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
@@ -177,4 +178,8 @@ type GetDistributionRootsLengthResponse struct {
 
 type CurrRewardsCalculationEndTimestampResponse struct {
 	Timestamp uint32
+}
+
+type GetCurrentClaimableDistributionRootResponse struct {
+	DistributionRoot rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -382,6 +382,14 @@ type ListAppointeePermissionsRequest struct {
 }
 
 type ListAppointeePermissionsResponse struct {
-	AppinteeAddress []common.Address
-	Selector        [][4]byte
+	AppointeeAddress []common.Address
+	Selector         [][4]byte
+}
+
+type ListPendingAdminsRequest struct {
+	AccountAddress common.Address
+}
+
+type ListPendingAdminsResponse struct {
+	PendingAdmins []common.Address
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -147,3 +147,15 @@ type GetOperatorSharesInStrategyRequest struct {
 type GetOperatorSharesInStrategyResponse struct {
 	Shares *big.Int
 }
+
+type CalculateDelegationApprovalDigestHashRequest struct {
+	OperatorAddress common.Address
+	StakerAddress   common.Address
+	ApproverAddress common.Address
+	ApproverSalt    [32]byte
+	Expiry          *big.Int
+}
+
+type CalculateDelegationApprovalDigestHashResponse struct {
+	DigestHash [32]byte
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -329,3 +329,12 @@ type GetAllocatableMagnitudeRequest struct {
 type GetAllocatableMagnitudeResponse struct {
 	AllocatableMagnitude uint64
 }
+
+type GetSlashableSharesForOperatorSetsRequest struct {
+	OperatorSets []allocationmanager.OperatorSet
+}
+
+// Original struct was OperatorSetStakes
+type GetSlashableSharesForOperatorSetsResponse struct {
+	OperatorSetStakes []OperatorSetStakes
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -159,3 +159,14 @@ type CalculateDelegationApprovalDigestHashRequest struct {
 type CalculateDelegationApprovalDigestHashResponse struct {
 	DigestHash [32]byte
 }
+
+type CalculateOperatorAVSRegistrationDigestHashRequest struct {
+	OperatorAddress common.Address
+	AVSAddress      common.Address
+	Salt            [32]byte
+	Expiry          *big.Int
+}
+
+type CalculateOperatorAVSRegistrationDigestHashResponse struct {
+	DigestHash [32]byte
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -95,64 +95,64 @@ type IsOperatorRegisteredResponse struct {
 	IsRegistered bool
 }
 
-type GetStakerSharesRequest struct {
+type StakerSharesRequest struct {
 	blockNumber   *big.Int
 	StakerAddress common.Address
 }
 
-type GetStakerSharesResponse struct {
+type StakerSharesResponse struct {
 	StrategiesAddresses []common.Address
 	Shares              []*big.Int
 }
 
-type GetDelegatedOperatorRequest struct {
+type DelegatedOperatorRequest struct {
 	blockNumber   *big.Int
 	StakerAddress common.Address
 }
 
-type GetDelegatedOperatorResponse struct {
+type DelegatedOperatorResponse struct {
 	OperatorAddress common.Address
 }
 
-type GetOperatorDetailsRequest struct {
+type OperatorDetailsRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
-type GetOperatorDetailsResponse struct {
+type OperatorDetailsResponse struct {
 	OperatorAddress           common.Address
 	DelegationApproverAddress common.Address
 	AllocationDelay           uint32
 }
 
-type GetStrategyAndUnderlyingTokenRequest struct {
+type StrategyAndUnderlyingTokenRequest struct {
 	blockNumber     *big.Int
 	StrategyAddress common.Address
 }
 
-type GetStrategyAndUnderlyingTokenResponse struct {
+type StrategyAndUnderlyingTokenResponse struct {
 	StrategyContract       *strategy.ContractIStrategy
 	UnderlyingTokenAddress common.Address
 }
 
-type GetStrategyAndUnderlyingERC20TokenRequest struct {
+type StrategyAndUnderlyingERC20TokenRequest struct {
 	blockNumber     *big.Int
 	StrategyAddress common.Address
 }
 
-type GetStrategyAndUnderlyingERC20TokenResponse struct {
+type StrategyAndUnderlyingERC20TokenResponse struct {
 	StrategyContract       *strategy.ContractIStrategy
 	ERC20Bindings          erc20.ContractIERC20Methods
 	UnderlyingTokenAddress common.Address
 }
 
-type GetOperatorSharesInStrategyRequest struct {
+type OperatorSharesInStrategyRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
 
-type GetOperatorSharesInStrategyResponse struct {
+type OperatorSharesInStrategyResponse struct {
 	Shares *big.Int
 }
 
@@ -181,11 +181,11 @@ type CalculateOperatorAVSRegistrationDigestHashResponse struct {
 	DigestHash [32]byte
 }
 
-type GetDistributionRootsLengthRequest struct {
+type DistributionRootsLengthRequest struct {
 	blockNumber *big.Int
 }
 
-type GetDistributionRootsLengthResponse struct {
+type DistributionRootsLengthResponse struct {
 	Length *big.Int
 }
 
@@ -197,30 +197,30 @@ type CurrRewardsCalculationEndTimestampResponse struct {
 	Timestamp uint32
 }
 
-type GetCurrentClaimableDistributionRootRequest struct {
+type CurrentClaimableDistributionRootRequest struct {
 	blockNumber *big.Int
 }
 
-type GetCurrentClaimableDistributionRootResponse struct {
+type CurrentClaimableDistributionRootResponse struct {
 	DistributionRoot rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot
 }
 
-type GetRootIndexFromHashRequest struct {
+type RootIndexFromHashRequest struct {
 	blockNumber *big.Int
 	RootHash    [32]byte
 }
 
-type GetRootIndexFromHashResponse struct {
+type RootIndexFromHashResponse struct {
 	RootIndex uint32
 }
 
-type GetCumulativeClaimedRequest struct {
+type CumulativeClaimedRequest struct {
 	blockNumber    *big.Int
 	ClaimerAddress common.Address
 	TokenAddress   common.Address
 }
 
-type GetCumulativeClaimedResponse struct {
+type CumulativeClaimedResponse struct {
 	CumulativeClaimed *big.Int
 }
 
@@ -233,80 +233,80 @@ type CheckClaimResponse struct {
 	IsValid bool
 }
 
-type GetOperatorAVSSplitRequest struct {
+type OperatorAVSSplitRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 	AvsAddress      common.Address
 }
 
-type GetOperatorAVSSplitResponse struct {
+type OperatorAVSSplitResponse struct {
 	Split uint16
 }
 
-type GetOperatorPISplitRequest struct {
+type OperatorPISplitRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
-type GetOperatorPISplitResponse struct {
+type OperatorPISplitResponse struct {
 	Split uint16
 }
 
-type GetMaxMagnitudes0Request struct {
+type MaxMagnitudes0Request struct {
 	blockNumber         *big.Int
 	OperatorAddress     common.Address
 	StrategiesAddresses []common.Address
 }
 
-type GetMaxMagnitudes0Response struct {
+type MaxMagnitudes0Response struct {
 	MaxMagnitudes []uint64
 }
 
-type GetAllocationInfoRequest struct {
+type AllocationInfoRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
 
-type GetAllocationInfoResponse struct {
+type AllocationInfoResponse struct {
 	AllocationInfo []AllocationInfo
 }
 
-type GetOperatorSharesRequest struct {
+type OperatorSharesRequest struct {
 	blockNumber         *big.Int
 	OperatorAddress     common.Address
 	StrategiesAddresses []common.Address
 }
 
-type GetOperatorSharesResponse struct {
+type OperatorSharesResponse struct {
 	Shares []*big.Int
 }
 
-type GetOperatorsSharesRequest struct {
+type OperatorsSharesRequest struct {
 	blockNumber         *big.Int
 	OperatorsAddresses  []common.Address
 	StrategiesAddresses []common.Address
 }
 
-type GetOperatorsSharesResponse struct {
+type OperatorsSharesResponse struct {
 	Shares [][]*big.Int
 }
 
-type GetNumOperatorSetsForOperatorRequest struct {
+type NumOperatorSetsForOperatorRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
-type GetNumOperatorSetsForOperatorResponse struct {
+type NumOperatorSetsForOperatorResponse struct {
 	NumOperatorSets *big.Int
 }
 
-type GetOperatorSetsForOperatorRequest struct {
+type OperatorSetsForOperatorRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
-type GetOperatorSetsForOperatorResponse struct {
+type OperatorSetsForOperatorResponse struct {
 	OperatorSets []allocationmanager.OperatorSet
 }
 
@@ -320,89 +320,88 @@ type IsOperatorRegisteredWithOperatorSetResponse struct {
 	IsRegistered bool
 }
 
-type GetOperatorsForOperatorSetRequest struct {
+type OperatorsForOperatorSetRequest struct {
 	blockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
-type GetOperatorsForOperatorSetResponse struct {
+type OperatorsForOperatorSetResponse struct {
 	Operators []common.Address
 }
 
-type GetNumOperatorsForOperatorSetRequest struct {
+type NumOperatorsForOperatorSetRequest struct {
 	blockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
-type GetNumOperatorsForOperatorSetResponse struct {
+type NumOperatorsForOperatorSetResponse struct {
 	NumOperators *big.Int
 }
 
-type GetStrategiesForOperatorSetRequest struct {
+type StrategiesForOperatorSetRequest struct {
 	blockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
-type GetStrategiesForOperatorSetResponse struct {
+type StrategiesForOperatorSetResponse struct {
 	StrategiesAddresses []common.Address
 }
 
-type GetSlashableSharesRequest struct {
+type SlashableSharesRequest struct {
 	blockNumber         *big.Int
 	OperatorAddress     common.Address
 	OperatorSet         allocationmanager.OperatorSet
 	StrategiesAddresses []common.Address
 }
 
-type GetSlashableSharesResponse struct {
+type SlashableSharesResponse struct {
 	SlashableShares map[common.Address]*big.Int
 }
 
-type GetAllocatableMagnitudeRequest struct {
+type AllocatableMagnitudeRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
 
-type GetAllocatableMagnitudeResponse struct {
+type AllocatableMagnitudeResponse struct {
 	AllocatableMagnitude uint64
 }
 
-type GetSlashableSharesForOperatorSetsRequest struct {
+type SlashableSharesForOperatorSetsRequest struct {
 	blockNumber  *big.Int
 	OperatorSets []allocationmanager.OperatorSet
 }
 
-// Original struct was OperatorSetStakes
-type GetSlashableSharesForOperatorSetsResponse struct {
+type SlashableSharesForOperatorSetsResponse struct {
 	OperatorSetStakes []OperatorSetStakes
 }
 
-type GetSlashableSharesForOperatorSetsBeforeRequest struct {
+type SlashableSharesForOperatorSetsBeforeRequest struct {
 	blockNumber  *big.Int
 	OperatorSets []allocationmanager.OperatorSet
 	FutureBlock  uint32
 }
 
-type GetSlashableSharesForOperatorSetsBeforeResponse struct {
+type SlashableSharesForOperatorSetsBeforeResponse struct {
 	OperatorSetStakes []OperatorSetStakes
 }
 
-type GetAllocationDelayRequest struct {
+type AllocationDelayRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
-type GetAllocationDelayResponse struct {
+type AllocationDelayResponse struct {
 	AllocationDelay uint32
 }
 
-type GetRegisteredSetsRequest struct {
+type RegisteredSetsRequest struct {
 	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
-type GetRegisteredSetsResponse struct {
+type RegisteredSetsResponse struct {
 	OperatorSets []allocationmanager.OperatorSet
 }
 

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -225,3 +225,12 @@ type GetMaxMagnitudes0Request struct {
 type GetMaxMagnitudes0Response struct {
 	MaxMagnitudes []uint64
 }
+
+type GetAllocationInfoRequest struct {
+	OperatorAddress common.Address
+	StrategyAddress common.Address
+}
+
+type GetAllocationInfoResponse struct {
+	AllocationInfo []AllocationInfo
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -401,3 +401,12 @@ type ListAdminsRequest struct {
 type ListAdminsResponse struct {
 	Admins []common.Address
 }
+
+type IsPendingAdminRequest struct {
+	AccountAddress      common.Address
+	PendingAdminAddress common.Address
+}
+
+type IsPendingAdminResponse struct {
+	IsPendingAdmin bool
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -252,3 +252,11 @@ type GetOperatorsSharesRequest struct {
 type GetOperatorsSharesResponse struct {
 	Shares [][]*big.Int
 }
+
+type GetNumOperatorSetsForOperatorRequest struct {
+	OperatorAddress common.Address
+}
+
+type GetNumOperatorSetsForOperatorResponse struct {
+	NumOperatorSets *big.Int
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -90,3 +90,12 @@ type IsOperatorRegisteredRequest struct {
 type IsOperatorRegisteredResponse struct {
 	IsRegistered bool
 }
+
+type GetStakerSharesRequest struct {
+	StakerAddress common.Address
+}
+
+type GetStakerSharesResponse struct {
+	StrategiesAddresses []common.Address
+	Shares              []*big.Int
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -243,3 +243,12 @@ type GetOperatorSharesRequest struct {
 type GetOperatorSharesResponse struct {
 	Shares []*big.Int
 }
+
+type GetOperatorsSharesRequest struct {
+	OperatorsAddresses  []common.Address
+	StrategiesAddresses []common.Address
+}
+
+type GetOperatorsSharesResponse struct {
+	Shares [][]*big.Int
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -99,3 +99,11 @@ type GetStakerSharesResponse struct {
 	StrategiesAddresses []common.Address
 	Shares              []*big.Int
 }
+
+type GetDelegatedOperatorRequest struct {
+	StakerAddress common.Address
+}
+
+type GetDelegatedOperatorResponse struct {
+	OperatorAddress common.Address
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -81,3 +81,12 @@ type RemovePendingAdminRequest struct {
 	AdminAddress   common.Address
 	WaitForReceipt bool
 }
+
+// Reader structs
+type IsOperatorRegisteredRequest struct {
+	OperatorAddress common.Address
+}
+
+type IsOperatorRegisteredResponse struct {
+	IsRegistered bool
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -191,3 +191,12 @@ type GetRootIndexFromHashRequest struct {
 type GetRootIndexFromHashResponse struct {
 	RootIndex uint32
 }
+
+type GetCumulativeClaimedRequest struct {
+	ClaimerAddress common.Address
+	TokenAddress   common.Address
+}
+
+type GetCumulativeClaimedResponse struct {
+	CumulativeClaimed *big.Int
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -216,3 +216,12 @@ type GetOperatorAVSSplitRequest struct {
 type GetOperatorAVSSplitResponse struct {
 	Split uint16
 }
+
+type GetMaxMagnitudes0Request struct {
+	OperatorAddress     common.Address
+	StrategiesAddresses []common.Address
+}
+
+type GetMaxMagnitudes0Response struct {
+	MaxMagnitudes []uint64
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -346,3 +346,22 @@ type GetAllocationDelayRequest struct {
 type GetAllocationDelayResponse struct {
 	AllocationDelay uint32
 }
+
+type GetRegisteredSetsRequest struct {
+	OperatorAddress common.Address
+}
+
+type GetRegisteredSetsResponse struct {
+	OperatorSets []allocationmanager.OperatorSet
+}
+
+type CanCallRequest struct {
+	AccountAddress   common.Address
+	AppointeeAddress common.Address
+	Target           common.Address
+	Selector         [4]byte
+}
+
+type CanCallResponse struct {
+	CanCall bool
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -208,3 +208,11 @@ type CheckClaimRequest struct {
 type CheckClaimResponse struct {
 	IsValid bool
 }
+
+type GetOperatorAVSSplitRequest struct {
+	OperatorAddress common.Address
+}
+
+type GetOperatorAVSSplitResponse struct {
+	Split uint16
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -107,3 +107,13 @@ type GetDelegatedOperatorRequest struct {
 type GetDelegatedOperatorResponse struct {
 	OperatorAddress common.Address
 }
+
+type GetOperatorDetailsRequest struct {
+	OperatorAddress common.Address
+}
+
+type GetOperatorDetailsResponse struct {
+	OperatorAddress           common.Address
+	DelegationApproverAddress common.Address
+	AllocationDelay           uint32
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -211,9 +211,18 @@ type CheckClaimResponse struct {
 
 type GetOperatorAVSSplitRequest struct {
 	OperatorAddress common.Address
+	AvsAddress      common.Address
 }
 
 type GetOperatorAVSSplitResponse struct {
+	Split uint16
+}
+
+type GetOperatorPISplitRequest struct {
+	OperatorAddress common.Address
+}
+
+type GetOperatorPISplitResponse struct {
 	Split uint16
 }
 

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -170,3 +170,7 @@ type CalculateOperatorAVSRegistrationDigestHashRequest struct {
 type CalculateOperatorAVSRegistrationDigestHashResponse struct {
 	DigestHash [32]byte
 }
+
+type GetDistributionRootsLengthResponse struct {
+	Length *big.Int
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -375,3 +375,13 @@ type ListAppointeesRequest struct {
 type ListAppointeesResponse struct {
 	Appointees []common.Address
 }
+
+type ListAppointeePermissionsRequest struct {
+	AccountAddress   common.Address
+	AppointeeAddress common.Address
+}
+
+type ListAppointeePermissionsResponse struct {
+	AppinteeAddress []common.Address
+	Selector        [][4]byte
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -87,6 +87,7 @@ type RemovePendingAdminRequest struct {
 
 // Reader structs
 type IsOperatorRegisteredRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -95,6 +96,7 @@ type IsOperatorRegisteredResponse struct {
 }
 
 type GetStakerSharesRequest struct {
+	blockNumber   *big.Int
 	StakerAddress common.Address
 }
 
@@ -104,6 +106,7 @@ type GetStakerSharesResponse struct {
 }
 
 type GetDelegatedOperatorRequest struct {
+	blockNumber   *big.Int
 	StakerAddress common.Address
 }
 
@@ -112,6 +115,7 @@ type GetDelegatedOperatorResponse struct {
 }
 
 type GetOperatorDetailsRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -122,6 +126,7 @@ type GetOperatorDetailsResponse struct {
 }
 
 type GetStrategyAndUnderlyingTokenRequest struct {
+	blockNumber     *big.Int
 	StrategyAddress common.Address
 }
 
@@ -131,6 +136,7 @@ type GetStrategyAndUnderlyingTokenResponse struct {
 }
 
 type GetStrategyAndUnderlyingERC20TokenRequest struct {
+	blockNumber     *big.Int
 	StrategyAddress common.Address
 }
 
@@ -141,6 +147,7 @@ type GetStrategyAndUnderlyingERC20TokenResponse struct {
 }
 
 type GetOperatorSharesInStrategyRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
@@ -150,6 +157,7 @@ type GetOperatorSharesInStrategyResponse struct {
 }
 
 type CalculateDelegationApprovalDigestHashRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 	StakerAddress   common.Address
 	ApproverAddress common.Address
@@ -162,6 +170,7 @@ type CalculateDelegationApprovalDigestHashResponse struct {
 }
 
 type CalculateOperatorAVSRegistrationDigestHashRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 	AVSAddress      common.Address
 	Salt            [32]byte
@@ -172,12 +181,24 @@ type CalculateOperatorAVSRegistrationDigestHashResponse struct {
 	DigestHash [32]byte
 }
 
+type GetDistributionRootsLengthRequest struct {
+	blockNumber *big.Int
+}
+
 type GetDistributionRootsLengthResponse struct {
 	Length *big.Int
 }
 
+type CurrRewardsCalculationEndTimestampRequest struct {
+	blockNumber *big.Int
+}
+
 type CurrRewardsCalculationEndTimestampResponse struct {
 	Timestamp uint32
+}
+
+type GetCurrentClaimableDistributionRootRequest struct {
+	blockNumber *big.Int
 }
 
 type GetCurrentClaimableDistributionRootResponse struct {
@@ -185,7 +206,8 @@ type GetCurrentClaimableDistributionRootResponse struct {
 }
 
 type GetRootIndexFromHashRequest struct {
-	RootHash [32]byte
+	blockNumber *big.Int
+	RootHash    [32]byte
 }
 
 type GetRootIndexFromHashResponse struct {
@@ -193,6 +215,7 @@ type GetRootIndexFromHashResponse struct {
 }
 
 type GetCumulativeClaimedRequest struct {
+	blockNumber    *big.Int
 	ClaimerAddress common.Address
 	TokenAddress   common.Address
 }
@@ -202,7 +225,8 @@ type GetCumulativeClaimedResponse struct {
 }
 
 type CheckClaimRequest struct {
-	Claim rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
+	blockNumber *big.Int
+	Claim       rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
 }
 
 type CheckClaimResponse struct {
@@ -210,6 +234,7 @@ type CheckClaimResponse struct {
 }
 
 type GetOperatorAVSSplitRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 	AvsAddress      common.Address
 }
@@ -219,6 +244,7 @@ type GetOperatorAVSSplitResponse struct {
 }
 
 type GetOperatorPISplitRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -227,6 +253,7 @@ type GetOperatorPISplitResponse struct {
 }
 
 type GetMaxMagnitudes0Request struct {
+	blockNumber         *big.Int
 	OperatorAddress     common.Address
 	StrategiesAddresses []common.Address
 }
@@ -236,6 +263,7 @@ type GetMaxMagnitudes0Response struct {
 }
 
 type GetAllocationInfoRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
@@ -245,6 +273,7 @@ type GetAllocationInfoResponse struct {
 }
 
 type GetOperatorSharesRequest struct {
+	blockNumber         *big.Int
 	OperatorAddress     common.Address
 	StrategiesAddresses []common.Address
 }
@@ -254,6 +283,7 @@ type GetOperatorSharesResponse struct {
 }
 
 type GetOperatorsSharesRequest struct {
+	blockNumber         *big.Int
 	OperatorsAddresses  []common.Address
 	StrategiesAddresses []common.Address
 }
@@ -263,6 +293,7 @@ type GetOperatorsSharesResponse struct {
 }
 
 type GetNumOperatorSetsForOperatorRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -271,6 +302,7 @@ type GetNumOperatorSetsForOperatorResponse struct {
 }
 
 type GetOperatorSetsForOperatorRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -279,6 +311,7 @@ type GetOperatorSetsForOperatorResponse struct {
 }
 
 type IsOperatorRegisteredWithOperatorSetRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 	OperatorSet     allocationmanager.OperatorSet
 }
@@ -288,6 +321,7 @@ type IsOperatorRegisteredWithOperatorSetResponse struct {
 }
 
 type GetOperatorsForOperatorSetRequest struct {
+	blockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
@@ -296,6 +330,7 @@ type GetOperatorsForOperatorSetResponse struct {
 }
 
 type GetNumOperatorsForOperatorSetRequest struct {
+	blockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
@@ -304,6 +339,7 @@ type GetNumOperatorsForOperatorSetResponse struct {
 }
 
 type GetStrategiesForOperatorSetRequest struct {
+	blockNumber *big.Int
 	OperatorSet allocationmanager.OperatorSet
 }
 
@@ -312,6 +348,7 @@ type GetStrategiesForOperatorSetResponse struct {
 }
 
 type GetSlashableSharesRequest struct {
+	blockNumber         *big.Int
 	OperatorAddress     common.Address
 	OperatorSet         allocationmanager.OperatorSet
 	StrategiesAddresses []common.Address
@@ -322,6 +359,7 @@ type GetSlashableSharesResponse struct {
 }
 
 type GetAllocatableMagnitudeRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
@@ -331,6 +369,7 @@ type GetAllocatableMagnitudeResponse struct {
 }
 
 type GetSlashableSharesForOperatorSetsRequest struct {
+	blockNumber  *big.Int
 	OperatorSets []allocationmanager.OperatorSet
 }
 
@@ -339,7 +378,18 @@ type GetSlashableSharesForOperatorSetsResponse struct {
 	OperatorSetStakes []OperatorSetStakes
 }
 
+type GetSlashableSharesForOperatorSetsBeforeRequest struct {
+	blockNumber  *big.Int
+	OperatorSets []allocationmanager.OperatorSet
+	FutureBlock  uint32
+}
+
+type GetSlashableSharesForOperatorSetsBeforeResponse struct {
+	OperatorSetStakes []OperatorSetStakes
+}
+
 type GetAllocationDelayRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -348,6 +398,7 @@ type GetAllocationDelayResponse struct {
 }
 
 type GetRegisteredSetsRequest struct {
+	blockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
@@ -356,6 +407,7 @@ type GetRegisteredSetsResponse struct {
 }
 
 type CanCallRequest struct {
+	blockNumber      *big.Int
 	AccountAddress   common.Address
 	AppointeeAddress common.Address
 	Target           common.Address
@@ -367,6 +419,7 @@ type CanCallResponse struct {
 }
 
 type ListAppointeesRequest struct {
+	blockNumber    *big.Int
 	AccountAddress common.Address
 	Target         common.Address
 	Select         [4]byte
@@ -377,6 +430,7 @@ type ListAppointeesResponse struct {
 }
 
 type ListAppointeePermissionsRequest struct {
+	blockNumber      *big.Int
 	AccountAddress   common.Address
 	AppointeeAddress common.Address
 }
@@ -387,6 +441,7 @@ type ListAppointeePermissionsResponse struct {
 }
 
 type ListPendingAdminsRequest struct {
+	blockNumber    *big.Int
 	AccountAddress common.Address
 }
 
@@ -395,6 +450,7 @@ type ListPendingAdminsResponse struct {
 }
 
 type ListAdminsRequest struct {
+	blockNumber    *big.Int
 	AccountAddress common.Address
 }
 
@@ -403,6 +459,7 @@ type ListAdminsResponse struct {
 }
 
 type IsPendingAdminRequest struct {
+	blockNumber         *big.Int
 	AccountAddress      common.Address
 	PendingAdminAddress common.Address
 }
@@ -412,6 +469,7 @@ type IsPendingAdminResponse struct {
 }
 
 type IsAdminRequest struct {
+	blockNumber    *big.Int
 	AccountAddress common.Address
 	AdminAddress   common.Address
 }

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -246,7 +246,6 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 		StrategyAddress: strategyAddr,
 	}
 
-	// TODO: Review this function after finishing the refactor of the ChainReader
 	response, err := w.elChainReader.GetStrategyAndUnderlyingERC20Token(
 		ctx,
 		request,

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -32,8 +32,8 @@ import (
 type Reader interface {
 	GetStrategyAndUnderlyingERC20Token(
 		ctx context.Context,
-		request GetStrategyAndUnderlyingERC20TokenRequest,
-	) (GetStrategyAndUnderlyingERC20TokenResponse, error)
+		request StrategyAndUnderlyingERC20TokenRequest,
+	) (StrategyAndUnderlyingERC20TokenResponse, error)
 }
 
 type ChainWriter struct {
@@ -242,7 +242,7 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 		return nil, err
 	}
 
-	request := GetStrategyAndUnderlyingERC20TokenRequest{
+	request := StrategyAndUnderlyingERC20TokenRequest{
 		StrategyAddress: strategyAddr,
 	}
 

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -32,7 +32,6 @@ import (
 type Reader interface {
 	GetStrategyAndUnderlyingERC20Token(
 		ctx context.Context,
-		blockNumber *big.Int,
 		request GetStrategyAndUnderlyingERC20TokenRequest,
 	) (GetStrategyAndUnderlyingERC20TokenResponse, error)
 }
@@ -250,7 +249,6 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 	// TODO: Review this function after finishing the refactor of the ChainReader
 	response, err := w.elChainReader.GetStrategyAndUnderlyingERC20Token(
 		ctx,
-		nil,
 		request,
 	)
 	if err != nil {

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -187,13 +187,15 @@ func TestRegisterAndDeregisterFromOperatorSets(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
-		isRegistered, err := chainReader.IsOperatorRegisteredWithOperatorSet(
-			context.Background(),
-			operatorAddress,
-			operatorSet,
+		request := elcontracts.IsOperatorRegisteredWithOperatorSetRequest{
+			OperatorAddress: operatorAddress,
+			OperatorSet:     operatorSet,
+		}
+		response, err := chainReader.IsOperatorRegisteredWithOperatorSet(
+			context.Background(), nil, request,
 		)
 		require.NoError(t, err)
-		require.Equal(t, true, isRegistered)
+		require.Equal(t, true, response.IsRegistered)
 	})
 
 	t.Run("register operator for same operator set", func(t *testing.T) {
@@ -221,13 +223,17 @@ func TestRegisterAndDeregisterFromOperatorSets(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
-		isRegistered, err := chainReader.IsOperatorRegisteredWithOperatorSet(
+		request := elcontracts.IsOperatorRegisteredWithOperatorSetRequest{
+			OperatorAddress: operatorAddress,
+			OperatorSet:     operatorSet,
+		}
+		response, err := chainReader.IsOperatorRegisteredWithOperatorSet(
 			context.Background(),
-			operatorAddress,
-			operatorSet,
+			nil,
+			request,
 		)
 		require.NoError(t, err)
-		require.False(t, isRegistered)
+		require.False(t, response.IsRegistered)
 	})
 
 	t.Run("deregister operator from operator set when not registered", func(t *testing.T) {

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -1217,7 +1217,7 @@ func newTestClaim(
 	earnerTreeRoot := crypto.Keccak256(encodedEarnerLeaf)
 
 	// Fetch the next root index from contract
-	nextRootIndex, err := chainReader.GetDistributionRootsLength(context.Background())
+	response, err := chainReader.GetDistributionRootsLength(context.Background(), nil)
 	if err != nil {
 		return nil, utils.WrapError("Failed to call GetDistributionRootsLength", err)
 	}
@@ -1225,7 +1225,7 @@ func newTestClaim(
 	tokenLeaves := []rewardscoordinator.IRewardsCoordinatorTypesTokenTreeMerkleLeaf{tokenLeaf}
 	// Construct the claim
 	claim := rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim{
-		RootIndex:   uint32(nextRootIndex.Uint64()),
+		RootIndex:   uint32(response.Length.Uint64()),
 		EarnerIndex: 0,
 		// Empty proof because leaf == root
 		EarnerTreeProof: []byte{},

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -192,7 +192,7 @@ func TestRegisterAndDeregisterFromOperatorSets(t *testing.T) {
 			OperatorSet:     operatorSet,
 		}
 		response, err := chainReader.IsOperatorRegisteredWithOperatorSet(
-			context.Background(), nil, request,
+			context.Background(), request,
 		)
 		require.NoError(t, err)
 		require.Equal(t, true, response.IsRegistered)
@@ -229,7 +229,7 @@ func TestRegisterAndDeregisterFromOperatorSets(t *testing.T) {
 		}
 		response, err := chainReader.IsOperatorRegisteredWithOperatorSet(
 			context.Background(),
-			nil,
+
 			request,
 		)
 		require.NoError(t, err)
@@ -382,7 +382,7 @@ func TestSetOperatorPISplit(t *testing.T) {
 	request := elcontracts.GetOperatorPISplitRequest{
 		OperatorAddress: operatorAddr,
 	}
-	response, err := chainReader.GetOperatorPISplit(context.Background(), nil, request)
+	response, err := chainReader.GetOperatorPISplit(context.Background(), request)
 	require.NoError(t, err)
 	require.Equal(t, expectedInitialSplit, response.Split)
 
@@ -393,7 +393,7 @@ func TestSetOperatorPISplit(t *testing.T) {
 	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
 	// Retrieve the operator PI split to check it has been set
-	response, err = chainReader.GetOperatorPISplit(context.Background(), nil, request)
+	response, err = chainReader.GetOperatorPISplit(context.Background(), request)
 	require.NoError(t, err)
 	require.Equal(t, newSplit, response.Split)
 
@@ -442,7 +442,7 @@ func TestSetOperatorAVSSplit(t *testing.T) {
 		OperatorAddress: operatorAddr,
 		AvsAddress:      avsAddr,
 	}
-	response, err := chainReader.GetOperatorAVSSplit(context.Background(), nil, request)
+	response, err := chainReader.GetOperatorAVSSplit(context.Background(), request)
 	require.NoError(t, err)
 	require.Equal(t, expectedInitialSplit, response.Split)
 
@@ -459,7 +459,7 @@ func TestSetOperatorAVSSplit(t *testing.T) {
 	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
 	// Retrieve the operator AVS split to check it has been set
-	response, err = chainReader.GetOperatorAVSSplit(context.Background(), nil, request)
+	response, err = chainReader.GetOperatorAVSSplit(context.Background(), request)
 	require.NoError(t, err)
 	require.Equal(t, newSplit, response.Split)
 
@@ -572,7 +572,7 @@ func TestSetAndRemovePermission(t *testing.T) {
 			Target:           target,
 			Selector:         selector,
 		}
-		response, err := chainReader.CanCall(context.Background(), nil, request)
+		response, err := chainReader.CanCall(context.Background(), request)
 		require.NoError(t, err)
 		require.True(t, response.CanCall)
 	})
@@ -593,7 +593,7 @@ func TestSetAndRemovePermission(t *testing.T) {
 			Target:           target,
 			Selector:         selector,
 		}
-		response, err := chainReader.CanCall(context.Background(), nil, request)
+		response, err := chainReader.CanCall(context.Background(), request)
 		require.NoError(t, err)
 		require.False(t, response.CanCall)
 	})
@@ -661,7 +661,7 @@ func TestModifyAllocations(t *testing.T) {
 	request := elcontracts.GetAllocationDelayRequest{
 		OperatorAddress: operatorAddr,
 	}
-	_, err = chainReader.GetAllocationDelay(context.Background(), nil, request)
+	_, err = chainReader.GetAllocationDelay(context.Background(), request)
 	require.NoError(t, err)
 
 	err = createOperatorSet(anvilHttpEndpoint, privateKeyHex, avsAddr, operatorSetId, strategyAddr)
@@ -676,19 +676,19 @@ func TestModifyAllocations(t *testing.T) {
 		OperatorAddress: operatorAddr,
 		StrategyAddress: strategyAddr,
 	}
-	response, err := chainReader.GetAllocationInfo(context.Background(), nil, requestAllocInfo)
+	response, err := chainReader.GetAllocationInfo(context.Background(), requestAllocInfo)
 	require.NoError(t, err)
 	pendingDiff := response.AllocationInfo[0].PendingDiff
 	require.Equal(t, big.NewInt(int64(newAllocation)), pendingDiff)
 	require.Equal(t, response.AllocationInfo[0].CurrentMagnitude, big.NewInt(0))
 
 	// Retrieve the allocation delay and advance the chain
-	responseDelay, err := chainReader.GetAllocationDelay(context.Background(), nil, request)
+	responseDelay, err := chainReader.GetAllocationDelay(context.Background(), request)
 	require.NoError(t, err)
 	testutils.AdvanceChainByNBlocksExecInContainer(context.Background(), int(responseDelay.AllocationDelay), anvilC)
 
 	// Check the new allocation has been updated after the delay
-	response, err = chainReader.GetAllocationInfo(context.Background(), nil, requestAllocInfo)
+	response, err = chainReader.GetAllocationInfo(context.Background(), requestAllocInfo)
 	require.NoError(t, err)
 
 	currentMagnitude := response.AllocationInfo[0].CurrentMagnitude
@@ -744,7 +744,7 @@ func TestAddAndRemovePendingAdmin(t *testing.T) {
 			AccountAddress:      operatorAddr,
 			PendingAdminAddress: pendingAdmin,
 		}
-		response, err := chainReader.IsPendingAdmin(context.Background(), nil, request)
+		response, err := chainReader.IsPendingAdmin(context.Background(), request)
 		require.NoError(t, err)
 		require.True(t, response.IsPendingAdmin)
 	})
@@ -763,7 +763,7 @@ func TestAddAndRemovePendingAdmin(t *testing.T) {
 			AccountAddress:      operatorAddr,
 			PendingAdminAddress: pendingAdmin,
 		}
-		response, err := chainReader.IsPendingAdmin(context.Background(), nil, request)
+		response, err := chainReader.IsPendingAdmin(context.Background(), request)
 		require.NoError(t, err)
 		require.False(t, response.IsPendingAdmin)
 	})
@@ -822,7 +822,7 @@ func TestAcceptAdmin(t *testing.T) {
 			AccountAddress: accountAddr,
 			AdminAddress:   pendingAdminAddr,
 		}
-		response, err := chainReader.IsAdmin(context.Background(), nil, request)
+		response, err := chainReader.IsAdmin(context.Background(), request)
 		require.NoError(t, err)
 		require.True(t, response.IsAdmin)
 	})
@@ -917,7 +917,7 @@ func TestRemoveAdmin(t *testing.T) {
 			AccountAddress: accountAddr,
 			AdminAddress:   admin2,
 		}
-		response, err := chainReader.IsAdmin(context.Background(), nil, request)
+		response, err := chainReader.IsAdmin(context.Background(), request)
 		require.NoError(t, err)
 		require.False(t, response.IsAdmin)
 	})
@@ -1265,7 +1265,10 @@ func newTestClaim(
 	earnerTreeRoot := crypto.Keccak256(encodedEarnerLeaf)
 
 	// Fetch the next root index from contract
-	response, err := chainReader.GetDistributionRootsLength(context.Background(), nil)
+	response, err := chainReader.GetDistributionRootsLength(
+		context.Background(),
+		elcontracts.GetDistributionRootsLengthRequest{},
+	)
 	if err != nil {
 		return nil, utils.WrapError("Failed to call GetDistributionRootsLength", err)
 	}
@@ -1286,7 +1289,10 @@ func newTestClaim(
 
 	root := [32]byte(earnerTreeRoot)
 	// Fetch the current timestamp to increase it
-	responseTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
+	responseTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(
+		context.Background(),
+		elcontracts.CurrRewardsCalculationEndTimestampRequest{},
+	)
 	if err != nil {
 		return nil, utils.WrapError("Failed to call CurrRewardsCalculationEndTimestamp", err)
 	}

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -379,7 +379,7 @@ func TestSetOperatorPISplit(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedInitialSplit := uint16(1000)
-	request := elcontracts.GetOperatorAVSSplitRequest{
+	request := elcontracts.GetOperatorPISplitRequest{
 		OperatorAddress: operatorAddr,
 	}
 	response, err := chainReader.GetOperatorPISplit(context.Background(), nil, request)
@@ -438,11 +438,15 @@ func TestSetOperatorAVSSplit(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedInitialSplit := uint16(1000)
-	initialSplit, err := chainReader.GetOperatorAVSSplit(context.Background(), operatorAddr, avsAddr)
+	request := elcontracts.GetOperatorAVSSplitRequest{
+		OperatorAddress: operatorAddr,
+		AvsAddress:      avsAddr,
+	}
+	response, err := chainReader.GetOperatorAVSSplit(context.Background(), nil, request)
 	require.NoError(t, err)
-	require.Equal(t, expectedInitialSplit, initialSplit)
+	require.Equal(t, expectedInitialSplit, response.Split)
 
-	newSplit := initialSplit + 1
+	newSplit := response.Split + 1
 	// Set a new operator AVS split
 	receipt, err = chainWriter.SetOperatorAVSSplit(
 		context.Background(),
@@ -455,9 +459,9 @@ func TestSetOperatorAVSSplit(t *testing.T) {
 	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
 	// Retrieve the operator AVS split to check it has been set
-	updatedSplit, err := chainReader.GetOperatorAVSSplit(context.Background(), operatorAddr, avsAddr)
+	response, err = chainReader.GetOperatorAVSSplit(context.Background(), nil, request)
 	require.NoError(t, err)
-	require.Equal(t, newSplit, updatedSplit)
+	require.Equal(t, newSplit, response.Split)
 
 	// Set a invalid operator AVS split
 	invalidSplit := uint16(10001)

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -566,9 +566,15 @@ func TestSetAndRemovePermission(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
-		canCall, err := chainReader.CanCall(context.Background(), accountAddress, appointeeAddress, target, selector)
+		request := elcontracts.CanCallRequest{
+			AccountAddress:   accountAddress,
+			AppointeeAddress: appointeeAddress,
+			Target:           target,
+			Selector:         selector,
+		}
+		response, err := chainReader.CanCall(context.Background(), nil, request)
 		require.NoError(t, err)
-		require.True(t, canCall)
+		require.True(t, response.CanCall)
 	})
 
 	t.Run("set permission to account when already set", func(t *testing.T) {
@@ -581,9 +587,15 @@ func TestSetAndRemovePermission(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
-		canCall, err := chainReader.CanCall(context.Background(), accountAddress, appointeeAddress, target, selector)
+		request := elcontracts.CanCallRequest{
+			AccountAddress:   accountAddress,
+			AppointeeAddress: appointeeAddress,
+			Target:           target,
+			Selector:         selector,
+		}
+		response, err := chainReader.CanCall(context.Background(), nil, request)
 		require.NoError(t, err)
-		require.False(t, canCall)
+		require.False(t, response.CanCall)
 	})
 
 	t.Run("remove permission from account when not set", func(t *testing.T) {

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -379,7 +379,7 @@ func TestSetOperatorPISplit(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedInitialSplit := uint16(1000)
-	request := elcontracts.GetOperatorPISplitRequest{
+	request := elcontracts.OperatorPISplitRequest{
 		OperatorAddress: operatorAddr,
 	}
 	response, err := chainReader.GetOperatorPISplit(context.Background(), request)
@@ -438,7 +438,7 @@ func TestSetOperatorAVSSplit(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedInitialSplit := uint16(1000)
-	request := elcontracts.GetOperatorAVSSplitRequest{
+	request := elcontracts.OperatorAVSSplitRequest{
 		OperatorAddress: operatorAddr,
 		AvsAddress:      avsAddr,
 	}
@@ -658,7 +658,7 @@ func TestModifyAllocations(t *testing.T) {
 	testutils.AdvanceChainByNBlocksExecInContainer(context.Background(), allocationConfigurationDelay+1, anvilC)
 
 	// Retrieve the allocation delay so that the delay is applied
-	request := elcontracts.GetAllocationDelayRequest{
+	request := elcontracts.AllocationDelayRequest{
 		OperatorAddress: operatorAddr,
 	}
 	_, err = chainReader.GetAllocationDelay(context.Background(), request)
@@ -672,7 +672,7 @@ func TestModifyAllocations(t *testing.T) {
 	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
 	// Check that the new allocation is pending and the current magnitude is zero
-	requestAllocInfo := elcontracts.GetAllocationInfoRequest{
+	requestAllocInfo := elcontracts.AllocationInfoRequest{
 		OperatorAddress: operatorAddr,
 		StrategyAddress: strategyAddr,
 	}
@@ -1267,7 +1267,7 @@ func newTestClaim(
 	// Fetch the next root index from contract
 	response, err := chainReader.GetDistributionRootsLength(
 		context.Background(),
-		elcontracts.GetDistributionRootsLengthRequest{},
+		elcontracts.DistributionRootsLengthRequest{},
 	)
 	if err != nil {
 		return nil, utils.WrapError("Failed to call GetDistributionRootsLength", err)

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -818,9 +818,13 @@ func TestAcceptAdmin(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
-		isAdmin, err := chainReader.IsAdmin(context.Background(), accountAddr, pendingAdminAddr)
+		request := elcontracts.IsAdminRequest{
+			AccountAddress: accountAddr,
+			AdminAddress:   pendingAdminAddr,
+		}
+		response, err := chainReader.IsAdmin(context.Background(), nil, request)
 		require.NoError(t, err)
-		require.True(t, isAdmin)
+		require.True(t, response.IsAdmin)
 	})
 
 	t.Run("accept admin when already accepted", func(t *testing.T) {
@@ -909,9 +913,13 @@ func TestRemoveAdmin(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
-		isAdmin, err := chainReader.IsAdmin(context.Background(), accountAddr, admin2)
+		request := elcontracts.IsAdminRequest{
+			AccountAddress: accountAddr,
+			AdminAddress:   admin2,
+		}
+		response, err := chainReader.IsAdmin(context.Background(), nil, request)
 		require.NoError(t, err)
-		require.False(t, isAdmin)
+		require.False(t, response.IsAdmin)
 	})
 
 	t.Run("remove admin 2 when already removed", func(t *testing.T) {

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -740,9 +740,13 @@ func TestAddAndRemovePendingAdmin(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
-		isPendingAdmin, err := chainReader.IsPendingAdmin(context.Background(), operatorAddr, pendingAdmin)
+		request := elcontracts.IsPendingAdminRequest{
+			AccountAddress:      operatorAddr,
+			PendingAdminAddress: pendingAdmin,
+		}
+		response, err := chainReader.IsPendingAdmin(context.Background(), nil, request)
 		require.NoError(t, err)
-		require.True(t, isPendingAdmin)
+		require.True(t, response.IsPendingAdmin)
 	})
 
 	t.Run("add pending admin when already added", func(t *testing.T) {
@@ -755,9 +759,13 @@ func TestAddAndRemovePendingAdmin(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
-		isPendingAdmin, err := chainReader.IsPendingAdmin(context.Background(), operatorAddr, pendingAdmin)
+		request := elcontracts.IsPendingAdminRequest{
+			AccountAddress:      operatorAddr,
+			PendingAdminAddress: pendingAdmin,
+		}
+		response, err := chainReader.IsPendingAdmin(context.Background(), nil, request)
 		require.NoError(t, err)
-		require.False(t, isPendingAdmin)
+		require.False(t, response.IsPendingAdmin)
 	})
 }
 

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -373,20 +373,23 @@ func TestSetOperatorPISplit(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedInitialSplit := uint16(1000)
-	initialSplit, err := chainReader.GetOperatorPISplit(context.Background(), operatorAddr)
+	request := elcontracts.GetOperatorAVSSplitRequest{
+		OperatorAddress: operatorAddr,
+	}
+	response, err := chainReader.GetOperatorPISplit(context.Background(), nil, request)
 	require.NoError(t, err)
-	require.Equal(t, expectedInitialSplit, initialSplit)
+	require.Equal(t, expectedInitialSplit, response.Split)
 
-	newSplit := initialSplit + 1
+	newSplit := response.Split + 1
 	// Set a new operator PI split
 	receipt, err = chainWriter.SetOperatorPISplit(context.Background(), operatorAddr, newSplit, waitForReceipt)
 	require.NoError(t, err)
 	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
 	// Retrieve the operator PI split to check it has been set
-	updatedSplit, err := chainReader.GetOperatorPISplit(context.Background(), operatorAddr)
+	response, err = chainReader.GetOperatorPISplit(context.Background(), nil, request)
 	require.NoError(t, err)
-	require.Equal(t, newSplit, updatedSplit)
+	require.Equal(t, newSplit, response.Split)
 
 	// Set a invalid operator PI split
 	invalidSplit := uint16(10001)

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -1238,7 +1238,7 @@ func newTestClaim(
 
 	root := [32]byte(earnerTreeRoot)
 	// Fetch the current timestamp to increase it
-	currRewardsCalculationEndTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background())
+	responseTimestamp, err := chainReader.CurrRewardsCalculationEndTimestamp(context.Background(), nil)
 	if err != nil {
 		return nil, utils.WrapError("Failed to call CurrRewardsCalculationEndTimestamp", err)
 	}
@@ -1261,7 +1261,7 @@ func newTestClaim(
 		return nil, utils.WrapError("Failed to setRewardsUpdate", err)
 	}
 
-	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, currRewardsCalculationEndTimestamp+1)
+	tx, err = rewardsCoordinator.SubmitRoot(noSendTxOpts, root, responseTimestamp.Timestamp+1)
 	if err != nil {
 		return nil, utils.WrapError("Failed to create SubmitRoot tx", err)
 	}

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -647,11 +647,15 @@ func TestModifyAllocations(t *testing.T) {
 	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 
 	// Check that the new allocation is pending and the current magnitude is zero
-	allocationInfo, err := chainReader.GetAllocationInfo(context.Background(), operatorAddr, strategyAddr)
+	request := elcontracts.GetAllocationInfoRequest{
+		OperatorAddress: operatorAddr,
+		StrategyAddress: strategyAddr,
+	}
+	response, err := chainReader.GetAllocationInfo(context.Background(), nil, request)
 	require.NoError(t, err)
-	pendingDiff := allocationInfo[0].PendingDiff
+	pendingDiff := response.AllocationInfo[0].PendingDiff
 	require.Equal(t, big.NewInt(int64(newAllocation)), pendingDiff)
-	require.Equal(t, allocationInfo[0].CurrentMagnitude, big.NewInt(0))
+	require.Equal(t, response.AllocationInfo[0].CurrentMagnitude, big.NewInt(0))
 
 	// Retrieve the allocation delay and advance the chain
 	allocationDelay, err := chainReader.GetAllocationDelay(context.Background(), operatorAddr)
@@ -659,10 +663,10 @@ func TestModifyAllocations(t *testing.T) {
 	testutils.AdvanceChainByNBlocksExecInContainer(context.Background(), int(allocationDelay), anvilC)
 
 	// Check the new allocation has been updated after the delay
-	allocationInfo, err = chainReader.GetAllocationInfo(context.Background(), operatorAddr, strategyAddr)
+	response, err = chainReader.GetAllocationInfo(context.Background(), nil, request)
 	require.NoError(t, err)
 
-	currentMagnitude := allocationInfo[0].CurrentMagnitude
+	currentMagnitude := response.AllocationInfo[0].CurrentMagnitude
 	require.Equal(t, big.NewInt(int64(newAllocation)), currentMagnitude)
 }
 


### PR DESCRIPTION
### What Changed?

This PR aims to improve the `elcontracts/reader` interface by implementing a request-response pattern. For the exposed functions, we create structs that represent the request (specific fields + `BlockNumber`) and the response.

Because the function signatures change, we also refactor the tests to align with the new pattern.

Below is a simple example of the new request-response pattern:

Example:
```go
func(r *ChainReader) Foo(
	ctx context.Context,
	request FooRequest,
) (FooResponse, error) {
	...
}

type FooRequest struct {
	BlockNumber *big.Int,
        ...
}
```

This is a work in progress and changes may occur.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it