### PR TITLE
chore: format contracts

### DIFF
--- a/contracts/script/DeployMockAvs.s.sol
+++ b/contracts/script/DeployMockAvs.s.sol
@@ -13,17 +13,11 @@ contract DeployMockAvs is DeployMockAvsRegistries {
     ProxyAdmin public mockAvsProxyAdmin;
 
     function run() public virtual {
-
         // The ContractsRegistry contract should always be deployed at this address on anvil
         // it's the address of the contract created at nonce 0 by the first anvil account (0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)
-        ContractsRegistry contractsRegistry = ContractsRegistry(
-            0x5FbDB2315678afecb367f032d93F642f64180aa3
-        );
-        EigenlayerContracts
-        memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
-        MockAvsOpsAddresses memory addressConfig = _loadAvsOpsAddresses(
-            "ops_addresses"
-        );
+        ContractsRegistry contractsRegistry = ContractsRegistry(0x5FbDB2315678afecb367f032d93F642f64180aa3);
+        EigenlayerContracts memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
+        MockAvsOpsAddresses memory addressConfig = _loadAvsOpsAddresses("ops_addresses");
 
         vm.startBroadcast();
 
@@ -33,20 +27,10 @@ contract DeployMockAvs is DeployMockAvsRegistries {
         emptyContract = new EmptyContract();
         mockAvsProxyAdmin = new ProxyAdmin();
         mockAvsServiceManager = MockAvsServiceManager(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(mockAvsProxyAdmin),
-                    ""
-                )
-            )
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(mockAvsProxyAdmin), ""))
         );
-        MockAvsContracts
-        memory mockAvsContracts = _deploymockAvsRegistryContracts(
-            eigenlayerContracts,
-            addressConfig,
-            mockAvsServiceManager,
-            mockAvsServiceManagerImplementation
+        MockAvsContracts memory mockAvsContracts = _deploymockAvsRegistryContracts(
+            eigenlayerContracts, addressConfig, mockAvsServiceManager, mockAvsServiceManagerImplementation
         );
 
         console.log("HERE16");
@@ -64,26 +48,14 @@ contract DeployMockAvs is DeployMockAvsRegistries {
         console.log("HERE17");
 
         mockAvsProxyAdmin.upgradeAndCall(
-            TransparentUpgradeableProxy(
-                payable(address(mockAvsServiceManager))
-            ),
+            TransparentUpgradeableProxy(payable(address(mockAvsServiceManager))),
             address(mockAvsServiceManagerImplementation),
-            abi.encodeWithSelector(
-                mockAvsServiceManager.initialize.selector,
-                addressConfig.communityMultisig
-            )
+            abi.encodeWithSelector(mockAvsServiceManager.initialize.selector, addressConfig.communityMultisig)
         );
-        require(
-            Ownable(address(mockAvsServiceManager)).owner() != address(0),
-            "Owner uninitialized"
-        );
+        require(Ownable(address(mockAvsServiceManager)).owner() != address(0), "Owner uninitialized");
 
         if (block.chainid == 31337 || block.chainid == 1337) {
-            _writeContractsToRegistry(
-                contractsRegistry,
-                eigenlayerContracts,
-                mockAvsContracts
-            );
+            _writeContractsToRegistry(contractsRegistry, eigenlayerContracts, mockAvsContracts);
         }
         vm.stopBroadcast();
     }

--- a/contracts/script/DeployMockAvsRegistries.s.sol
+++ b/contracts/script/DeployMockAvsRegistries.s.sol
@@ -9,7 +9,12 @@ import {IStrategyManager, IStrategy} from "eigenlayer-contracts/src/contracts/in
 import "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 import "eigenlayer-middleware/src/RegistryCoordinator.sol" as blsregcoord;
 import {IServiceManager} from "eigenlayer-middleware/src/interfaces/IServiceManager.sol";
-import {IBLSApkRegistry, IIndexRegistry, IStakeRegistry, StakeType} from "eigenlayer-middleware/src/RegistryCoordinator.sol";
+import {
+    IBLSApkRegistry,
+    IIndexRegistry,
+    IStakeRegistry,
+    StakeType
+} from "eigenlayer-middleware/src/RegistryCoordinator.sol";
 import {BLSApkRegistry} from "eigenlayer-middleware/src/BLSApkRegistry.sol";
 import {IndexRegistry} from "eigenlayer-middleware/src/IndexRegistry.sol";
 import {StakeRegistry} from "eigenlayer-middleware/src/StakeRegistry.sol";
@@ -75,11 +80,7 @@ contract DeployMockAvsRegistries is Script, ConfigsReadWriter, EigenlayerContrac
         require(Ownable(address(deployed.coordinator)).owner() != address(0), "Owner uninitialized");
         _writeDeploymentOutput(manager, managerImpl);
 
-        return MockAvsContracts(
-            manager,
-            deployed.coordinator,
-            deployed.stateRetriever
-        );
+        return MockAvsContracts(manager, deployed.coordinator, deployed.stateRetriever);
     }
 
     function _deployPauserRegistry(MockAvsOpsAddresses memory config) internal {
@@ -103,31 +104,21 @@ contract DeployMockAvsRegistries is Script, ConfigsReadWriter, EigenlayerContrac
     }
 
     function _deployProxy() internal returns (address) {
-        return address(
-            new TransparentUpgradeableProxy(
-                address(deployed.emptyContract),
-                address(deployed.proxyAdmin),
-                ""
-            )
-        );
+        return
+            address(new TransparentUpgradeableProxy(address(deployed.emptyContract), address(deployed.proxyAdmin), ""));
     }
 
-    function _deployAndUpgradeImplementations(
-        EigenlayerContracts memory eigen,
-        MockAvsServiceManager manager
-    ) internal {
+    function _deployAndUpgradeImplementations(EigenlayerContracts memory eigen, MockAvsServiceManager manager)
+        internal
+    {
         registries.blsApkRegistryImplementation = new BLSApkRegistry(deployed.coordinator);
         _upgradeProxy(address(registries.blsApkRegistry), address(registries.blsApkRegistryImplementation));
 
         registries.indexRegistryImplementation = new IndexRegistry(deployed.coordinator);
         _upgradeProxy(address(registries.indexRegistry), address(registries.indexRegistryImplementation));
 
-        registries.stakeRegistryImplementation = new StakeRegistry(
-            deployed.coordinator,
-            eigen.delegationManager,
-            eigen.avsDirectory,
-            manager
-        );
+        registries.stakeRegistryImplementation =
+            new StakeRegistry(deployed.coordinator, eigen.delegationManager, eigen.avsDirectory, manager);
         _upgradeProxy(address(registries.stakeRegistry), address(registries.stakeRegistryImplementation));
 
         deployed.coordinatorImplementation = new blsregcoord.RegistryCoordinator(
@@ -146,7 +137,8 @@ contract DeployMockAvsRegistries is Script, ConfigsReadWriter, EigenlayerContrac
 
     function _initializeRegistryCoordinator(MockAvsOpsAddresses memory config) internal {
         uint32 numQuorums = 0;
-        blsregcoord.RegistryCoordinator.OperatorSetParam[] memory params = new blsregcoord.RegistryCoordinator.OperatorSetParam[](numQuorums);
+        blsregcoord.RegistryCoordinator.OperatorSetParam[] memory params =
+            new blsregcoord.RegistryCoordinator.OperatorSetParam[](numQuorums);
 
         for (uint32 i = 0; i < numQuorums; i++) {
             params[i] = blsregcoord.IRegistryCoordinator.OperatorSetParam({
@@ -179,10 +171,7 @@ contract DeployMockAvsRegistries is Script, ConfigsReadWriter, EigenlayerContrac
         );
     }
 
-    function _writeDeploymentOutput(
-        MockAvsServiceManager manager,
-        MockAvsServiceManager managerImpl
-    ) internal {
+    function _writeDeploymentOutput(MockAvsServiceManager manager, MockAvsServiceManager managerImpl) internal {
         string memory parent = "parent object";
         string memory addresses = "addresses";
 
@@ -191,12 +180,10 @@ contract DeployMockAvsRegistries is Script, ConfigsReadWriter, EigenlayerContrac
         vm.serializeAddress(addresses, "mockAvsServiceManagerImplementation", address(managerImpl));
         vm.serializeAddress(addresses, "registryCoordinator", address(deployed.coordinator));
         vm.serializeAddress(addresses, "registryCoordinatorImplementation", address(deployed.coordinatorImplementation));
-        string memory output = vm.serializeAddress(addresses, "operatorStateRetriever", address(deployed.stateRetriever));
+        string memory output =
+            vm.serializeAddress(addresses, "operatorStateRetriever", address(deployed.stateRetriever));
 
-        writeOutput(
-            vm.serializeString(parent, addresses, output),
-            "mockavs_deployment_output"
-        );
+        writeOutput(vm.serializeString(parent, addresses, output), "mockavs_deployment_output");
     }
 
     function _writeContractsToRegistry(

--- a/contracts/script/DeployTokensStrategiesCreateQuorums.s.sol
+++ b/contracts/script/DeployTokensStrategiesCreateQuorums.s.sol
@@ -19,24 +19,16 @@ import {ContractsRegistry} from "../src/ContractsRegistry.sol";
 import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 
-contract DeployTokensStrategiesCreateQuorums is
-    Script,
-    EigenlayerContractsParser,
-    MockAvsContractsParser
-{
-    uint MINT_AMOUNT = 5_000 ether;
+contract DeployTokensStrategiesCreateQuorums is Script, EigenlayerContractsParser, MockAvsContractsParser {
+    uint256 MINT_AMOUNT = 5_000 ether;
 
     function run() external {
         // hardcoded as first contract deployed by anvil's 0th account
         // (generated from mnemonic "test test test test test test test test test test test junk")
         // 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 (sk = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80)
-        ContractsRegistry contractsRegistry = ContractsRegistry(
-            0x5FbDB2315678afecb367f032d93F642f64180aa3
-        );
-        EigenlayerContracts
-            memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
-        MockAvsContracts
-            memory mockAvsContracts = _loadMockAvsDeployedContracts();
+        ContractsRegistry contractsRegistry = ContractsRegistry(0x5FbDB2315678afecb367f032d93F642f64180aa3);
+        EigenlayerContracts memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
+        MockAvsContracts memory mockAvsContracts = _loadMockAvsDeployedContracts();
         IStrategy strat;
         IERC20 mockToken;
         vm.startBroadcast();
@@ -47,13 +39,12 @@ contract DeployTokensStrategiesCreateQuorums is
                 eigenlayerContracts.baseStrategyImplementation,
                 eigenlayerContracts.strategyManager
             );
-            contractsRegistry.registerContract(
-                "erc20MockStrategy",
-                address(strat)
-            );
+            contractsRegistry.registerContract("erc20MockStrategy", address(strat));
         } else if (block.chainid == 17000) {
-            strat = IStrategy(0x5C8b55722f421556a2AAfb7A3EA63d4c3e514312); /// Whitelisted stETH strat
-            mockToken = IERC20(0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034); /// stETH
+            strat = IStrategy(0x5C8b55722f421556a2AAfb7A3EA63d4c3e514312);
+            /// Whitelisted stETH strat
+            mockToken = IERC20(0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034);
+            /// stETH
         } else {
             revert("Configure Token and Strategy for Chain");
         }
@@ -90,54 +81,34 @@ contract DeployTokensStrategiesCreateQuorums is
         strats[0] = erc20MockStrategy;
         bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         thirdPartyTransfersForbiddenValues[0] = false;
-        strategyManager.addStrategiesToDepositWhitelist(
-            strats
-        );
+        strategyManager.addStrategiesToDepositWhitelist(strats);
 
         // WRITE JSON DATA
         // TODO: support more than one token/strategy pair
         string memory parent_object = "parent object";
         string memory deployed_addresses = "addresses";
-        vm.serializeAddress(
-            deployed_addresses,
-            "erc20mock",
-            address(mockERC20)
-        );
-        string memory deployed_addresses_output = vm.serializeAddress(
-            deployed_addresses,
-            "erc20mockstrategy",
-            address(erc20MockStrategy)
-        );
-        string memory finalJson = vm.serializeString(
-            parent_object,
-            deployed_addresses,
-            deployed_addresses_output
-        );
+        vm.serializeAddress(deployed_addresses, "erc20mock", address(mockERC20));
+        string memory deployed_addresses_output =
+            vm.serializeAddress(deployed_addresses, "erc20mockstrategy", address(erc20MockStrategy));
+        string memory finalJson = vm.serializeString(parent_object, deployed_addresses, deployed_addresses_output);
         writeOutput(finalJson, "token_and_strategy_deployment_output");
 
         return (IERC20(mockERC20), erc20MockStrategy);
     }
 
-    function _createQuorum(
-        regcoord.RegistryCoordinator mockAvsRegCoord,
-        IStrategy strat
-    ) internal {
+    function _createQuorum(regcoord.RegistryCoordinator mockAvsRegCoord, IStrategy strat) internal {
         // for each quorum to setup, we need to define
         // quorumsOperatorSetParams, quorumsMinimumStake, and quorumsStrategyParams
-        regcoord.RegistryCoordinator.OperatorSetParam
-            memory quorumOperatorSetParams = regcoord
-                .IRegistryCoordinator
-                .OperatorSetParam({
-                    // hardcoded for now
-                    maxOperatorCount: 10000,
-                    kickBIPsOfOperatorStake: 15000,
-                    kickBIPsOfTotalStake: 100
-                });
+        regcoord.RegistryCoordinator.OperatorSetParam memory quorumOperatorSetParams = regcoord
+            .IRegistryCoordinator
+            .OperatorSetParam({
+            // hardcoded for now
+            maxOperatorCount: 10000,
+            kickBIPsOfOperatorStake: 15000,
+            kickBIPsOfTotalStake: 100
+        });
         uint96 quorumMinimumStake = 0;
-        IStakeRegistry.StrategyParams[]
-            memory quorumStrategyParams = new IStakeRegistry.StrategyParams[](
-                1
-            );
+        IStakeRegistry.StrategyParams[] memory quorumStrategyParams = new IStakeRegistry.StrategyParams[](1);
         quorumStrategyParams[0] = IStakeRegistry.StrategyParams({
             strategy: strat,
             // setting this to 1 ether since the divisor is also 1 ether
@@ -148,9 +119,7 @@ contract DeployTokensStrategiesCreateQuorums is
         });
 
         regcoord.RegistryCoordinator(address(mockAvsRegCoord)).createTotalDelegatedStakeQuorum(
-            quorumOperatorSetParams,
-            quorumMinimumStake,
-            quorumStrategyParams
+            quorumOperatorSetParams, quorumMinimumStake, quorumStrategyParams
         );
     }
 }

--- a/contracts/script/RegisterOperatorsWithEigenlayer.s.sol
+++ b/contracts/script/RegisterOperatorsWithEigenlayer.s.sol
@@ -12,11 +12,7 @@ import {ConfigsReadWriter} from "./parsers/ConfigsReadWriter.sol";
 // This script registers a bunch of operators with eigenlayer
 // We don't register with eigencert/eigenda because events are not registered in saved anvil state, so we need to register
 // them at runtime whenver we start anvil for a test or localnet.
-contract RegisterOperators is
-    ConfigsReadWriter,
-    EigenlayerContractsParser,
-    TokenAndStrategyContractsParser
-{
+contract RegisterOperators is ConfigsReadWriter, EigenlayerContractsParser, TokenAndStrategyContractsParser {
     string internal mnemonic;
     uint256 internal numberOfOperators;
 
@@ -30,25 +26,17 @@ contract RegisterOperators is
     }
 
     function run() external {
-        EigenlayerContracts
-            memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
-        TokenAndStrategyContracts
-            memory tokenAndStrategy = _loadTokenAndStrategyContracts();
+        EigenlayerContracts memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
+        TokenAndStrategyContracts memory tokenAndStrategy = _loadTokenAndStrategyContracts();
 
         address[] memory operators = new address[](numberOfOperators);
         uint256[] memory operatorsETHAmount = new uint256[](numberOfOperators);
-        uint256[] memory operatorTokenAmounts = new uint256[](
-            numberOfOperators
-        );
+        uint256[] memory operatorTokenAmounts = new uint256[](numberOfOperators);
         for (uint256 i; i < numberOfOperators; i++) {
-            (address operator, ) = deriveRememberKey(mnemonic, uint32(i));
+            (address operator,) = deriveRememberKey(mnemonic, uint32(i));
             operators[i] = operator;
             operatorsETHAmount[i] = 5 ether;
-            operatorTokenAmounts[i] = bound(
-                uint256(keccak256(bytes.concat(bytes32(uint256(i))))),
-                1 ether,
-                10 ether
-            );
+            operatorTokenAmounts[i] = bound(uint256(keccak256(bytes.concat(bytes32(uint256(i))))), 1 ether, 10 ether);
         }
         vm.startBroadcast();
 
@@ -56,11 +44,7 @@ contract RegisterOperators is
         _allocateEthOrErc20(address(0), operators, operatorsETHAmount);
 
         // Allocate tokens to operators
-        _allocateEthOrErc20(
-            address(tokenAndStrategy.token),
-            operators,
-            operatorTokenAmounts
-        );
+        _allocateEthOrErc20(address(tokenAndStrategy.token), operators, operatorTokenAmounts);
 
         vm.stopBroadcast();
 
@@ -69,32 +53,19 @@ contract RegisterOperators is
             address delegationApprover = address(0); // anyone can delegate to this operator
             uint32 allocationDelay = 2; // 2 blocks
             uint32 stakerOptOutWindowBlocks = 100;
-            string memory metadataURI = string.concat(
-                "https://coolstuff.com/operator/",
-                vm.toString(i)
-            );
+            string memory metadataURI = string.concat("https://coolstuff.com/operator/", vm.toString(i));
             (, uint256 privateKey) = deriveRememberKey(mnemonic, uint32(i));
             vm.startBroadcast(privateKey);
-            eigenlayerContracts.delegationManager.registerAsOperator(
-                delegationApprover,
-                allocationDelay,
-                metadataURI
-            );
+            eigenlayerContracts.delegationManager.registerAsOperator(delegationApprover, allocationDelay, metadataURI);
             eigenlayerContracts.strategyManager.depositIntoStrategy(
-                tokenAndStrategy.strategy,
-                IERC20(tokenAndStrategy.token),
-                operatorTokenAmounts[i]
+                tokenAndStrategy.strategy, IERC20(tokenAndStrategy.token), operatorTokenAmounts[i]
             );
             vm.stopBroadcast();
         }
     }
 
     // setting token=address(0) will allocate eth
-    function _allocateEthOrErc20(
-        address token,
-        address[] memory tos,
-        uint256[] memory amounts
-    ) internal {
+    function _allocateEthOrErc20(address token, address[] memory tos, uint256[] memory amounts) internal {
         for (uint256 i = 0; i < tos.length; i++) {
             if (token == address(0)) {
                 payable(tos[i]).transfer(amounts[i]);

--- a/contracts/script/parsers/ConfigsReadWriter.sol
+++ b/contracts/script/parsers/ConfigsReadWriter.sol
@@ -10,45 +10,24 @@ import "forge-std/StdJson.sol";
 contract ConfigsReadWriter is Script {
     // Forge scripts best practice: https://book.getfoundry.sh/tutorials/best-practices#scripts
     // inputFileName should not contain the .json extension, we add it automatically
-    function readInput(
-        string memory inputFileName
-    ) internal view returns (string memory) {
-        string memory inputDir = string.concat(
-            vm.projectRoot(),
-            "/script/input/"
-        );
+    function readInput(string memory inputFileName) internal view returns (string memory) {
+        string memory inputDir = string.concat(vm.projectRoot(), "/script/input/");
         string memory chainDir = string.concat(vm.toString(block.chainid), "/");
         string memory file = string.concat(inputFileName, ".json");
         return vm.readFile(string.concat(inputDir, chainDir, file));
     }
 
-    function readOutput(
-        string memory outputFileName
-    ) internal view returns (string memory) {
-        string memory inputDir = string.concat(
-            vm.projectRoot(),
-            "/script/output/"
-        );
+    function readOutput(string memory outputFileName) internal view returns (string memory) {
+        string memory inputDir = string.concat(vm.projectRoot(), "/script/output/");
         string memory chainDir = string.concat(vm.toString(block.chainid), "/");
         string memory file = string.concat(outputFileName, ".json");
         return vm.readFile(string.concat(inputDir, chainDir, file));
     }
 
-    function writeOutput(
-        string memory outputJson,
-        string memory outputFileName
-    ) internal {
-        string memory outputDir = string.concat(
-            vm.projectRoot(),
-            "/script/output/"
-        );
+    function writeOutput(string memory outputJson, string memory outputFileName) internal {
+        string memory outputDir = string.concat(vm.projectRoot(), "/script/output/");
         string memory chainDir = string.concat(vm.toString(block.chainid), "/");
-        string memory outputFilePath = string.concat(
-            outputDir,
-            chainDir,
-            outputFileName,
-            ".json"
-        );
+        string memory outputFilePath = string.concat(outputDir, chainDir, outputFileName, ".json");
         vm.writeJson(outputJson, outputFilePath);
     }
 }

--- a/contracts/script/parsers/EigenlayerContractsParser.sol
+++ b/contracts/script/parsers/EigenlayerContractsParser.sol
@@ -13,9 +13,10 @@ import {IAllocationManager} from "eigenlayer-contracts/src/contracts/interfaces/
 
 import {ConfigsReadWriter} from "./ConfigsReadWriter.sol";
 import "forge-std/StdJson.sol";
-import {IAllocationManager} from "../../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IAllocationManager} from
+    "../../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 
-    struct EigenlayerContracts {
+struct EigenlayerContracts {
     ProxyAdmin eigenlayerProxyAdmin;
     PauserRegistry eigenlayerPauserReg;
     IStrategyManager strategyManager;
@@ -27,75 +28,37 @@ import {IAllocationManager} from "../../lib/eigenlayer-middleware/lib/eigenlayer
 }
 
 contract EigenlayerContractsParser is ConfigsReadWriter {
-    function _loadEigenlayerDeployedContracts()
-        internal
-        view
-        returns (EigenlayerContracts memory)
-    {
+    function _loadEigenlayerDeployedContracts() internal view returns (EigenlayerContracts memory) {
         // Eigenlayer contracts
-        string memory eigenlayerDeployedContracts = readOutput(
-            "eigenlayer_deployment_output"
-        );
-        ProxyAdmin eigenlayerProxyAdmin = ProxyAdmin(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.eigenLayerProxyAdmin"
-            )
-        );
-        PauserRegistry eigenlayerPauserReg = PauserRegistry(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.eigenLayerPauserReg"
-            )
-        );
-        IStrategyManager strategyManager = IStrategyManager(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.strategyManager"
-            )
-        );
-        IDelegationManager delegationManager = IDelegationManager(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.delegationManager"
-            )
-        );
-        IAVSDirectory avsDirectory = IAVSDirectory(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.avsDirectory"
-            )
-        );
+        string memory eigenlayerDeployedContracts = readOutput("eigenlayer_deployment_output");
+        ProxyAdmin eigenlayerProxyAdmin =
+            ProxyAdmin(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.eigenLayerProxyAdmin"));
+        PauserRegistry eigenlayerPauserReg =
+            PauserRegistry(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.eigenLayerPauserReg"));
+        IStrategyManager strategyManager =
+            IStrategyManager(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.strategyManager"));
+        IDelegationManager delegationManager =
+            IDelegationManager(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.delegationManager"));
+        IAVSDirectory avsDirectory =
+            IAVSDirectory(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.avsDirectory"));
         StrategyBaseTVLLimits baseStrategyImplementation = StrategyBaseTVLLimits(
-                stdJson.readAddress(
-                    eigenlayerDeployedContracts,
-                    ".addresses.baseStrategyImplementation"
-                )
-            );
-
-        IRewardsCoordinator rewardsCoordinator = IRewardsCoordinator(
-             stdJson.readAddress(
-                 eigenlayerDeployedContracts,
-                 ".addresses.rewardsCoordinator"
-             )
+            stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.baseStrategyImplementation")
         );
 
-        IAllocationManager allocationManager = IAllocationManager(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.allocationManager"
-            )
+        IRewardsCoordinator rewardsCoordinator =
+            IRewardsCoordinator(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.rewardsCoordinator"));
+
+        IAllocationManager allocationManager =
+            IAllocationManager(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.allocationManager"));
+        return EigenlayerContracts(
+            eigenlayerProxyAdmin,
+            eigenlayerPauserReg,
+            strategyManager,
+            delegationManager,
+            avsDirectory,
+            rewardsCoordinator,
+            baseStrategyImplementation,
+            allocationManager
         );
-        return
-            EigenlayerContracts(
-                eigenlayerProxyAdmin,
-                eigenlayerPauserReg,
-                strategyManager,
-                delegationManager,
-                avsDirectory,
-                rewardsCoordinator,
-                baseStrategyImplementation,
-                allocationManager
-            );
     }
 }

--- a/contracts/script/parsers/MockAvsContractsParser.sol
+++ b/contracts/script/parsers/MockAvsContractsParser.sol
@@ -16,51 +16,23 @@ struct MockAvsContracts {
 }
 
 contract MockAvsContractsParser is ConfigsReadWriter {
-    function _loadMockAvsDeployedContracts()
-        internal
-        view
-        returns (MockAvsContracts memory)
-    {
+    function _loadMockAvsDeployedContracts() internal view returns (MockAvsContracts memory) {
         // Eigenlayer contracts
-        string memory mockAvsDeployedContracts = readOutput(
-            "mockavs_deployment_output"
-        );
-        MockAvsServiceManager mockAvsServiceManager = MockAvsServiceManager(
-            stdJson.readAddress(
-                mockAvsDeployedContracts,
-                ".addresses.mockAvsServiceManager"
-            )
-        );
+        string memory mockAvsDeployedContracts = readOutput("mockavs_deployment_output");
+        MockAvsServiceManager mockAvsServiceManager =
+            MockAvsServiceManager(stdJson.readAddress(mockAvsDeployedContracts, ".addresses.mockAvsServiceManager"));
         require(
-            address(mockAvsServiceManager) != address(0),
-            "MockAvsContractsParser: mockAvsServiceManager address is 0"
+            address(mockAvsServiceManager) != address(0), "MockAvsContractsParser: mockAvsServiceManager address is 0"
         );
-        RegistryCoordinator registryCoordinator = RegistryCoordinator(
-            stdJson.readAddress(
-                mockAvsDeployedContracts,
-                ".addresses.registryCoordinator"
-            )
-        );
+        RegistryCoordinator registryCoordinator =
+            RegistryCoordinator(stdJson.readAddress(mockAvsDeployedContracts, ".addresses.registryCoordinator"));
+        require(address(registryCoordinator) != address(0), "MockAvsContractsParser: registryCoordinator address is 0");
+        OperatorStateRetriever operatorStateRetriever =
+            OperatorStateRetriever(stdJson.readAddress(mockAvsDeployedContracts, ".addresses.operatorStateRetriever"));
         require(
-            address(registryCoordinator) != address(0),
-            "MockAvsContractsParser: registryCoordinator address is 0"
-        );
-        OperatorStateRetriever operatorStateRetriever = OperatorStateRetriever(
-            stdJson.readAddress(
-                mockAvsDeployedContracts,
-                ".addresses.operatorStateRetriever"
-            )
-        );
-        require(
-            address(operatorStateRetriever) != address(0),
-            "MockAvsContractsParser: operatorStateRetriever address is 0"
+            address(operatorStateRetriever) != address(0), "MockAvsContractsParser: operatorStateRetriever address is 0"
         );
 
-        return
-            MockAvsContracts(
-                mockAvsServiceManager,
-                registryCoordinator,
-                operatorStateRetriever
-            );
+        return MockAvsContracts(mockAvsServiceManager, registryCoordinator, operatorStateRetriever);
     }
 }

--- a/contracts/script/parsers/TokensAndStrategiesContractsParser.sol
+++ b/contracts/script/parsers/TokensAndStrategiesContractsParser.sol
@@ -14,22 +14,13 @@ struct TokenAndStrategyContracts {
 
 // TODO: support more than one token/strategy pair (dee deployTokensAndStrategies script)
 contract TokenAndStrategyContractsParser is ConfigsReadWriter {
-    function _loadTokenAndStrategyContracts()
-        internal
-        view
-        returns (TokenAndStrategyContracts memory)
-    {
+    function _loadTokenAndStrategyContracts() internal view returns (TokenAndStrategyContracts memory) {
         // Token and Strategy contracts
-        string memory tokenAndStrategyConfigFile = readOutput(
-            "token_and_strategy_deployment_output"
-        );
+        string memory tokenAndStrategyConfigFile = readOutput("token_and_strategy_deployment_output");
 
-        bytes memory tokensAndStrategiesConfigsRaw = stdJson.parseRaw(
-            tokenAndStrategyConfigFile,
-            ".addresses"
-        );
-        TokenAndStrategyContracts memory tokensAndStrategiesContracts = abi
-            .decode(tokensAndStrategiesConfigsRaw, (TokenAndStrategyContracts));
+        bytes memory tokensAndStrategiesConfigsRaw = stdJson.parseRaw(tokenAndStrategyConfigFile, ".addresses");
+        TokenAndStrategyContracts memory tokensAndStrategiesContracts =
+            abi.decode(tokensAndStrategiesConfigsRaw, (TokenAndStrategyContracts));
 
         return tokensAndStrategiesContracts;
     }

--- a/contracts/src/ContractsRegistry.sol
+++ b/contracts/src/ContractsRegistry.sol
@@ -9,8 +9,8 @@ pragma solidity ^0.8.12;
 // forge create src/ContractsRegistry.sol:ContractsRegistry --rpc-url $RPC_URL  --private-key $PRIVATE_KEY
 contract ContractsRegistry {
     mapping(string => address) public contracts;
-    mapping(uint => string) public contractNames;
-    uint public contractCount;
+    mapping(uint256 => string) public contractNames;
+    uint256 public contractCount;
 
     function registerContract(string memory name, address _contract) public {
         // we treat redeploys as a bug since this is only meant to be used for testing.

--- a/contracts/src/MockAvsServiceManager.sol
+++ b/contracts/src/MockAvsServiceManager.sol
@@ -9,7 +9,8 @@ import {IRegistryCoordinator} from "eigenlayer-middleware/src/interfaces/IRegist
 import {IBLSSignatureChecker} from "eigenlayer-middleware/src/interfaces/IBLSSignatureChecker.sol";
 import {ServiceManagerBase} from "eigenlayer-middleware/src/ServiceManagerBase.sol";
 import {BLSSignatureChecker} from "eigenlayer-middleware/src/BLSSignatureChecker.sol";
-import {IAllocationManager} from "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IAllocationManager} from
+    "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 
 contract MockAvsServiceManager is ServiceManagerBase, BLSSignatureChecker {
     constructor(

--- a/contracts/src/MockERC20.sol
+++ b/contracts/src/MockERC20.sol
@@ -9,11 +9,7 @@ contract MockERC20 is ERC20("Mock Token", "MCK") {
     }
 
     /// WARNING: Vulnerable, bypasses allowance check. Do not use in production!
-    function transferFrom(
-        address from,
-        address to,
-        uint256 amount
-    ) public virtual override returns (bool) {
+    function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
         super._transfer(from, to, amount);
         return true;
     }


### PR DESCRIPTION
### What Changed?
This PR formats the contracts with `forge fmt`.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it