### PR TITLE
refactor: `elcontracts` new reader interface 

### DIFF
--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -91,6 +91,7 @@ func NewReaderFromConfig(
 	), nil
 }
 
+// IsOperatorRegistered returns if an operator is registered
 func (r *ChainReader) IsOperatorRegistered(
 	ctx context.Context,
 	request OperatorRequest,
@@ -150,6 +151,7 @@ func (r *ChainReader) GetDelegatedOperator(
 	return DelegateOperatorResponse{OperatorAddress: operatorAddress}, nil
 }
 
+// GetOperatorDetails returns the operator's details
 func (r *ChainReader) GetOperatorDetails(
 	ctx context.Context,
 	request OperatorRequest,

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -211,7 +211,7 @@ func (r *ChainReader) GetStrategyAndUnderlyingToken(
 	if err != nil {
 		return StrategyTokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
 	}
-	return StrategyTokenResponse{StrategyContract: *contractStrategy, TokenAddress: underlyingTokenAddr}, nil
+	return StrategyTokenResponse{StrategyContract: *contractStrategy, UnderlyingTokenAddress: underlyingTokenAddr}, nil
 }
 
 // GetStrategyAndUnderlyingERC20Token returns the strategy contract, the erc20 bindings for the underlying token
@@ -225,7 +225,9 @@ func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 	if err != nil {
 		return StrategyERC20TokenResponse{}, utils.WrapError("Failed to fetch strategy contract", err)
 	}
-	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(&bind.CallOpts{Context: ctx})
+	underlyingTokenAddr, err := contractStrategy.UnderlyingToken(
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
+	)
 	if err != nil {
 		return StrategyERC20TokenResponse{}, utils.WrapError("Failed to fetch token contract", err)
 	}

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -93,13 +93,21 @@ func NewReaderFromConfig(
 
 func (r *ChainReader) IsOperatorRegistered(
 	ctx context.Context,
-	operator types.Operator,
-) (bool, error) {
+	request OperatorRequest,
+) (OperatorRegisterResponse, error) {
 	if r.delegationManager == nil {
-		return false, errors.New("DelegationManager contract not provided")
+		return OperatorRegisterResponse{}, errors.New("DelegationManager contract not provided")
 	}
 
-	return r.delegationManager.IsOperator(&bind.CallOpts{Context: ctx}, gethcommon.HexToAddress(operator.Address))
+	isRegistered, err := r.delegationManager.IsOperator(
+		&bind.CallOpts{Context: ctx, BlockNumber: request.BlockNumber},
+		gethcommon.HexToAddress(request.Operator.Address),
+	)
+	if err != nil {
+		return OperatorRegisterResponse{}, utils.WrapError("failed to check if operator is registered", err)
+	}
+
+	return OperatorRegisterResponse{IsRegistered: isRegistered}, nil
 }
 
 // GetStakerShares returns the amount of shares that a staker has in all of the strategies in which they have nonzero

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -236,9 +236,9 @@ func (r *ChainReader) GetStrategyAndUnderlyingERC20Token(
 	}
 
 	return StrategyERC20TokenResponse{
-		StrategyContract: *contractStrategy,
-		ERC20Bindings:    contractUnderlyingToken,
-		TokenAddress:     underlyingTokenAddr,
+		StrategyContract:        *contractStrategy,
+		UnderlyingERC20Contract: contractUnderlyingToken,
+		UnderlyingTokenAddress:  underlyingTokenAddr,
 	}, nil
 }
 

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
+	erc20 "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IERC20"
+	strategy "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IStrategy"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/types"
 
@@ -94,6 +96,22 @@ type OperatorResponse struct {
 	Operator types.Operator
 }
 
+type StrategyRequest struct {
+	BlockNumber     *big.Int
+	StrategyAddress common.Address
+}
+
+type StrategyTokenResponse struct {
+	StrategyContract strategy.ContractIStrategy
+	TokenAddress     common.Address
+}
+
+type StrategyERC20TokenResponse struct {
+	StrategyContract strategy.ContractIStrategy
+	ERC20Bindings    erc20.ContractIERC20Methods
+	TokenAddress     common.Address
+}
+
 type OperatorRegisterResponse struct {
 	IsRegistered bool
 }
@@ -110,4 +128,14 @@ type StakerSharesResponse struct {
 
 type DelegateOperatorResponse struct {
 	OperatorAddress common.Address
+}
+
+type SharesInStrategyRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+	StrategyAddress common.Address
+}
+
+type SharesResponse struct {
+	Shares *big.Int
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -88,6 +88,7 @@ type RemovePendingAdminRequest struct {
 // READER TYPES
 
 // OperatorRequest represents a request that requires an operator's address
+// If `BlockNumber` is nil, the latest block will be used
 type OperatorRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
@@ -99,6 +100,7 @@ type OperatorResponse struct {
 }
 
 // StrategyRequest represents a request that requires a strategy's address
+// If `BlockNumber` is nil, the latest block will be used
 type StrategyRequest struct {
 	BlockNumber     *big.Int
 	StrategyAddress common.Address
@@ -124,6 +126,7 @@ type OperatorRegisterResponse struct {
 }
 
 // StakerRequest represents a request that requires a staker's address
+// If `BlockNumber` is nil, the latest block will be used
 type StakerRequest struct {
 	BlockNumber   *big.Int
 	StakerAddress common.Address
@@ -140,14 +143,15 @@ type DelegateOperatorResponse struct {
 	OperatorAddress common.Address
 }
 
-// SharesInStrategyRequest represents a request that requires a strategy's address and an operator's address
+// SharesInStrategyRequest represents a request that requires both strategy's address and operator's address
+// If `BlockNumber` is nil, the latest block will be used
 type SharesInStrategyRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
 
-// ShareResponse contains the shares
+// ShareResponse contains the numbers of shares
 type SharesResponse struct {
 	Shares *big.Int
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -102,8 +102,8 @@ type StrategyRequest struct {
 }
 
 type StrategyTokenResponse struct {
-	StrategyContract strategy.ContractIStrategy
-	TokenAddress     common.Address
+	StrategyContract       strategy.ContractIStrategy
+	UnderlyingTokenAddress common.Address
 }
 
 type StrategyERC20TokenResponse struct {

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -5,6 +5,7 @@ import (
 
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	"github.com/Layr-Labs/eigensdk-go/types"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -80,4 +81,15 @@ type RemovePendingAdminRequest struct {
 	AccountAddress common.Address
 	AdminAddress   common.Address
 	WaitForReceipt bool
+}
+
+// READER TYPES
+
+type OperatorRequest struct {
+	BlockNumber *big.Int
+	Operator    types.Operator
+}
+
+type OperatorRegisterResponse struct {
+	IsRegistered bool
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -107,9 +107,9 @@ type StrategyTokenResponse struct {
 }
 
 type StrategyERC20TokenResponse struct {
-	StrategyContract strategy.ContractIStrategy
-	ERC20Bindings    erc20.ContractIERC20Methods
-	TokenAddress     common.Address
+	StrategyContract        strategy.ContractIStrategy
+	UnderlyingERC20Contract erc20.ContractIERC20Methods
+	UnderlyingTokenAddress  common.Address
 }
 
 type OperatorRegisterResponse struct {

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -87,55 +87,67 @@ type RemovePendingAdminRequest struct {
 
 // READER TYPES
 
+// OperatorRequest represents a request that requires an operator's address
 type OperatorRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
+// OperatorResponse represents the operator information
 type OperatorResponse struct {
 	Operator types.Operator
 }
 
+// StrategyRequest represents a request that requires a strategy's address
 type StrategyRequest struct {
 	BlockNumber     *big.Int
 	StrategyAddress common.Address
 }
 
+// StrategyTokenResponse contains the strategy contract and the underlying token address
 type StrategyTokenResponse struct {
 	StrategyContract       strategy.ContractIStrategy
 	UnderlyingTokenAddress common.Address
 }
 
+// StrategyERC20TokenResponse contains the strategy contract, the underlying token address and the underlying ERC20
+// contract
 type StrategyERC20TokenResponse struct {
 	StrategyContract        strategy.ContractIStrategy
 	UnderlyingERC20Contract erc20.ContractIERC20Methods
 	UnderlyingTokenAddress  common.Address
 }
 
+// OperatorRegisterResponse indicates if the operator is registered or not
 type OperatorRegisterResponse struct {
 	IsRegistered bool
 }
 
+// StakerRequest represents a request that requires a staker's address
 type StakerRequest struct {
 	BlockNumber   *big.Int
 	StakerAddress common.Address
 }
 
+// StakerSharesResponse contains the staker's shares
 type StakerSharesResponse struct {
 	StrategiesAddresses []common.Address
 	Shares              []*big.Int
 }
 
+// DelegateOperatorResponse represents the operator's delegate address
 type DelegateOperatorResponse struct {
 	OperatorAddress common.Address
 }
 
+// SharesInStrategyRequest represents a request that requires a strategy's address and an operator's address
 type SharesInStrategyRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
 
+// ShareResponse contains the shares
 type SharesResponse struct {
 	Shares *big.Int
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -86,10 +86,28 @@ type RemovePendingAdminRequest struct {
 // READER TYPES
 
 type OperatorRequest struct {
-	BlockNumber *big.Int
-	Operator    types.Operator
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+}
+
+type OperatorResponse struct {
+	Operator types.Operator
 }
 
 type OperatorRegisterResponse struct {
 	IsRegistered bool
+}
+
+type StakerRequest struct {
+	BlockNumber   *big.Int
+	StakerAddress common.Address
+}
+
+type StakerSharesResponse struct {
+	StrategiesAddresses []common.Address
+	Shares              []*big.Int
+}
+
+type DelegateOperatorResponse struct {
+	OperatorAddress common.Address
 }

--- a/chainio/clients/elcontracts/writer.go
+++ b/chainio/clients/elcontracts/writer.go
@@ -18,9 +18,7 @@ import (
 	avsdirectory "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AVSDirectory"
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
 	delegationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/DelegationManager"
-	erc20 "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IERC20"
 	rewardscoordinator "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IRewardsCoordinator"
-	strategy "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IStrategy"
 	permissioncontroller "github.com/Layr-Labs/eigensdk-go/contracts/bindings/PermissionController"
 	regcoord "github.com/Layr-Labs/eigensdk-go/contracts/bindings/RegistryCoordinator"
 	strategymanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/StrategyManager"
@@ -33,8 +31,8 @@ import (
 
 type Reader interface {
 	GetStrategyAndUnderlyingERC20Token(
-		ctx context.Context, strategyAddr gethcommon.Address,
-	) (*strategy.ContractIStrategy, erc20.ContractIERC20Methods, gethcommon.Address, error)
+		ctx context.Context, request StrategyRequest,
+	) (StrategyERC20TokenResponse, error)
 }
 
 type ChainWriter struct {
@@ -242,15 +240,15 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 	if err != nil {
 		return nil, err
 	}
-	_, underlyingTokenContract, underlyingTokenAddr, err := w.elChainReader.GetStrategyAndUnderlyingERC20Token(
+	response, err := w.elChainReader.GetStrategyAndUnderlyingERC20Token(
 		ctx,
-		strategyAddr,
+		StrategyRequest{StrategyAddress: strategyAddr},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	tx, err := underlyingTokenContract.Approve(noSendTxOpts, w.strategyManagerAddr, amount)
+	tx, err := response.UnderlyingERC20Contract.Approve(noSendTxOpts, w.strategyManagerAddr, amount)
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to approve token transfer"), err)
 	}
@@ -259,7 +257,7 @@ func (w *ChainWriter) DepositERC20IntoStrategy(
 		return nil, errors.New("failed to send tx with err: " + err.Error())
 	}
 
-	tx, err = w.strategyManager.DepositIntoStrategy(noSendTxOpts, strategyAddr, underlyingTokenAddr, amount)
+	tx, err = w.strategyManager.DepositIntoStrategy(noSendTxOpts, strategyAddr, response.UnderlyingTokenAddress, amount)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What Changed?
This PR is part of an incremental refactor to improve  the `elcontracts/reader` interface by implementing a request-response pattern. For the exposed functions, we create structs that represent the request (specific fields + `BlockNumber`) and the response.

Because the function signatures change, we also refactor the tests to align with the new pattern.

Methods updated in this PR: `IsOperatorRegistered`, `GetStakerShares`, `GetDelegatedOperator`, `GetOperatorDetails`, `GetStrategyAndUnderlyingToken`, `GetStrategyAndUnderlyingERC20Token` and `GetOperatorSharesInStrategy`.

> Tracking methods in #494 

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it