### PR TITLE
refactor: `avsregistry` interface

### DIFF
--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -229,6 +229,7 @@ func (r *ChainReader) GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(
 // So, if the blockNumber and blockHash are not set in opts, blockNumber will be set
 // to the latest block.
 // All calls to the chain use `opts` parameter.
+// REVIEW THE COMMENT ABOVE. IT MAKES SENSE WITH THE NEW IMPLEMENTATION?
 func (r *ChainReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(
 	ctx context.Context,
 	request OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest,

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -193,10 +193,10 @@ func (r *ChainReader) GetOperatorAddrsInQuorumsAtCurrentBlock(
 // block
 func (r *ChainReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 	ctx context.Context,
-	request OperatorsStakeInQuorumsOfOperatorAtBlockRequest,
-) (OperatorsStakeInQuorumsOfOperatorResponse, error) {
+	request OperatorsStakeInQuorumsByOperatorAtBlockRequest,
+) (OperatorsStakeInQuorumsByOperatorResponse, error) {
 	if r.operatorStateRetriever == nil {
-		return OperatorsStakeInQuorumsOfOperatorResponse{}, errors.New(
+		return OperatorsStakeInQuorumsByOperatorResponse{}, errors.New(
 			"OperatorStateRetriever contract not provided",
 		)
 	}
@@ -207,11 +207,11 @@ func (r *ChainReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 		request.OperatorId,
 		request.HistoricalBlockNumber)
 	if err != nil {
-		return OperatorsStakeInQuorumsOfOperatorResponse{}, utils.WrapError("Failed to get operators state", err)
+		return OperatorsStakeInQuorumsByOperatorResponse{}, utils.WrapError("Failed to get operators state", err)
 	}
 
 	quorums := types.BitmapToQuorumIds(quorumBitmap)
-	return OperatorsStakeInQuorumsOfOperatorResponse{
+	return OperatorsStakeInQuorumsByOperatorResponse{
 		QuorumNumbers:           quorums,
 		OperatorsStakesInQuorum: operatorStakes,
 	}, nil
@@ -221,14 +221,14 @@ func (r *ChainReader) GetOperatorsStakeInQuorumsOfOperatorAtBlock(
 // current block
 func (r *ChainReader) GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(
 	ctx context.Context,
-	request OperatorsStakeInQuorumsOfOperatorAtCurrentBlockRequest,
-) (OperatorsStakeInQuorumsOfOperatorResponse, error) {
+	request OperatorsStakeInQuorumsByOperatorAtCurrentBlockRequest,
+) (OperatorsStakeInQuorumsByOperatorResponse, error) {
 	curBlock, err := r.ethClient.BlockNumber(ctx)
 	if err != nil {
-		return OperatorsStakeInQuorumsOfOperatorResponse{}, utils.WrapError("Failed to get current block number", err)
+		return OperatorsStakeInQuorumsByOperatorResponse{}, utils.WrapError("Failed to get current block number", err)
 	}
 
-	return r.GetOperatorsStakeInQuorumsOfOperatorAtBlock(ctx, OperatorsStakeInQuorumsOfOperatorAtBlockRequest{
+	return r.GetOperatorsStakeInQuorumsOfOperatorAtBlock(ctx, OperatorsStakeInQuorumsByOperatorAtBlockRequest{
 		BlockNumber:           request.BlockNumber,
 		HistoricalBlockNumber: uint32(curBlock),
 		OperatorId:            request.OperatorId,
@@ -239,7 +239,7 @@ func (r *ChainReader) GetOperatorsStakeInQuorumsOfOperatorAtCurrentBlock(
 // are registered
 func (r *ChainReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(
 	ctx context.Context,
-	request OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest,
+	request OperatorQuorumStakeAtCurrentBlockRequest,
 ) (OperatorStakeInQuorumsOfOperatorResponse, error) {
 	if r.registryCoordinator == nil {
 		return OperatorStakeInQuorumsOfOperatorResponse{}, errors.New(
@@ -405,10 +405,10 @@ func (r *ChainReader) QueryRegistrationDetail(
 // IsOperatorRegistered checks if an operator is registered with an AVS
 func (r *ChainReader) IsOperatorRegistered(
 	ctx context.Context,
-	request OperatorRegisteredRequest,
-) (OperatorRegisteredResponse, error) {
+	request OperatorRegistrationRequest,
+) (OperatorRegistrationResponse, error) {
 	if r.registryCoordinator == nil {
-		return OperatorRegisteredResponse{}, errors.New("RegistryCoordinator contract not provided")
+		return OperatorRegistrationResponse{}, errors.New("RegistryCoordinator contract not provided")
 	}
 
 	operatorStatus, err := r.registryCoordinator.GetOperatorStatus(
@@ -416,12 +416,12 @@ func (r *ChainReader) IsOperatorRegistered(
 		request.OperatorAddress,
 	)
 	if err != nil {
-		return OperatorRegisteredResponse{}, utils.WrapError("Failed to get operator status", err)
+		return OperatorRegistrationResponse{}, utils.WrapError("Failed to get operator status", err)
 	}
 
 	// 0 = NEVER_REGISTERED, 1 = REGISTERED, 2 = DEREGISTERED
 	registeredWithAvs := operatorStatus == 1
-	return OperatorRegisteredResponse{IsRegistered: registeredWithAvs}, nil
+	return OperatorRegistrationResponse{IsRegistered: registeredWithAvs}, nil
 }
 
 // QueryExistingRegisteredOperatorPubKeys returns the public keys of registered operators

--- a/chainio/clients/avsregistry/reader.go
+++ b/chainio/clients/avsregistry/reader.go
@@ -22,7 +22,7 @@ import (
 
 // DefaultQueryBlockRange different node providers have different eth_getLogs range limits.
 // 10k is an arbitrary choice that should work for most
-var DefaultQueryBlockRange = big.NewInt(10_000)
+var DefaultQueryBlockRange uint64 = 10_000
 
 type Config struct {
 	RegistryCoordinatorAddress    common.Address
@@ -426,7 +426,7 @@ func (r *ChainReader) QueryExistingRegisteredOperatorPubKeys(
 		request.StopBlock = curBlockNum
 	}
 	if request.BlockRange == 0 {
-		request.BlockRange = DefaultQueryBlockRange.Uint64()
+		request.BlockRange = DefaultQueryBlockRange
 	}
 
 	operatorAddresses := make([]types.OperatorAddr, 0)
@@ -523,7 +523,7 @@ func (r *ChainReader) QueryExistingRegisteredOperatorSockets(
 		request.StopBlock = curBlockNum
 	}
 	if request.BlockRange == 0 {
-		request.BlockRange = DefaultQueryBlockRange.Uint64()
+		request.BlockRange = DefaultQueryBlockRange
 	}
 
 	operatorIdToSocketMap := make(map[types.OperatorId]types.Socket)

--- a/chainio/clients/avsregistry/reader_test.go
+++ b/chainio/clients/avsregistry/reader_test.go
@@ -94,7 +94,10 @@ func TestReaderMethods(t *testing.T) {
 				BlockNumber: nil,
 				OperatorId:  response.OperatorId,
 			}
-			responseOperators, err := chainReader.GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(context.Background(), stakesRequest)
+			responseOperators, err := chainReader.GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(
+				context.Background(),
+				stakesRequest,
+			)
 			require.NoError(t, err)
 			require.Equal(t, 0, len(responseOperators.QuorumStakes))
 		})

--- a/chainio/clients/avsregistry/reader_test.go
+++ b/chainio/clients/avsregistry/reader_test.go
@@ -68,7 +68,7 @@ func TestReaderMethods(t *testing.T) {
 			response, err := chainReader.GetOperatorId(context.Background(), request)
 			require.NoError(t, err)
 
-			operatorStakeRequest := avsregistry.OperatorsStakeInQuorumsOfOperatorAtBlockRequest{
+			operatorStakeRequest := avsregistry.OperatorsStakeInQuorumsByOperatorAtBlockRequest{
 				BlockNumber:           nil,
 				OperatorId:            response.OperatorId,
 				HistoricalBlockNumber: 100,
@@ -90,7 +90,7 @@ func TestReaderMethods(t *testing.T) {
 			response, err := chainReader.GetOperatorId(context.Background(), request)
 			require.NoError(t, err)
 
-			stakesRequest := avsregistry.OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest{
+			stakesRequest := avsregistry.OperatorQuorumStakeAtCurrentBlockRequest{
 				BlockNumber: nil,
 				OperatorId:  response.OperatorId,
 			}
@@ -164,7 +164,7 @@ func TestReaderMethods(t *testing.T) {
 
 	t.Run("is operator registered", func(t *testing.T) {
 		operatorAddress := common.HexToAddress("0x1234567890123456789012345678901234567890")
-		request := avsregistry.OperatorRegisteredRequest{
+		request := avsregistry.OperatorRegistrationRequest{
 			BlockNumber:     nil,
 			OperatorAddress: operatorAddress,
 		}

--- a/chainio/clients/avsregistry/reader_test.go
+++ b/chainio/clients/avsregistry/reader_test.go
@@ -2,12 +2,11 @@ package avsregistry_test
 
 import (
 	"context"
-	"math/big"
 	"testing"
 
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/testutils/testclients"
 	"github.com/Layr-Labs/eigensdk-go/types"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -19,37 +18,63 @@ func TestReaderMethods(t *testing.T) {
 	quorumNumbers := types.QuorumNums{0}
 
 	t.Run("get quorum state", func(t *testing.T) {
-		count, err := chainReader.GetQuorumCount(&bind.CallOpts{})
+		request := avsregistry.QuorumCountRequest{
+			BlockNumber: nil,
+		}
+		response, err := chainReader.GetQuorumCount(context.Background(), request)
 		require.NoError(t, err)
-		require.NotNil(t, count)
+		require.NotNil(t, response.QuorumCount)
 	})
 
 	t.Run("get operator stake in quorums at current block", func(t *testing.T) {
-		stake, err := chainReader.GetOperatorsStakeInQuorumsAtCurrentBlock(&bind.CallOpts{}, quorumNumbers)
+		request := avsregistry.OperatorsStakeInQuorumAtCurrentBlockRequest{
+			BlockNumber:   nil,
+			QuorumNumbers: quorumNumbers,
+		}
+		response, err := chainReader.GetOperatorsStakeInQuorumsAtCurrentBlock(context.Background(), request)
 		require.NoError(t, err)
-		require.NotNil(t, stake)
+		require.NotNil(t, response.OperatorsStakeInQuorum)
 	})
 
 	t.Run("get operator stake in quorums at block", func(t *testing.T) {
-		stake, err := chainReader.GetOperatorsStakeInQuorumsAtBlock(&bind.CallOpts{}, quorumNumbers, 100)
+		request := avsregistry.OperatorsStakeInQuorumAtBlockRequest{
+			BlockNumber:           nil,
+			QuorumNumbers:         quorumNumbers,
+			HistoricalBlockNumber: 100,
+		}
+		response, err := chainReader.GetOperatorsStakeInQuorumsAtBlock(context.Background(), request)
 		require.NoError(t, err)
-		require.NotNil(t, stake)
+		require.NotNil(t, response.OperatorsStakeInQuorum)
 	})
 
 	t.Run("get operator address in quorums at current block", func(t *testing.T) {
-		addresses, err := chainReader.GetOperatorAddrsInQuorumsAtCurrentBlock(&bind.CallOpts{}, quorumNumbers)
+		request := avsregistry.OperatorAddrsInQuorumsAtCurrentBlockRequest{
+			BlockNumber:   nil,
+			QuorumNumbers: quorumNumbers,
+		}
+		response, err := chainReader.GetOperatorAddrsInQuorumsAtCurrentBlock(context.Background(), request)
 		require.NoError(t, err)
-		require.NotNil(t, addresses)
+		require.NotNil(t, response.OperatorAddrsInQuorums)
 	})
 
 	t.Run(
 		"get operators stake in quorums of operator at block returns error for non-registered operator",
 		func(t *testing.T) {
 			operatorAddress := common.Address{0x1}
-			operatorId, err := chainReader.GetOperatorId(&bind.CallOpts{}, operatorAddress)
+			request := avsregistry.OperatorIdRequest{
+				BlockNumber:     nil,
+				OperatorAddress: operatorAddress,
+			}
+			response, err := chainReader.GetOperatorId(context.Background(), request)
 			require.NoError(t, err)
 
-			_, _, err = chainReader.GetOperatorsStakeInQuorumsOfOperatorAtBlock(&bind.CallOpts{}, operatorId, 100)
+			operatorStakeRequest := avsregistry.OperatorsStakeInQuorumsOfOperatorAtBlockRequest{
+				BlockNumber:           nil,
+				OperatorId:            response.OperatorId,
+				HistoricalBlockNumber: 100,
+			}
+
+			_, err = chainReader.GetOperatorsStakeInQuorumsOfOperatorAtBlock(context.Background(), operatorStakeRequest)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "Failed to get operators state")
 		})
@@ -58,81 +83,123 @@ func TestReaderMethods(t *testing.T) {
 		"get single operator stake in quorums of operator at current block returns error for non-registered operator",
 		func(t *testing.T) {
 			operatorAddress := common.Address{0x1}
-			operatorId, err := chainReader.GetOperatorId(&bind.CallOpts{}, operatorAddress)
+			request := avsregistry.OperatorIdRequest{
+				BlockNumber:     nil,
+				OperatorAddress: operatorAddress,
+			}
+			response, err := chainReader.GetOperatorId(context.Background(), request)
 			require.NoError(t, err)
 
-			stakes, err := chainReader.GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(&bind.CallOpts{}, operatorId)
+			stakesRequest := avsregistry.OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest{
+				BlockNumber: nil,
+				OperatorId:  response.OperatorId,
+			}
+			responseOperators, err := chainReader.GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(context.Background(), stakesRequest)
 			require.NoError(t, err)
-			require.Equal(t, 0, len(stakes))
+			require.Equal(t, 0, len(responseOperators.QuorumStakes))
 		})
 
 	t.Run("get check signatures indices returns error for non-registered operator", func(t *testing.T) {
 		operatorAddress := common.Address{0x1}
-		operatorId, err := chainReader.GetOperatorId(&bind.CallOpts{}, operatorAddress)
+		request := avsregistry.OperatorIdRequest{
+			BlockNumber:     nil,
+			OperatorAddress: operatorAddress,
+		}
+		response, err := chainReader.GetOperatorId(context.Background(), request)
 		require.NoError(t, err)
 
 		_, err = chainReader.GetCheckSignaturesIndices(
-			&bind.CallOpts{},
-			100,
-			quorumNumbers,
-			[]types.OperatorId{operatorId},
+			context.Background(),
+			avsregistry.SignaturesIndicesRequest{
+				BlockNumber:          nil,
+				ReferenceBlockNumber: 100,
+				QuorumNumbers:        quorumNumbers,
+				NonSignerOperatorIds: []types.OperatorId{response.OperatorId},
+			},
 		)
 		require.Contains(t, err.Error(), "Failed to get check signatures indices")
 	})
 
 	t.Run("get operator id", func(t *testing.T) {
 		operatorAddress := common.Address{0x1}
-		operatorId, err := chainReader.GetOperatorId(&bind.CallOpts{}, operatorAddress)
+		request := avsregistry.OperatorIdRequest{
+			BlockNumber:     nil,
+			OperatorAddress: operatorAddress,
+		}
+		response, err := chainReader.GetOperatorId(context.Background(), request)
 		require.NoError(t, err)
-		require.NotNil(t, operatorId)
+		require.NotNil(t, response.OperatorId)
 	})
 
 	t.Run("get operator from id returns zero address for non-registered operator", func(t *testing.T) {
 		operatorAddress := common.HexToAddress("0x1234567890123456789012345678901234567890")
-		operatorId, err := chainReader.GetOperatorId(&bind.CallOpts{}, operatorAddress)
+		request := avsregistry.OperatorIdRequest{
+			BlockNumber:     nil,
+			OperatorAddress: operatorAddress,
+		}
+		response, err := chainReader.GetOperatorId(context.Background(), request)
 		require.NoError(t, err)
 
-		retrievedAddress, err := chainReader.GetOperatorFromId(&bind.CallOpts{}, operatorId)
+		responseOperator, err := chainReader.GetOperatorFromId(context.Background(), avsregistry.OperatorFromIdRequest{
+			BlockNumber: nil,
+			OperatorId:  response.OperatorId,
+		})
 		require.NoError(t, err)
-		require.Equal(t, retrievedAddress, common.Address{0x0})
+		require.Equal(t, responseOperator.OperatorAddress, common.Address{0x0})
 	})
 
 	t.Run("query registration detail", func(t *testing.T) {
 		operatorAddress := common.HexToAddress("0x1234567890123456789012345678901234567890")
-		quorums, err := chainReader.QueryRegistrationDetail(&bind.CallOpts{}, operatorAddress)
+		request := avsregistry.RegistrationDetailRequest{
+			BlockNumber:     nil,
+			OperatorAddress: operatorAddress,
+		}
+		response, err := chainReader.QueryRegistrationDetail(context.Background(), request)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(quorums))
+		require.Equal(t, 1, len(response.Quorums))
 	})
 
 	t.Run("is operator registered", func(t *testing.T) {
 		operatorAddress := common.HexToAddress("0x1234567890123456789012345678901234567890")
-		isRegistered, err := chainReader.IsOperatorRegistered(&bind.CallOpts{}, operatorAddress)
+		request := avsregistry.OperatorRegisteredRequest{
+			BlockNumber:     nil,
+			OperatorAddress: operatorAddress,
+		}
+		response, err := chainReader.IsOperatorRegistered(context.Background(), request)
 		require.NoError(t, err)
-		require.False(t, isRegistered)
+		require.False(t, response.IsRegistered)
 	})
 
 	t.Run(
 		"query existing registered operator pub keys", func(t *testing.T) {
-			addresses, pubKeys, err := chainReader.QueryExistingRegisteredOperatorPubKeys(
+			request := avsregistry.OperatorQueryRequest{
+				BlockNumber: nil,
+				StartBlock:  0,
+				StopBlock:   0,
+				BlockRange:  0,
+			}
+			response, err := chainReader.QueryExistingRegisteredOperatorPubKeys(
 				context.Background(),
-				big.NewInt(0),
-				nil,
-				nil,
+				request,
 			)
 			require.NoError(t, err)
-			require.Equal(t, 0, len(pubKeys))
-			require.Equal(t, 0, len(addresses))
+			require.Equal(t, 0, len(response.OperatorAddresses))
+			require.Equal(t, 0, len(response.OperatorsPubkeys))
 		})
 
 	t.Run(
 		"query existing registered operator sockets", func(t *testing.T) {
-			address_to_sockets, err := chainReader.QueryExistingRegisteredOperatorSockets(
+			request := avsregistry.OperatorQueryRequest{
+				BlockNumber: nil,
+				StartBlock:  0,
+				StopBlock:   0,
+				BlockRange:  0,
+			}
+			response, err := chainReader.QueryExistingRegisteredOperatorSockets(
 				context.Background(),
-				big.NewInt(0),
-				nil,
-				nil,
+				request,
 			)
 			require.NoError(t, err)
-			require.Equal(t, 0, len(address_to_sockets))
+			require.Equal(t, 0, len(response.Sockets))
 		})
 }

--- a/chainio/clients/avsregistry/types.go
+++ b/chainio/clients/avsregistry/types.go
@@ -1,0 +1,131 @@
+package avsregistry
+
+import (
+	"math/big"
+
+	opstateretriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
+	"github.com/Layr-Labs/eigensdk-go/types"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+type QuorumCountRequest struct {
+	BlockNumber *big.Int
+}
+
+type QuorumCountResponse struct {
+	QuorumCount uint8
+}
+
+type SignaturesIndicesRequest struct {
+	BlockNumber          *big.Int
+	ReferenceBlockNumber uint32
+	QuorumNumbers        types.QuorumNums
+	NonSignerOperatorIds []types.OperatorId
+}
+
+type SignaturesIndicesResponse struct {
+	SignaturesIndices opstateretriever.OperatorStateRetrieverCheckSignaturesIndices
+}
+
+type OperatorIdRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress gethcommon.Address
+}
+
+type OperatorIdResponse struct {
+	OperatorId [32]byte
+}
+
+type OperatorFromIdRequest struct {
+	BlockNumber *big.Int
+	OperatorId  types.OperatorId
+}
+
+type OperatorFromIdResponse struct {
+	OperatorAddress gethcommon.Address
+}
+
+type RegistrationDetailRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress gethcommon.Address
+}
+
+type RegistrationDetailResponse struct {
+	Quorums []bool
+}
+
+type OperatorRegisteredRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress gethcommon.Address
+}
+
+type OperatorRegisteredResponse struct {
+	IsRegistered bool
+}
+
+// Uint64 or Uint32? There was a comment in the original code that
+// wants to use uint instead of big.Int
+type OperatorQueryRequest struct {
+	BlockNumber *big.Int
+	StartBlock  uint64
+	StopBlock   uint64
+	BlockRange  uint64
+}
+
+type OperatorPubKeysRequestResponse struct {
+	OperatorAddresses []gethcommon.Address
+	OperatorsPubkeys  []types.OperatorPubkeys
+}
+
+type OperatorSocketsResponse struct {
+	Sockets map[types.OperatorId]types.Socket
+}
+
+type OperatorsStakeInQuorumAtCurrentBlockRequest struct {
+	BlockNumber   *big.Int
+	QuorumNumbers types.QuorumNums
+}
+
+type OperatorsStakeInQuorumAtBlockRequest struct {
+	BlockNumber           *big.Int
+	HistoricalBlockNumber uint32
+	QuorumNumbers         types.QuorumNums
+}
+
+type OperatorsStakeInQuorumResponse struct {
+	OperatorsStakeInQuorum [][]opstateretriever.OperatorStateRetrieverOperator
+}
+
+type OperatorAddrsInQuorumsAtCurrentBlockRequest struct {
+	BlockNumber   *big.Int
+	QuorumNumbers types.QuorumNums
+}
+
+type OperatorAddrsInQuorumsAtCurrentBlockResponse struct {
+	OperatorAddrsInQuorums [][]gethcommon.Address
+}
+
+type OperatorsStakeInQuorumsOfOperatorAtBlockRequest struct {
+	BlockNumber           *big.Int
+	HistoricalBlockNumber uint32
+	OperatorId            types.OperatorId
+}
+
+type OperatorsStakeInQuorumsOfOperatorAtCurrentBlockRequest struct {
+	BlockNumber *big.Int
+	OperatorId  types.OperatorId
+}
+
+type OperatorsStakeInQuorumsOfOperatorResponse struct {
+	QuorumNumbers           types.QuorumNums
+	OperatorsStakesInQuorum [][]opstateretriever.OperatorStateRetrieverOperator
+}
+
+type OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest struct {
+	BlockNumber *big.Int
+	OperatorId  types.OperatorId
+}
+
+type OperatorStakeInQuorumsOfOperatorResponse struct {
+	QuorumStakes map[types.QuorumNum]types.StakeAmount
+}

--- a/chainio/clients/avsregistry/types.go
+++ b/chainio/clients/avsregistry/types.go
@@ -63,8 +63,6 @@ type OperatorRegisteredResponse struct {
 	IsRegistered bool
 }
 
-// Uint64 or Uint32? There was a comment in the original code that
-// wants to use uint instead of big.Int
 type OperatorQueryRequest struct {
 	BlockNumber *big.Int
 	StartBlock  uint64

--- a/chainio/clients/avsregistry/types.go
+++ b/chainio/clients/avsregistry/types.go
@@ -62,12 +62,12 @@ type RegistrationDetailResponse struct {
 	Quorums []bool
 }
 
-type OperatorRegisteredRequest struct {
+type OperatorRegistrationRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress gethcommon.Address
 }
 
-type OperatorRegisteredResponse struct {
+type OperatorRegistrationResponse struct {
 	IsRegistered bool
 }
 
@@ -111,23 +111,23 @@ type OperatorAddrsInQuorumsAtCurrentBlockResponse struct {
 	OperatorAddrsInQuorums [][]gethcommon.Address
 }
 
-type OperatorsStakeInQuorumsOfOperatorAtBlockRequest struct {
+type OperatorsStakeInQuorumsByOperatorAtBlockRequest struct {
 	BlockNumber           *big.Int
 	HistoricalBlockNumber uint32
 	OperatorId            types.OperatorId
 }
 
-type OperatorsStakeInQuorumsOfOperatorAtCurrentBlockRequest struct {
+type OperatorsStakeInQuorumsByOperatorAtCurrentBlockRequest struct {
 	BlockNumber *big.Int
 	OperatorId  types.OperatorId
 }
 
-type OperatorsStakeInQuorumsOfOperatorResponse struct {
+type OperatorsStakeInQuorumsByOperatorResponse struct {
 	QuorumNumbers           types.QuorumNums
 	OperatorsStakesInQuorum [][]opstateretriever.OperatorStateRetrieverOperator
 }
 
-type OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest struct {
+type OperatorQuorumStakeAtCurrentBlockRequest struct {
 	BlockNumber *big.Int
 	OperatorId  types.OperatorId
 }
@@ -173,7 +173,7 @@ type SocketUpdateRequest struct {
 	WaitForReceipt bool
 }
 
-type OperatorRegisterInQuourimWithAvsRequest struct {
+type OperatorRegisterInQuorumWithAVSRequest struct {
 	OperatorEcdsaPrivateKey            *ecdsa.PrivateKey
 	OperatorToAvsRegistrationSigSalt   [32]byte
 	OperatorToAvsRegistrationSigExpiry *big.Int

--- a/chainio/clients/avsregistry/types.go
+++ b/chainio/clients/avsregistry/types.go
@@ -172,3 +172,13 @@ type SocketUpdateRequest struct {
 	Socket         types.Socket
 	WaitForReceipt bool
 }
+
+type OperatorRegisterInQuourimWithAvsRequest struct {
+	OperatorEcdsaPrivateKey            *ecdsa.PrivateKey
+	OperatorToAvsRegistrationSigSalt   [32]byte
+	OperatorToAvsRegistrationSigExpiry *big.Int
+	BlsKeyPair                         *bls.KeyPair
+	QuorumNumbers                      types.QuorumNums
+	Socket                             string
+	WaitForReceipt                     bool
+}

--- a/chainio/clients/avsregistry/types.go
+++ b/chainio/clients/avsregistry/types.go
@@ -1,12 +1,20 @@
 package avsregistry
 
 import (
+	"crypto/ecdsa"
 	"math/big"
 
 	opstateretriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
+	regcoord "github.com/Layr-Labs/eigensdk-go/contracts/bindings/RegistryCoordinator"
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 )
+
+type TxOptions struct {
+	Options *bind.TransactOpts
+}
 
 type QuorumCountRequest struct {
 	BlockNumber *big.Int
@@ -126,4 +134,41 @@ type OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest struct {
 
 type OperatorStakeInQuorumsOfOperatorResponse struct {
 	QuorumStakes map[types.QuorumNum]types.StakeAmount
+}
+
+type OperatorRegisterRequest struct {
+	OperatorEcdsaPrivateKey *ecdsa.PrivateKey
+	BlsKeyPair              *bls.KeyPair
+	QuorumNumbers           types.QuorumNums
+	Socket                  string
+	WaitForReceipt          bool
+}
+
+type StakesOfEntireOperatorSetForQuorumsRequest struct {
+	OperatorsPerQuorum [][]gethcommon.Address
+	QuorumNumbers      types.QuorumNums
+	WaitForReceipt     bool
+}
+
+type StakesOfOperatorSubsetForAllQuorumsRequest struct {
+	OperatorsAddresses []gethcommon.Address
+	WaitForReceipt     bool
+}
+
+type OperatorDeregisterRequest struct {
+	QuorumNumbers  types.QuorumNums
+	Pubkey         regcoord.BN254G1Point
+	WaitForReceipt bool
+}
+
+type OperatorDeregisterOperatorSetsRequest struct {
+	OperatorSetIds types.OperatorSetIds
+	Operator       types.Operator
+	Pubkey         regcoord.BN254G1Point
+	WaitForReceipt bool
+}
+
+type SocketUpdateRequest struct {
+	Socket         types.Socket
+	WaitForReceipt bool
 }

--- a/chainio/clients/avsregistry/types.go
+++ b/chainio/clients/avsregistry/types.go
@@ -70,7 +70,7 @@ type OperatorQueryRequest struct {
 	BlockRange  uint64
 }
 
-type OperatorPubKeysRequestResponse struct {
+type OperatorPubKeysResponse struct {
 	OperatorAddresses []gethcommon.Address
 	OperatorsPubkeys  []types.OperatorPubkeys
 }

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -382,6 +382,7 @@ func (w *ChainWriter) UpdateStakesOfOperatorSubsetForAllQuorums(
 	return receipt, nil
 }
 
+// DeregisterOperator is used to deregister an operator from one or more quorums.
 func (w *ChainWriter) DeregisterOperator(
 	ctx context.Context,
 	request OperatorDeregisterRequest,
@@ -405,6 +406,7 @@ func (w *ChainWriter) DeregisterOperator(
 	return receipt, nil
 }
 
+// DeregisterOperatorOperatorSets is used to deregister an operator from one or more operator sets.
 func (w *ChainWriter) DeregisterOperatorOperatorSets(
 	ctx context.Context,
 	request OperatorDeregisterOperatorSetsRequest,
@@ -434,6 +436,7 @@ func (w *ChainWriter) DeregisterOperatorOperatorSets(
 	return receipt, nil
 }
 
+// UpdateSocket is used to update the socket of the msg.sender given they are a registered operator
 func (w *ChainWriter) UpdateSocket(
 	ctx context.Context,
 	request SocketUpdateRequest,

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -121,7 +121,7 @@ func (w *ChainWriter) RegisterOperatorInQuorumWithAVSRegistryCoordinator(
 	// https://github.com/Layr-Labs/eigenlayer-middleware/blob/m2-mainnet/docs/RegistryCoordinator.md#registeroperator
 	// TODO(madhur): check to see if we can make the signer and txmgr more flexible so we can use them (and remote
 	// signers) to sign non txs
-	request OperatorRegisterInQuourimWithAvsRequest,
+	request OperatorRegisterInQuorumWithAVSRequest,
 	txOptions *TxOptions,
 ) (*gethtypes.Receipt, error) {
 	operatorAddr := crypto.PubkeyToAddress(request.OperatorEcdsaPrivateKey.PublicKey)

--- a/internal/fakes/avs_registry.go
+++ b/internal/fakes/avs_registry.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	apkregistrybindings "github.com/Layr-Labs/eigensdk-go/contracts/bindings/BLSApkRegistry"
 	opstateretriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
 	"github.com/Layr-Labs/eigensdk-go/types"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -46,55 +46,50 @@ func NewFakeAVSRegistryReader(
 
 func (f *FakeAVSRegistryReader) QueryExistingRegisteredOperatorPubKeys(
 	ctx context.Context,
-	startBlock *big.Int,
-	stopBlock *big.Int,
-	blockRange *big.Int,
-) ([]types.OperatorAddr, []types.OperatorPubkeys, error) {
-	return f.opAddress, f.opPubKeys, f.err
+	request avsregistry.OperatorQueryRequest,
+) (avsregistry.OperatorPubKeysResponse, error) {
+	return avsregistry.OperatorPubKeysResponse{OperatorAddresses: f.opAddress, OperatorsPubkeys: f.opPubKeys}, f.err
 }
 
 func (f *FakeAVSRegistryReader) QueryExistingRegisteredOperatorSockets(
 	ctx context.Context,
-	startBlock *big.Int,
-	stopBlock *big.Int,
-	blockRange *big.Int,
-) (map[types.OperatorId]types.Socket, error) {
+	request avsregistry.OperatorQueryRequest,
+) (avsregistry.OperatorSocketsResponse, error) {
 	if len(f.opPubKeys) == 0 {
-		return nil, nil
+		return avsregistry.OperatorSocketsResponse{}, nil
 	}
 
-	return map[types.OperatorId]types.Socket{
+	return avsregistry.OperatorSocketsResponse{Sockets: map[types.OperatorId]types.Socket{
 		types.OperatorIdFromG1Pubkey(f.opPubKeys[0].G1Pubkey): f.socket,
-	}, nil
+	}}, nil
 }
 
 func (f *FakeAVSRegistryReader) GetOperatorFromId(
-	opts *bind.CallOpts,
-	operatorId types.OperatorId,
-) (common.Address, error) {
-	return f.opAddress[0], f.err
+	ctx context.Context,
+	request avsregistry.OperatorFromIdRequest,
+) (avsregistry.OperatorFromIdResponse, error) {
+	return avsregistry.OperatorFromIdResponse{OperatorAddress: f.opAddress[0]}, f.err
 }
 
 func (f *FakeAVSRegistryReader) GetOperatorsStakeInQuorumsAtBlock(
-	opts *bind.CallOpts,
-	quorumNumbers types.QuorumNums,
-	blockNumber types.BlockNum,
-) ([][]opstateretriever.OperatorStateRetrieverOperator, error) {
-	return [][]opstateretriever.OperatorStateRetrieverOperator{
-		{
+	ctx context.Context,
+	request avsregistry.OperatorsStakeInQuorumAtBlockRequest,
+) (avsregistry.OperatorsStakeInQuorumResponse, error) {
+	return avsregistry.OperatorsStakeInQuorumResponse{
+		OperatorsStakeInQuorum: [][]opstateretriever.OperatorStateRetrieverOperator{
 			{
-				OperatorId: f.operatorId,
-				Stake:      big.NewInt(123),
+				{
+					OperatorId: f.operatorId,
+					Stake:      big.NewInt(123),
+				},
 			},
 		},
 	}, nil
 }
 
 func (f *FakeAVSRegistryReader) GetCheckSignaturesIndices(
-	opts *bind.CallOpts,
-	referenceBlockNumber uint32,
-	quorumNumbers types.QuorumNums,
-	nonSignerOperatorIds []types.OperatorId,
-) (opstateretriever.OperatorStateRetrieverCheckSignaturesIndices, error) {
-	return opstateretriever.OperatorStateRetrieverCheckSignaturesIndices{}, nil
+	ctx context.Context,
+	request avsregistry.SignaturesIndicesRequest,
+) (avsregistry.SignaturesIndicesResponse, error) {
+	return avsregistry.SignaturesIndicesResponse{}, nil
 }

--- a/metrics/collectors/economic/economic.go
+++ b/metrics/collectors/economic/economic.go
@@ -22,7 +22,7 @@ type avsRegistryReader interface {
 
 	GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(
 		ctx context.Context,
-		request avsregistry.OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest,
+		request avsregistry.OperatorQuorumStakeAtCurrentBlockRequest,
 	) (avsregistry.OperatorStakeInQuorumsOfOperatorResponse, error)
 }
 
@@ -160,7 +160,7 @@ func (ec *Collector) Collect(ch chan<- prometheus.Metric) {
 	} else {
 		// probably should start using the avsregistry service instead of avsRegistryReader so that we can
 		// swap out backend for a subgraph eventually
-		response, err := ec.avsRegistryReader.GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(context.Background(), avsregistry.OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest{
+		response, err := ec.avsRegistryReader.GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(context.Background(), avsregistry.OperatorQuorumStakeAtCurrentBlockRequest{
 			BlockNumber: nil,
 			OperatorId:  ec.operatorId,
 		})

--- a/metrics/collectors/economic/economic_test.go
+++ b/metrics/collectors/economic/economic_test.go
@@ -5,13 +5,13 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/testutils"
 	"github.com/Layr-Labs/eigensdk-go/types"
 )
@@ -39,15 +39,18 @@ type fakeAVSRegistryReader struct {
 	stakes     map[types.QuorumNum]*big.Int
 }
 
-func (f *fakeAVSRegistryReader) GetOperatorId(opts *bind.CallOpts, operatorAddr common.Address) ([32]byte, error) {
-	return f.operatorId, nil
+func (f *fakeAVSRegistryReader) GetOperatorId(
+	ctx context.Context,
+	request avsregistry.OperatorIdRequest,
+) (avsregistry.OperatorIdResponse, error) {
+	return avsregistry.OperatorIdResponse{OperatorId: f.operatorId}, nil
 }
 
 func (f *fakeAVSRegistryReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(
-	opts *bind.CallOpts,
-	operatorId types.OperatorId,
-) (map[types.QuorumNum]*big.Int, error) {
-	return f.stakes, nil
+	ctx context.Context,
+	request avsregistry.OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest,
+) (avsregistry.OperatorStakeInQuorumsOfOperatorResponse, error) {
+	return avsregistry.OperatorStakeInQuorumsOfOperatorResponse{QuorumStakes: f.stakes}, nil
 }
 
 func newFakeAVSRegistryReader() *fakeAVSRegistryReader {

--- a/metrics/collectors/economic/economic_test.go
+++ b/metrics/collectors/economic/economic_test.go
@@ -48,7 +48,7 @@ func (f *fakeAVSRegistryReader) GetOperatorId(
 
 func (f *fakeAVSRegistryReader) GetOperatorStakeInQuorumsOfOperatorAtCurrentBlock(
 	ctx context.Context,
-	request avsregistry.OperatorStakeInQuorumsOfOperatorAtCurrentBlockRequest,
+	request avsregistry.OperatorQuorumStakeAtCurrentBlockRequest,
 ) (avsregistry.OperatorStakeInQuorumsOfOperatorResponse, error) {
 	return avsregistry.OperatorStakeInQuorumsOfOperatorResponse{QuorumStakes: f.stakes}, nil
 }

--- a/services/avsregistry/avsregistry.go
+++ b/services/avsregistry/avsregistry.go
@@ -3,9 +3,8 @@ package avsregistry
 import (
 	"context"
 
-	opstateretriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/types"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 // AvsRegistryServicemService is a service that indexes the Avs Registry contracts and provides a way to query for
@@ -31,9 +30,7 @@ type AvsRegistryService interface {
 	// GetCheckSignaturesIndices returns the registry indices of the nonsigner operators specified by
 	// nonSignerOperatorIds who were registered at referenceBlockNumber.
 	GetCheckSignaturesIndices(
-		opts *bind.CallOpts,
-		referenceBlockNumber types.BlockNum,
-		quorumNumbers types.QuorumNums,
-		nonSignerOperatorIds []types.OperatorId,
-	) (opstateretriever.OperatorStateRetrieverCheckSignaturesIndices, error)
+		ctx context.Context,
+		request avsregistry.SignaturesIndicesRequest,
+	) (avsregistry.SignaturesIndicesResponse, error)
 }

--- a/services/avsregistry/avsregistry_fake.go
+++ b/services/avsregistry/avsregistry_fake.go
@@ -5,10 +5,9 @@ import (
 	"errors"
 	"math/big"
 
-	opstateretriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/types"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 type FakeAvsRegistryService struct {
@@ -83,8 +82,8 @@ func (f *FakeAvsRegistryService) GetQuorumsAvsStateAtBlock(
 }
 
 func (f *FakeAvsRegistryService) GetCheckSignaturesIndices(
-	opts *bind.CallOpts, referenceBlockNumber types.BlockNum,
-	quorumNumbers types.QuorumNums, nonSignerOperatorIds []types.OperatorId,
-) (opstateretriever.OperatorStateRetrieverCheckSignaturesIndices, error) {
-	return opstateretriever.OperatorStateRetrieverCheckSignaturesIndices{}, nil
+	ctx context.Context,
+	request avsregistry.SignaturesIndicesRequest,
+) (avsregistry.SignaturesIndicesResponse, error) {
+	return avsregistry.SignaturesIndicesResponse{}, nil
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -9,12 +9,12 @@ import (
 	"sync"
 	"time"
 
+	avs "github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/services/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/Layr-Labs/eigensdk-go/utils"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 var (
@@ -562,11 +562,16 @@ func (a *BlsAggregatorService) sendAggregatedResponse(
 		nonSignersG1Pubkeys = append(nonSignersG1Pubkeys, operator.OperatorInfo.Pubkeys.G1Pubkey)
 	}
 
-	indices, err := a.avsRegistryService.GetCheckSignaturesIndices(
-		&bind.CallOpts{},
-		taskCreatedBlock,
-		quorumNumbers,
-		nonSignersOperatorIds,
+	response, err := a.avsRegistryService.GetCheckSignaturesIndices(
+		context.Background(),
+		// taskCreatedBlock,
+		// quorumNumbers,
+		// nonSignersOperatorIds,
+		avs.SignaturesIndicesRequest{
+			ReferenceBlockNumber: taskCreatedBlock,
+			QuorumNumbers:        quorumNumbers,
+			NonSignerOperatorIds: nonSignersOperatorIds,
+		},
 	)
 	if err != nil {
 		a.aggregatedResponsesC <- BlsAggregationServiceResponse{
@@ -585,10 +590,10 @@ func (a *BlsAggregatorService) sendAggregatedResponse(
 		QuorumApksG1:                 quorumApksG1,
 		SignersApkG2:                 digestAggregatedOperators.signersApkG2,
 		SignersAggSigG1:              digestAggregatedOperators.signersAggSigG1,
-		NonSignerQuorumBitmapIndices: indices.NonSignerQuorumBitmapIndices,
-		QuorumApkIndices:             indices.QuorumApkIndices,
-		TotalStakeIndices:            indices.TotalStakeIndices,
-		NonSignerStakeIndices:        indices.NonSignerStakeIndices,
+		NonSignerQuorumBitmapIndices: response.SignaturesIndices.NonSignerQuorumBitmapIndices,
+		QuorumApkIndices:             response.SignaturesIndices.QuorumApkIndices,
+		TotalStakeIndices:            response.SignaturesIndices.TotalStakeIndices,
+		NonSignerStakeIndices:        response.SignaturesIndices.NonSignerStakeIndices,
 	}
 	a.aggregatedResponsesC <- blsAggregationServiceResponse
 }

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
+	avs "github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	avssm "github.com/Layr-Labs/eigensdk-go/contracts/bindings/MockAvsServiceManager"
 )
 
@@ -1721,14 +1722,22 @@ func TestIntegrationBlsAgg(t *testing.T) {
 		blsAggServ := NewBlsAggregatorService(avsRegistryService, hashFunction, logger)
 
 		// register operator
+		opts, err := avsClients.TxManager.GetNoSendTxOpts()
+		require.NoError(t, err)
+		txOptions := &avs.TxOptions{
+			Options: opts,
+		}
 		quorumNumbers := testData.Input.QuorumNumbers
 		_, err = avsWriter.RegisterOperator(
 			context.Background(),
-			ecdsaPrivKey,
-			blsKeyPair,
-			quorumNumbers,
-			"socket",
-			true,
+			avs.OperatorRegisterRequest{
+				OperatorEcdsaPrivateKey: ecdsaPrivKey,
+				QuorumNumbers:           quorumNumbers,
+				BlsKeyPair:              blsKeyPair,
+				Socket:                  "socket",
+				WaitForReceipt:          true,
+			},
+			txOptions,
 		)
 		require.NoError(t, err)
 

--- a/services/operatorsinfo/operatorsinfo_inmemory.go
+++ b/services/operatorsinfo/operatorsinfo_inmemory.go
@@ -72,7 +72,6 @@ type resp struct {
 	operatorExists bool
 }
 
-// REVIEW: Could we do a refactor here and start using uint64?
 type Opts struct {
 	StartBlock uint64
 	StopBlock  uint64


### PR DESCRIPTION
### What Changed?

This PR aims to improve the avsregistry interface by implementing a request-response pattern. Because the function signatures have changed, we also refactor the tests to align with the new pattern. Additionally, there were conflicts in other packages (`fake`, `metrics`, `service`) since they share an interface with `avsregistry`. Therefore, I had to update the interface and the corresponding methods.

## Reader
- Request Structs: Each function now accepts a dedicated request struct containing specific fields along with a `BlockNumber`. This encapsulates all necessary parameters into a single object.
- Response Structs: Functions return structured responses.

```go
func(r *ChainReader) Foo(
	ctx context.Context,
	request FooRequest,
) (FooResponse, error) {
	...
}

type FooRequest struct {
	BlockNumber *big.Int,
        ...
}

type FooResponse struct {
        ...
}
```

## Writer
- Request Structs: Each function ow accepts a struct with specific fields along with a `WaitForReceipt` flag.
- Response Structs: We continue returning the Ethereum Receipt (from [go-ethereum](https://github.com/ethereum/go-ethereum)) instead of creating a custom response struct.

```go
func (w *ChainWriter) Bar(
	ctx context.Context,
	request BarRequest,
	txOptions *TxOptions,
) (*types.Receipt, error) {
       ...
}

type TxOptions struct {
    Options *bind.TransactOpts
}

type BarRequest struct {
    WaitForReceipt bool
    // ... other fields
}
```

This is a work in progress and changes may occur.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it