### PR TITLE
refactor: `elcontracts/writer` interface

### DIFF
--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -446,13 +446,13 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        ops,
+		Options: ops,
 	}
 
 	request := elcontracts.ClaimProcessRequest{
 		Claim:            *claim,
 		RecipientAddress: rewardsCoordinatorAddr,
+		WaitForReceipt:   true,
 	}
 
 	receipt, err = chainWriter.ProcessClaim(context.Background(), request, txOptions)
@@ -489,8 +489,7 @@ func TestCheckClaim(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        ops,
+		Options: ops,
 	}
 
 	activationDelay := uint32(0)
@@ -506,6 +505,7 @@ func TestCheckClaim(t *testing.T) {
 	request := elcontracts.ClaimProcessRequest{
 		Claim:            *claim,
 		RecipientAddress: rewardsCoordinatorAddr,
+		WaitForReceipt:   true,
 	}
 
 	receipt, err = chainWriter.ProcessClaim(context.Background(), request, txOptions)
@@ -576,14 +576,14 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	delay := uint32(1)
 	request := elcontracts.AllocationDelayRequest{
 		OperatorAddress: operatorAddr,
 		Delay:           delay,
+		WaitForReceipt:  true,
 	}
 	receipt, err := chainWriter.SetAllocationDelay(context.Background(), request, txOptions)
 	require.NoError(t, err)
@@ -615,6 +615,7 @@ func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
 	modifyAllocationRequest := elcontracts.AllocationModifyRequest{
 		OperatorAddress: operatorAddr,
 		Allocations:     allocateParams,
+		WaitForReceipt:  true,
 	}
 
 	receipt, err = chainWriter.ModifyAllocations(context.Background(), modifyAllocationRequest, txOptions)
@@ -684,13 +685,11 @@ func TestAdminFunctions(t *testing.T) {
 	assert.NoError(t, err)
 
 	operatorTxOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        optsOperator,
+		Options: optsOperator,
 	}
 
 	pendingAdminTxOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        optsPendingAdmin,
+		Options: optsPendingAdmin,
 	}
 
 	t.Run("non-existent pending admin", func(t *testing.T) {
@@ -711,6 +710,7 @@ func TestAdminFunctions(t *testing.T) {
 		request := elcontracts.PendingAdminAcceptRequest{
 			AccountAddress: operatorAddr,
 			AdminAddress:   pendingAdminAddr,
+			WaitForReceipt: true,
 		}
 
 		receipt, err := accountChainWriter.AddPendingAdmin(context.Background(), request, operatorTxOptions)
@@ -737,6 +737,7 @@ func TestAdminFunctions(t *testing.T) {
 	t.Run("list admins", func(t *testing.T) {
 		acceptAdminRequest := elcontracts.AdminAcceptRequest{
 			AccountAddress: operatorAddr,
+			WaitForReceipt: true,
 		}
 
 		receipt, err := adminChainWriter.AcceptAdmin(context.Background(), acceptAdminRequest, pendingAdminTxOptions)
@@ -787,8 +788,7 @@ func TestAppointeesFunctions(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	t.Run("list appointees when empty", func(t *testing.T) {
@@ -803,6 +803,7 @@ func TestAppointeesFunctions(t *testing.T) {
 			AppointeeAddress: appointeeAddress,
 			Target:           target,
 			Selector:         selector,
+			WaitForReceipt:   true,
 		}
 
 		receipt, err := chainWriter.SetPermission(context.Background(), setPermissionRequest, txOptions)
@@ -1156,8 +1157,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	strategyAddr := contractAddrs.Erc20MockStrategy
@@ -1177,6 +1177,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 		OperatorSetIds:             []uint32{operatorSetId},
 		Socket:                     "socket",
 		BlsKeyPair:                 keypair,
+		WaitForReceipt:             true,
 	}
 
 	receipt, err := chainWriter.RegisterForOperatorSets(
@@ -1194,6 +1195,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 	allocationDelayRequest := elcontracts.AllocationDelayRequest{
 		OperatorAddress: operatorAddr,
 		Delay:           uint32(allocationDelay),
+		WaitForReceipt:  true,
 	}
 
 	receipt, err = chainWriter.SetAllocationDelay(
@@ -1221,6 +1223,7 @@ func TestOperatorSetsAndSlashableShares(t *testing.T) {
 	modifyAllocationRequest := elcontracts.AllocationModifyRequest{
 		OperatorAddress: operatorAddr,
 		Allocations:     allocationParams,
+		WaitForReceipt:  true,
 	}
 
 	receipt, err = chainWriter.ModifyAllocations(

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -122,12 +122,12 @@ type ClaimForRequest struct {
 	Claimer common.Address
 }
 
-type ClaimProcess struct {
+type ClaimProcessRequest struct {
 	Claim            rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
 	RecipientAddress common.Address
 }
 
-type ClaimsProcess struct {
+type ClaimsProcessRequest struct {
 	Claims           []rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
 	RecipientAddress common.Address
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -87,12 +87,12 @@ type RemovePendingAdminRequest struct {
 }
 
 type TxOptions struct {
-	WaitForReceipt bool
-	Options        *bind.TransactOpts
+	Options *bind.TransactOpts
 }
 
 type RegisterOperatorRequest struct {
-	Operator types.Operator
+	Operator       types.Operator
+	WaitForReceipt bool
 }
 
 type RegisterOperatorSetsRequest struct {
@@ -102,61 +102,73 @@ type RegisterOperatorSetsRequest struct {
 	OperatorSetIds             []uint32
 	BlsKeyPair                 *bls.KeyPair
 	Socket                     string
+	WaitForReceipt             bool
 }
 
 type OperatorDetailsRequest struct {
-	Operator types.Operator
+	Operator       types.Operator
+	WaitForReceipt bool
 }
 
 type MetadataURIRequest struct {
 	OperatorAddress common.Address
 	Uri             string
+	WaitForReceipt  bool
 }
 
 type ERC20IntoStrategyRequest struct {
 	StrategyAddress common.Address
 	Amount          *big.Int
+	WaitForReceipt  bool
 }
 
 type ClaimForRequest struct {
-	Claimer common.Address
+	Claimer        common.Address
+	WaitForReceipt bool
 }
 
 type ClaimProcessRequest struct {
 	Claim            rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
 	RecipientAddress common.Address
+	WaitForReceipt   bool
 }
 
 type ClaimsProcessRequest struct {
 	Claims           []rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
 	RecipientAddress common.Address
+	WaitForReceipt   bool
 }
 
 type OperatorAVSSplitRequest struct {
 	OperatorAddress common.Address
 	AVSAddress      common.Address
 	Split           uint16
+	WaitForReceipt  bool
 }
 
 type OperatorPISplitRequest struct {
 	OperatorAddress common.Address
 	Split           uint16
+	WaitForReceipt  bool
 }
 
 type OperatorSetDeregisterRequest struct {
 	OperatorAddress common.Address
 	AVSAddress      common.Address
 	OperatorSetIds  []uint32
+	WaitForReceipt  bool
 }
 
 type AllocationModifyRequest struct {
 	OperatorAddress common.Address
 	Allocations     []allocationmanager.IAllocationManagerTypesAllocateParams
+	WaitForReceipt  bool
 }
 
 type AllocationDelayRequest struct {
 	OperatorAddress common.Address
 	Delay           uint32
+	WaitForReceipt  bool
 }
 
 type PermissionRemoveRequest struct {
@@ -164,6 +176,7 @@ type PermissionRemoveRequest struct {
 	AppointeeAddress common.Address
 	Target           common.Address
 	Selector         [4]byte
+	WaitForReceipt   bool
 }
 
 type PermissionSetRequest struct {
@@ -171,23 +184,28 @@ type PermissionSetRequest struct {
 	AppointeeAddress common.Address
 	Target           common.Address
 	Selector         [4]byte
+	WaitForReceipt   bool
 }
 
 type AdminAcceptRequest struct {
 	AccountAddress common.Address
+	WaitForReceipt bool
 }
 
 type PendingAdminAcceptRequest struct {
 	AccountAddress common.Address
 	AdminAddress   common.Address
+	WaitForReceipt bool
 }
 
 type AdminRemoveRequest struct {
 	AccountAddress common.Address
 	AdminAddress   common.Address
+	WaitForReceipt bool
 }
 
 type PendingAdminRemoveRequest struct {
 	AccountAddress common.Address
 	AdminAddress   common.Address
+	WaitForReceipt bool
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -4,8 +4,12 @@ import (
 	"math/big"
 
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
-	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
+	rewardscoordinator "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IRewardsCoordinator"
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	"github.com/Layr-Labs/eigensdk-go/types"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -80,4 +84,110 @@ type RemovePendingAdminRequest struct {
 	AccountAddress common.Address
 	AdminAddress   common.Address
 	WaitForReceipt bool
+}
+
+type TxOptions struct {
+	WaitForReceipt bool
+	Options        *bind.TransactOpts
+}
+
+type RegisterOperatorRequest struct {
+	Operator types.Operator
+}
+
+type RegisterOperatorSetsRequest struct {
+	RegistryCoordinatorAddress common.Address
+	OperatorAddress            common.Address
+	AVSAddress                 common.Address
+	OperatorSetIds             []uint32
+	BlsKeyPair                 *bls.KeyPair
+	Socket                     string
+}
+
+type OperatorDetailsRequest struct {
+	Operator types.Operator
+}
+
+type MetadataURIRequest struct {
+	OperatorAddress common.Address
+	Uri             string
+}
+
+type ERC20IntoStrategyRequest struct {
+	StrategyAddress common.Address
+	Amount          *big.Int
+}
+
+type ClaimForRequest struct {
+	Claimer common.Address
+}
+
+type ClaimProcess struct {
+	Claim            rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
+	RecipientAddress common.Address
+}
+
+type ClaimsProcess struct {
+	Claims           []rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
+	RecipientAddress common.Address
+}
+
+type OperatorAVSSplitRequest struct {
+	OperatorAddress common.Address
+	AVSAddress      common.Address
+	Split           uint16
+}
+
+type OperatorPISplitRequest struct {
+	OperatorAddress common.Address
+	Split           uint16
+}
+
+type OperatorSetDeregisterRequest struct {
+	OperatorAddress common.Address
+	AVSAddress      common.Address
+	OperatorSetIds  []uint32
+}
+
+type AllocationModifyRequest struct {
+	OperatorAddress common.Address
+	Allocations     []allocationmanager.IAllocationManagerTypesAllocateParams
+}
+
+type AllocationDelayRequest struct {
+	OperatorAddress common.Address
+	Delay           uint32
+}
+
+type PermissionRemoveRequest struct {
+	AccountAddress   common.Address
+	AppointeeAddress common.Address
+	Target           common.Address
+	Selector         [4]byte
+}
+
+type PermissionSetRequest struct {
+	AccountAddress   common.Address
+	AppointeeAddress common.Address
+	Target           common.Address
+	Selector         [4]byte
+}
+
+type AdminAcceptRequest struct {
+	AccountAddress common.Address
+}
+
+type PendingAdminAcceptRequest struct {
+	AccountAddress common.Address
+	AdminAddress   common.Address
+}
+
+type AdminRemoveRequest struct {
+	AccountAddress common.Address
+	AdminAddress   common.Address
+}
+
+type PendingAdminRemoveRequest struct {
+	AccountAddress common.Address
+	AdminAddress   common.Address
 }

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -278,7 +278,7 @@ func (w *ChainWriter) SetClaimerFor(
 
 func (w *ChainWriter) ProcessClaim(
 	ctx context.Context,
-	request ClaimProcess,
+	request ClaimProcessRequest,
 	txOptions *TxOptions,
 ) (*gethtypes.Receipt, error) {
 	if w.rewardsCoordinator == nil {
@@ -306,13 +306,8 @@ func (w *ChainWriter) SetOperatorAVSSplit(
 		return nil, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
-	if err != nil {
-		return nil, utils.WrapError("failed to get no send tx opts", err)
-	}
-
 	tx, err := w.rewardsCoordinator.SetOperatorAVSSplit(
-		noSendTxOpts,
+		txOptions.Options,
 		request.OperatorAddress,
 		request.AVSAddress,
 		request.Split,
@@ -337,12 +332,7 @@ func (w *ChainWriter) SetOperatorPISplit(
 		return nil, errors.New("RewardsCoordinator contract not provided")
 	}
 
-	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
-	if err != nil {
-		return nil, utils.WrapError("failed to get no send tx opts", err)
-	}
-
-	tx, err := w.rewardsCoordinator.SetOperatorPISplit(noSendTxOpts, request.OperatorAddress, request.Split)
+	tx, err := w.rewardsCoordinator.SetOperatorPISplit(txOptions.Options, request.OperatorAddress, request.Split)
 	if err != nil {
 		return nil, utils.WrapError("failed to create SetOperatorAVSSplit tx", err)
 	}
@@ -356,7 +346,7 @@ func (w *ChainWriter) SetOperatorPISplit(
 
 func (w *ChainWriter) ProcessClaims(
 	ctx context.Context,
-	request ClaimsProcess,
+	request ClaimsProcessRequest,
 	txOptions *TxOptions,
 ) (*gethtypes.Receipt, error) {
 	if w.rewardsCoordinator == nil {
@@ -367,12 +357,7 @@ func (w *ChainWriter) ProcessClaims(
 		return nil, errors.New("claims is empty, at least one claim must be provided")
 	}
 
-	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
-	if err != nil {
-		return nil, utils.WrapError("failed to get no send tx opts", err)
-	}
-
-	tx, err := w.rewardsCoordinator.ProcessClaims(noSendTxOpts, request.Claims, request.RecipientAddress)
+	tx, err := w.rewardsCoordinator.ProcessClaims(txOptions.Options, request.Claims, request.RecipientAddress)
 	if err != nil {
 		return nil, utils.WrapError("failed to create ProcessClaims tx", err)
 	}
@@ -393,13 +378,8 @@ func (w *ChainWriter) ForceDeregisterFromOperatorSets(
 		return nil, errors.New("AVSDirectory contract not provided")
 	}
 
-	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
-	if err != nil {
-		return nil, utils.WrapError("failed to get no send tx opts", err)
-	}
-
 	tx, err := w.allocationManager.DeregisterFromOperatorSets(
-		noSendTxOpts,
+		txOptions.Options,
 		allocationmanager.IAllocationManagerTypesDeregisterParams{
 			Operator:       request.OperatorAddress,
 			Avs:            request.AVSAddress,
@@ -428,12 +408,7 @@ func (w *ChainWriter) ModifyAllocations(
 		return nil, errors.New("AllocationManager contract not provided")
 	}
 
-	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
-	if err != nil {
-		return nil, utils.WrapError("failed to get no send tx opts", err)
-	}
-
-	tx, err := w.allocationManager.ModifyAllocations(noSendTxOpts, request.OperatorAddress, request.Allocations)
+	tx, err := w.allocationManager.ModifyAllocations(txOptions.Options, request.OperatorAddress, request.Allocations)
 	if err != nil {
 		return nil, utils.WrapError("failed to create ModifyAllocations tx", err)
 	}
@@ -455,12 +430,7 @@ func (w *ChainWriter) SetAllocationDelay(
 		return nil, errors.New("AllocationManager contract not provided")
 	}
 
-	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
-	if err != nil {
-		return nil, utils.WrapError("failed to get no send tx opts", err)
-	}
-
-	tx, err := w.allocationManager.SetAllocationDelay(noSendTxOpts, request.OperatorAddress, request.Delay)
+	tx, err := w.allocationManager.SetAllocationDelay(txOptions.Options, request.OperatorAddress, request.Delay)
 	if err != nil {
 		return nil, utils.WrapError("failed to create InitializeAllocationDelay tx", err)
 	}
@@ -481,13 +451,8 @@ func (w *ChainWriter) DeregisterFromOperatorSets(
 		return nil, errors.New("AllocationManager contract not provided")
 	}
 
-	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
-	if err != nil {
-		return nil, utils.WrapError("failed to get no send tx opts", err)
-	}
-
 	tx, err := w.allocationManager.DeregisterFromOperatorSets(
-		noSendTxOpts,
+		txOptions.Options,
 		allocationmanager.IAllocationManagerTypesDeregisterParams{
 			Operator:       request.OperatorAddress,
 			Avs:            request.AVSAddress,
@@ -514,11 +479,6 @@ func (w *ChainWriter) RegisterForOperatorSets(
 		return nil, errors.New("AllocationManager contract not provided")
 	}
 
-	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
-	if err != nil {
-		return nil, utils.WrapError("failed to get no send tx opts", err)
-	}
-
 	pubkeyRegParams, err := getPubkeyRegistrationParams(
 		w.ethClient,
 		request.RegistryCoordinatorAddress,
@@ -534,7 +494,7 @@ func (w *ChainWriter) RegisterForOperatorSets(
 		return nil, utils.WrapError("failed to encode registration params", err)
 	}
 	tx, err := w.allocationManager.RegisterForOperatorSets(
-		noSendTxOpts,
+		txOptions.Options,
 		request.OperatorAddress,
 		allocationmanager.IAllocationManagerTypesRegisterParams{
 			Avs:            request.AVSAddress,

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -120,6 +120,7 @@ func NewWriterFromConfig(
 	), nil
 }
 
+// RegisterAsOperator registers an operator to EigenLayer
 func (w *ChainWriter) RegisterAsOperator(
 	ctx context.Context,
 	request RegisterOperatorRequest,
@@ -149,6 +150,7 @@ func (w *ChainWriter) RegisterAsOperator(
 	return receipt, nil
 }
 
+// UpdateOperatorDetails updates the operator details of the operator
 func (w *ChainWriter) UpdateOperatorDetails(
 	ctx context.Context,
 	request OperatorDetailsRequest,
@@ -183,6 +185,7 @@ func (w *ChainWriter) UpdateOperatorDetails(
 	return receipt, nil
 }
 
+// UpdateMetadataURI updates the metadata URI of the operator
 func (w *ChainWriter) UpdateMetadataURI(
 	ctx context.Context,
 	request MetadataURIRequest,
@@ -209,6 +212,8 @@ func (w *ChainWriter) UpdateMetadataURI(
 	return receipt, nil
 }
 
+// DepositERC20IntoStrategy gets the underlying token of the strategy and deposits the given amount of tokens into the
+// strategy
 func (w *ChainWriter) DepositERC20IntoStrategy(
 	ctx context.Context,
 	request ERC20IntoStrategyRequest,
@@ -255,6 +260,7 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 	return receipt, nil
 }
 
+// SetClaimerFor sets the claimer authorized to call processClaim on behalf of the earner.
 func (w *ChainWriter) SetClaimerFor(
 	ctx context.Context,
 	request ClaimForRequest,
@@ -276,6 +282,8 @@ func (w *ChainWriter) SetClaimerFor(
 	return receipt, nil
 }
 
+// ProcessClaim processes a merkle-based rewards claim for the specified earner, transferring balance to the given
+// recipient.
 func (w *ChainWriter) ProcessClaim(
 	ctx context.Context,
 	request ClaimProcessRequest,
@@ -297,6 +305,7 @@ func (w *ChainWriter) ProcessClaim(
 	return receipt, nil
 }
 
+// SetOperatorAVSSplit sets the AVS split for a given operator and AVS address.
 func (w *ChainWriter) SetOperatorAVSSplit(
 	ctx context.Context,
 	request OperatorAVSSplitRequest,
@@ -323,6 +332,7 @@ func (w *ChainWriter) SetOperatorAVSSplit(
 	return receipt, nil
 }
 
+// SetOperatorPISplit sets the PI Split for a given operator.
 func (w *ChainWriter) SetOperatorPISplit(
 	ctx context.Context,
 	request OperatorPISplitRequest,
@@ -344,6 +354,8 @@ func (w *ChainWriter) SetOperatorPISplit(
 	return receipt, nil
 }
 
+// ProcessClaims processes multiple merkle-based reward claims in a single batch, transferring balances to the
+// specified recipient.
 func (w *ChainWriter) ProcessClaims(
 	ctx context.Context,
 	request ClaimsProcessRequest,
@@ -369,6 +381,7 @@ func (w *ChainWriter) ProcessClaims(
 	return receipt, nil
 }
 
+// ForceDeregisterFromOperatorSets removes an operator from one or more operator sets associated with a given AVS.
 func (w *ChainWriter) ForceDeregisterFromOperatorSets(
 	ctx context.Context,
 	request OperatorSetDeregisterRequest,
@@ -399,6 +412,7 @@ func (w *ChainWriter) ForceDeregisterFromOperatorSets(
 	return receipt, nil
 }
 
+// ModifyAllocations modifies the proportions of slashable stake allocated to an operator set from a list of strategies
 func (w *ChainWriter) ModifyAllocations(
 	ctx context.Context,
 	request AllocationModifyRequest,
@@ -421,6 +435,7 @@ func (w *ChainWriter) ModifyAllocations(
 	return receipt, nil
 }
 
+// SetAllocationDelay defines the number of blocks (delay) before an operator’s allocated stake becomes slashable.
 func (w *ChainWriter) SetAllocationDelay(
 	ctx context.Context,
 	request AllocationDelayRequest,
@@ -442,6 +457,7 @@ func (w *ChainWriter) SetAllocationDelay(
 	return receipt, nil
 }
 
+// DeregisterFromOperatorSets removes an operator from one or more operator sets associated with a given AVS.
 func (w *ChainWriter) DeregisterFromOperatorSets(
 	ctx context.Context,
 	request OperatorSetDeregisterRequest,
@@ -470,6 +486,7 @@ func (w *ChainWriter) DeregisterFromOperatorSets(
 	return receipt, nil
 }
 
+// RegisterForOperatorSets allows an operator to register for one or more operator sets for an AVS.
 func (w *ChainWriter) RegisterForOperatorSets(
 	ctx context.Context,
 	request RegisterOperatorSetsRequest,
@@ -513,6 +530,7 @@ func (w *ChainWriter) RegisterForOperatorSets(
 	return receipt, nil
 }
 
+// RemovePermission removes an appointee for a given account.
 func (w *ChainWriter) RemovePermission(
 	ctx context.Context,
 	request PermissionRemoveRequest,
@@ -525,7 +543,7 @@ func (w *ChainWriter) RemovePermission(
 	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
-// Should be a public or private method?
+// Should be a public or private method? Can we move this logic to RemovePermission?
 func (w *ChainWriter) NewRemovePermissionTx(
 	request PermissionRemoveRequest,
 	txOpts *bind.TransactOpts,
@@ -543,7 +561,7 @@ func (w *ChainWriter) NewRemovePermissionTx(
 	)
 }
 
-// Should be a public or private method?
+// Should be a public or private method? Can we move this logic to SetPermission?
 func (w *ChainWriter) NewSetPermissionTx(
 	request PermissionSetRequest,
 	txOpts *bind.TransactOpts,
@@ -560,6 +578,7 @@ func (w *ChainWriter) NewSetPermissionTx(
 	)
 }
 
+// SetPermission sets an appointee for a given account.
 func (w *ChainWriter) SetPermission(
 	ctx context.Context,
 	request PermissionSetRequest,
@@ -573,7 +592,7 @@ func (w *ChainWriter) SetPermission(
 	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
-// Should be a public or private method?
+// Should be a public or private method? Can we move this logic to AcceptAdmin?
 func (w *ChainWriter) NewAcceptAdminTx(
 	request AdminAcceptRequest,
 	txOpts *bind.TransactOpts,
@@ -584,6 +603,7 @@ func (w *ChainWriter) NewAcceptAdminTx(
 	return w.permissionController.AcceptAdmin(txOpts, request.AccountAddress)
 }
 
+// AcceptAdmin removes a pending admin from the list of pending admins and adds them to the list of admins.
 func (w *ChainWriter) AcceptAdmin(
 	ctx context.Context,
 	request AdminAcceptRequest,
@@ -596,7 +616,7 @@ func (w *ChainWriter) AcceptAdmin(
 	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
-// Should be a public or private method?
+// Should be a public or private method? Can we move this logic to AddPendingAdmin?
 func (w *ChainWriter) NewAddPendingAdminTx(
 	request PendingAdminAcceptRequest,
 	txOpts *bind.TransactOpts,
@@ -607,6 +627,7 @@ func (w *ChainWriter) NewAddPendingAdminTx(
 	return w.permissionController.AddPendingAdmin(txOpts, request.AccountAddress, request.AdminAddress)
 }
 
+// AddPendingAdmin adds an admin to the list of pending admins.
 func (w *ChainWriter) AddPendingAdmin(
 	ctx context.Context,
 	request PendingAdminAcceptRequest,
@@ -619,7 +640,7 @@ func (w *ChainWriter) AddPendingAdmin(
 	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
-// Should be a public or private method?
+// Should be a public or private method? Can we move this logic to RemoveAdmin?
 func (w *ChainWriter) NewRemoveAdminTx(
 	request AdminRemoveRequest,
 	txOpts *bind.TransactOpts,
@@ -630,6 +651,7 @@ func (w *ChainWriter) NewRemoveAdminTx(
 	return w.permissionController.RemoveAdmin(txOpts, request.AccountAddress, request.AdminAddress)
 }
 
+// RemoveAdmin removes an admin of an account.
 func (w *ChainWriter) RemoveAdmin(
 	ctx context.Context,
 	request AdminRemoveRequest,
@@ -642,7 +664,7 @@ func (w *ChainWriter) RemoveAdmin(
 	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
-// Should be a public or private method?
+// Should be a public or private method? Can we move this logic to RemovePendingAdmin?
 func (w *ChainWriter) NewRemovePendingAdminTx(
 	request PendingAdminRemoveRequest,
 	txOpts *bind.TransactOpts,
@@ -653,6 +675,7 @@ func (w *ChainWriter) NewRemovePendingAdminTx(
 	return w.permissionController.RemovePendingAdmin(txOpts, request.AccountAddress, request.AdminAddress)
 }
 
+// RemovePendingAdmin removes a pending admin of an account
 func (w *ChainWriter) RemovePendingAdmin(
 	ctx context.Context,
 	request PendingAdminRemoveRequest,

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -140,7 +140,7 @@ func (w *ChainWriter) RegisterAsOperator(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -168,7 +168,7 @@ func (w *ChainWriter) UpdateOperatorDetails(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -196,7 +196,7 @@ func (w *ChainWriter) UpdateMetadataURI(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -232,7 +232,7 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to approve token transfer"), err)
 	}
-	_, err = w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	_, err = w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -246,7 +246,7 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
@@ -268,7 +268,7 @@ func (w *ChainWriter) SetClaimerFor(
 	if err != nil {
 		return nil, err
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -289,7 +289,7 @@ func (w *ChainWriter) ProcessClaim(
 	if err != nil {
 		return nil, utils.WrapError("failed to create ProcessClaim tx", err)
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -315,7 +315,7 @@ func (w *ChainWriter) SetOperatorAVSSplit(
 	if err != nil {
 		return nil, utils.WrapError("failed to create SetOperatorAVSSplit tx", err)
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -336,7 +336,7 @@ func (w *ChainWriter) SetOperatorPISplit(
 	if err != nil {
 		return nil, utils.WrapError("failed to create SetOperatorAVSSplit tx", err)
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -361,7 +361,7 @@ func (w *ChainWriter) ProcessClaims(
 	if err != nil {
 		return nil, utils.WrapError("failed to create ProcessClaims tx", err)
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -391,7 +391,7 @@ func (w *ChainWriter) ForceDeregisterFromOperatorSets(
 		return nil, utils.WrapError("failed to create ForceDeregisterFromOperatorSets tx", err)
 	}
 
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -413,7 +413,7 @@ func (w *ChainWriter) ModifyAllocations(
 		return nil, utils.WrapError("failed to create ModifyAllocations tx", err)
 	}
 
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -434,7 +434,7 @@ func (w *ChainWriter) SetAllocationDelay(
 	if err != nil {
 		return nil, utils.WrapError("failed to create InitializeAllocationDelay tx", err)
 	}
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -462,7 +462,7 @@ func (w *ChainWriter) DeregisterFromOperatorSets(
 		return nil, utils.WrapError("failed to create DeregisterFromOperatorSets tx", err)
 	}
 
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -505,7 +505,7 @@ func (w *ChainWriter) RegisterForOperatorSets(
 		return nil, utils.WrapError("failed to create RegisterForOperatorSets tx", err)
 	}
 
-	receipt, err := w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	receipt, err := w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 	if err != nil {
 		return nil, utils.WrapError("failed to send tx", err)
 	}
@@ -522,7 +522,7 @@ func (w *ChainWriter) RemovePermission(
 	if err != nil {
 		return nil, utils.WrapError("failed to create NewRemovePermissionTx", err)
 	}
-	return w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
 // Should be a public or private method?
@@ -570,7 +570,7 @@ func (w *ChainWriter) SetPermission(
 		return nil, utils.WrapError("failed to create NewSetPermissionTx", err)
 	}
 
-	return w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
 // Should be a public or private method?
@@ -593,7 +593,7 @@ func (w *ChainWriter) AcceptAdmin(
 	if err != nil {
 		return nil, utils.WrapError("failed to create AcceptAdmin transaction", err)
 	}
-	return w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
 // Should be a public or private method?
@@ -616,7 +616,7 @@ func (w *ChainWriter) AddPendingAdmin(
 	if err != nil {
 		return nil, utils.WrapError("failed to create AddPendingAdminTx", err)
 	}
-	return w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
 // Should be a public or private method?
@@ -639,7 +639,7 @@ func (w *ChainWriter) RemoveAdmin(
 	if err != nil {
 		return nil, utils.WrapError("failed to create RemoveAdmin transaction", err)
 	}
-	return w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
 // Should be a public or private method?
@@ -663,7 +663,7 @@ func (w *ChainWriter) RemovePendingAdmin(
 		return nil, utils.WrapError("failed to create RemovePendingAdmin transaction", err)
 	}
 
-	return w.txMgr.Send(ctx, tx, txOptions.WaitForReceipt)
+	return w.txMgr.Send(ctx, tx, request.WaitForReceipt)
 }
 
 func getPubkeyRegistrationParams(

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -87,8 +87,7 @@ func TestRegisterOperator(t *testing.T) {
 		require.NoError(t, err)
 
 		txOptions := &elcontracts.TxOptions{
-			WaitForReceipt: true,
-			Options:        opts,
+			Options: opts,
 		}
 
 		operator :=
@@ -99,7 +98,8 @@ func TestRegisterOperator(t *testing.T) {
 			}
 
 		request := elcontracts.RegisterOperatorRequest{
-			Operator: operator,
+			Operator:       operator,
+			WaitForReceipt: true,
 		}
 
 		receipt, err := clients.ElChainWriter.RegisterAsOperator(context.Background(), request, txOptions)
@@ -125,8 +125,7 @@ func TestRegisterOperator(t *testing.T) {
 		require.NoError(t, err)
 
 		txOptions := &elcontracts.TxOptions{
-			WaitForReceipt: true,
-			Options:        opts,
+			Options: opts,
 		}
 
 		operator :=
@@ -137,7 +136,8 @@ func TestRegisterOperator(t *testing.T) {
 			}
 
 		request := elcontracts.RegisterOperatorRequest{
-			Operator: operator,
+			Operator:       operator,
+			WaitForReceipt: true,
 		}
 
 		_, err = clients.ElChainWriter.RegisterAsOperator(context.Background(), request, txOptions)
@@ -200,11 +200,11 @@ func TestRegisterAndDeregisterFromOperatorSets(t *testing.T) {
 		OperatorSetIds:             []uint32{operatorSetId},
 		Socket:                     "socket",
 		BlsKeyPair:                 keypair,
+		WaitForReceipt:             true,
 	}
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	operatorSet := allocationmanager.OperatorSet{
@@ -243,6 +243,7 @@ func TestRegisterAndDeregisterFromOperatorSets(t *testing.T) {
 		OperatorAddress: operatorAddress,
 		AVSAddress:      avsAddress,
 		OperatorSetIds:  []uint32{operatorSetId},
+		WaitForReceipt:  true,
 	}
 
 	t.Run("deregister operator from operator set", func(t *testing.T) {
@@ -281,8 +282,7 @@ func TestChainWriter(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	t.Run("update operator details", func(t *testing.T) {
@@ -297,7 +297,8 @@ func TestChainWriter(t *testing.T) {
 		}
 
 		request := elcontracts.OperatorDetailsRequest{
-			Operator: operatorModified,
+			Operator:       operatorModified,
+			WaitForReceipt: true,
 		}
 
 		receipt, err := clients.ElChainWriter.UpdateOperatorDetails(context.Background(), request, txOptions)
@@ -313,7 +314,8 @@ func TestChainWriter(t *testing.T) {
 		}
 
 		request := elcontracts.OperatorDetailsRequest{
-			Operator: wrongOperatorModified,
+			Operator:       wrongOperatorModified,
+			WaitForReceipt: true,
 		}
 
 		_, err := clients.ElChainWriter.UpdateOperatorDetails(
@@ -331,6 +333,7 @@ func TestChainWriter(t *testing.T) {
 		request := elcontracts.MetadataURIRequest{
 			OperatorAddress: walletModifiedAddress,
 			Uri:             "https://0.0.0.0",
+			WaitForReceipt:  true,
 		}
 
 		receipt, err := clients.ElChainWriter.UpdateMetadataURI(
@@ -346,6 +349,7 @@ func TestChainWriter(t *testing.T) {
 		requestWronOperator := elcontracts.MetadataURIRequest{
 			OperatorAddress: common.HexToAddress(testutils.ANVIL_THIRD_ADDRESS),
 			Uri:             "https://0.0.0.0",
+			WaitForReceipt:  true,
 		}
 		_, err := clients.ElChainWriter.UpdateMetadataURI(
 			context.Background(),
@@ -359,6 +363,7 @@ func TestChainWriter(t *testing.T) {
 		request := elcontracts.ERC20IntoStrategyRequest{
 			StrategyAddress: contractAddrs.Erc20MockStrategy,
 			Amount:          big.NewInt(1),
+			WaitForReceipt:  true,
 		}
 		receipt, err := clients.ElChainWriter.DepositERC20IntoStrategy(
 			context.Background(),
@@ -397,12 +402,12 @@ func TestSetClaimerFor(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	request := elcontracts.ClaimForRequest{
-		Claimer: common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS),
+		Claimer:        common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS),
+		WaitForReceipt: true,
 	}
 
 	// call SetClaimerFor
@@ -450,8 +455,7 @@ func TestSetOperatorPISplit(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	expectedInitialSplit := uint16(1000)
@@ -465,6 +469,7 @@ func TestSetOperatorPISplit(t *testing.T) {
 	request := elcontracts.OperatorPISplitRequest{
 		OperatorAddress: operatorAddr,
 		Split:           newSplit,
+		WaitForReceipt:  true,
 	}
 
 	receipt, err = chainWriter.SetOperatorPISplit(context.Background(), request, txOptions)
@@ -522,8 +527,7 @@ func TestSetOperatorAVSSplit(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	expectedInitialSplit := uint16(1000)
@@ -537,6 +541,7 @@ func TestSetOperatorAVSSplit(t *testing.T) {
 		OperatorAddress: operatorAddr,
 		AVSAddress:      avsAddr,
 		Split:           newSplit,
+		WaitForReceipt:  true,
 	}
 
 	receipt, err = chainWriter.SetOperatorAVSSplit(
@@ -592,8 +597,7 @@ func TestSetAllocationDelay(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	t.Run("set allocation delay", func(t *testing.T) {
@@ -601,6 +605,7 @@ func TestSetAllocationDelay(t *testing.T) {
 		request := elcontracts.AllocationDelayRequest{
 			OperatorAddress: operatorAddr,
 			Delay:           delay,
+			WaitForReceipt:  true,
 		}
 		receipt, err := chainWriter.SetAllocationDelay(context.Background(), request, txOptions)
 		require.NoError(t, err)
@@ -653,6 +658,7 @@ func TestSetAndRemovePermission(t *testing.T) {
 		AppointeeAddress: appointeeAddress,
 		Target:           target,
 		Selector:         selector,
+		WaitForReceipt:   true,
 	}
 
 	removePermissionRequest := elcontracts.PermissionRemoveRequest{
@@ -660,6 +666,7 @@ func TestSetAndRemovePermission(t *testing.T) {
 		AppointeeAddress: appointeeAddress,
 		Target:           target,
 		Selector:         selector,
+		WaitForReceipt:   true,
 	}
 
 	txManager, err := testclients.NewTestTxManager(anvilHttpEndpoint, testutils.ANVIL_FIRST_PRIVATE_KEY)
@@ -669,8 +676,7 @@ func TestSetAndRemovePermission(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	t.Run("set permission to account", func(t *testing.T) {
@@ -732,8 +738,7 @@ func TestModifyAllocations(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	strategyAddr := contractAddrs.Erc20MockStrategy
@@ -756,6 +761,7 @@ func TestModifyAllocations(t *testing.T) {
 	requestAllocation := elcontracts.AllocationModifyRequest{
 		OperatorAddress: operatorAddr,
 		Allocations:     allocateParams,
+		WaitForReceipt:  true,
 	}
 
 	_, err = chainWriter.ModifyAllocations(context.Background(), requestAllocation, txOptions)
@@ -765,6 +771,7 @@ func TestModifyAllocations(t *testing.T) {
 	requestDelay := elcontracts.AllocationDelayRequest{
 		OperatorAddress: operatorAddr,
 		Delay:           delay,
+		WaitForReceipt:  true,
 	}
 	// The allocation delay must be initialized before modifying the allocations
 	receipt, err := chainWriter.SetAllocationDelay(context.Background(), requestDelay, txOptions)
@@ -836,19 +843,20 @@ func TestAddAndRemovePendingAdmin(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	pendingAdmin := common.HexToAddress(testutils.ANVIL_THIRD_ADDRESS)
 	acceptPendingAdminRequest := elcontracts.PendingAdminAcceptRequest{
 		AccountAddress: operatorAddr,
 		AdminAddress:   pendingAdmin,
+		WaitForReceipt: true,
 	}
 
 	removePendingAdminRequest := elcontracts.PendingAdminRemoveRequest{
 		AccountAddress: operatorAddr,
 		AdminAddress:   pendingAdmin,
+		WaitForReceipt: true,
 	}
 
 	t.Run("remove pending admin when not added", func(t *testing.T) {
@@ -923,19 +931,18 @@ func TestAcceptAdmin(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptionsAccount := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        optsAccount,
+		Options: optsAccount,
 	}
 
 	txOptionsPendingAdmin := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        optsPendingAdmin,
+		Options: optsPendingAdmin,
 	}
 
 	pendingAdminAddr := common.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
 	request := elcontracts.PendingAdminAcceptRequest{
 		AccountAddress: accountAddr,
 		AdminAddress:   pendingAdminAddr,
+		WaitForReceipt: true,
 	}
 	receipt, err := accountChainWriter.AddPendingAdmin(context.Background(), request, txOptionsAccount)
 	require.NoError(t, err)
@@ -943,6 +950,7 @@ func TestAcceptAdmin(t *testing.T) {
 
 	acceptAdminRequest := elcontracts.AdminAcceptRequest{
 		AccountAddress: accountAddr,
+		WaitForReceipt: true,
 	}
 	t.Run("accept admin", func(t *testing.T) {
 		receipt, err = adminChainWriter.AcceptAdmin(context.Background(), acceptAdminRequest, txOptionsPendingAdmin)
@@ -1012,29 +1020,29 @@ func TestRemoveAdmin(t *testing.T) {
 	require.NoError(t, err)
 
 	accountTxOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        optsAccount,
+		Options: optsAccount,
 	}
 
 	admin1TxOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        optsAdmin1,
+		Options: optsAdmin1,
 	}
 
 	admin2TxOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        optsAdmin2,
+		Options: optsAdmin2,
 	}
 	addAdmin1Request := elcontracts.PendingAdminAcceptRequest{
 		AccountAddress: accountAddr,
 		AdminAddress:   admin1,
+		WaitForReceipt: true,
 	}
 	addAdmin2Request := elcontracts.PendingAdminAcceptRequest{
 		AccountAddress: accountAddr,
 		AdminAddress:   admin2,
+		WaitForReceipt: true,
 	}
 	acceptAdminRequest := elcontracts.AdminAcceptRequest{
 		AccountAddress: accountAddr,
+		WaitForReceipt: true,
 	}
 
 	// Add and accept admin 1
@@ -1058,6 +1066,7 @@ func TestRemoveAdmin(t *testing.T) {
 	removeAdminRequest := elcontracts.AdminRemoveRequest{
 		AccountAddress: accountAddr,
 		AdminAddress:   admin2,
+		WaitForReceipt: true,
 	}
 
 	t.Run("remove admin 2", func(t *testing.T) {
@@ -1106,8 +1115,7 @@ func TestProcessClaim(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	activationDelay := uint32(0)
@@ -1124,6 +1132,7 @@ func TestProcessClaim(t *testing.T) {
 	request := elcontracts.ClaimProcessRequest{
 		Claim:            *claim,
 		RecipientAddress: recipient,
+		WaitForReceipt:   true,
 	}
 	receipt, err = chainWriter.ProcessClaim(context.Background(), request, txOptions)
 	require.NoError(t, err)
@@ -1160,8 +1169,7 @@ func TestProcessClaims(t *testing.T) {
 	require.NoError(t, err)
 
 	txOptions := &elcontracts.TxOptions{
-		WaitForReceipt: true,
-		Options:        opts,
+		Options: opts,
 	}
 
 	activationDelay := uint32(0)
@@ -1179,6 +1187,7 @@ func TestProcessClaims(t *testing.T) {
 	request := elcontracts.ClaimsProcessRequest{
 		Claims:           emptyClaims,
 		RecipientAddress: recipient,
+		WaitForReceipt:   true,
 	}
 	_, err = chainWriter.ProcessClaims(context.Background(), request, txOptions)
 	require.Error(t, err, "cannot process empty claims")
@@ -1196,6 +1205,7 @@ func TestProcessClaims(t *testing.T) {
 	request = elcontracts.ClaimsProcessRequest{
 		Claims:           claims,
 		RecipientAddress: recipient,
+		WaitForReceipt:   true,
 	}
 	receipt, err = chainWriter.ProcessClaims(context.Background(), request, txOptions)
 	require.NoError(t, err)

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -169,7 +169,7 @@ func TestRegisterAndDeregisterFromOperatorSets(t *testing.T) {
 	chainReader, err := testclients.NewTestChainReaderFromConfig(anvilHttpEndpoint, config)
 	require.NoError(t, err)
 
-	txManager, err := testclients.NewTestTxManager(anvilHttpEndpoint, testutils.ANVIL_FIRST_PRIVATE_KEY)
+	txManager, err := testclients.NewTestTxManager(anvilHttpEndpoint, testutils.ANVIL_SECOND_PRIVATE_KEY)
 	require.NoError(t, err)
 
 	opts, err := txManager.GetNoSendTxOpts()


### PR DESCRIPTION
### What Changed?
This PR improves the `elcontracts/reader` interface by implementing a request-response pattern. For the exposed functions, we now use structs to represent the request (the necessary parameters for the function + `WaitForReceipt` flag). We continue returning the Ethereum Receipt (from [go-ethereum](https://github.com/ethereum/go-ethereum)) instead of creating a custom response struct.

Because the function signatures change, we also refactor the tests to align with the new pattern.

Below is a simple example of the new request-response pattern:

```go
func (w *ChainWriter) Bar(
	ctx context.Context,
	request BarRequest,
	txOptions *TxOptions,
) (*types.Receipt, error) {
       ...
}

type TxOptions struct {
    Options *bind.TransactOpts
}

type BarRequest struct {
    WaitForReceipt bool
    // ... other fields
}
```

This is a work in progress and changes may occur.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it