### PR TITLE
refactor: `elcontracts` update more `reader` interfaces

### DIFF
--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -224,6 +224,8 @@ func (r *ChainReader) GetOperatorSharesInStrategy(
 	)
 }
 
+// CalculateDelegationApprovalDigestHash calculates the digest hash that must be signed by the operator’s delegation
+// approver.
 func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 	ctx context.Context,
 	request ApprovalDigestHashRequest,
@@ -247,6 +249,8 @@ func (r *ChainReader) CalculateDelegationApprovalDigestHash(
 	return DigestHashResponse{DigestHash: hash}, nil
 }
 
+// CalculateOperatorAVSRegistrationDigestHash calculates the digest hash to be signed by an operator to register with an
+// AVS
 func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	ctx context.Context,
 	request AVSRegistrationDigestHashRequest,
@@ -269,6 +273,7 @@ func (r *ChainReader) CalculateOperatorAVSRegistrationDigestHash(
 	return DigestHashResponse{DigestHash: hash}, nil
 }
 
+// GetOperatorAVSRegistrationStatus returns the length of distribution roots posted
 func (r *ChainReader) GetDistributionRootsLength(ctx context.Context, request RootRequest) (RootLengthResponse, error) {
 	if r.rewardsCoordinator == nil {
 		return RootLengthResponse{}, errors.New("RewardsCoordinator contract not provided")
@@ -284,6 +289,7 @@ func (r *ChainReader) GetDistributionRootsLength(ctx context.Context, request Ro
 	return RootLengthResponse{Length: lengt}, nil
 }
 
+// CurrRewardsCalculationEndTimestamp fetches the end timestamp until which RewardsSubmissions have been calculated
 func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 	ctx context.Context,
 	request RewardsEndTimestampRequest,
@@ -302,6 +308,7 @@ func (r *ChainReader) CurrRewardsCalculationEndTimestamp(
 	return EndTimestampResponse{EndTimestamp: endTimestamp}, nil
 }
 
+// GetCurrentClaimableDistributionRoot returns the latest claimable root that is not disabled and activated
 func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	ctx context.Context,
 	request RootRequest,
@@ -325,6 +332,7 @@ func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 	return ClaimableDistributionRootResponse{DistributionRoot: root}, nil
 }
 
+// GetRootIndexFromHash returns the index of a root hash
 func (r *ChainReader) GetRootIndexFromHash(
 	ctx context.Context,
 	request RootHashRequest,
@@ -344,6 +352,7 @@ func (r *ChainReader) GetRootIndexFromHash(
 	return RootIndexResponse{Index: index}, nil
 }
 
+// GetCumulativeClaimed fetches the total amount claimed by an earner for a specific token.
 func (r *ChainReader) GetCumulativeClaimed(
 	ctx context.Context,
 	request CumulativeClaimedRequest,
@@ -364,6 +373,7 @@ func (r *ChainReader) GetCumulativeClaimed(
 	return CumulativeClaimedResponse{CumulativeClaimed: claimed}, nil
 }
 
+// CheckClaim checks if the claim would currently pass the check in processClaim
 func (r *ChainReader) CheckClaim(
 	ctx context.Context,
 	request ClaimRequest,

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -322,7 +322,7 @@ func (r *ChainReader) GetCurrentClaimableDistributionRoot(
 		)
 	}
 
-	return ClaimableDistributionRootResponse{Root: root}, nil
+	return ClaimableDistributionRootResponse{DistributionRoot: root}, nil
 }
 
 func (r *ChainReader) GetRootIndexFromHash(
@@ -380,7 +380,7 @@ func (r *ChainReader) CheckClaim(
 		return ClaimResponse{}, utils.WrapError("failed to check claim", err)
 	}
 
-	return ClaimResponse{ValidClaim: claim}, nil
+	return ClaimResponse{CheckClaim: claim}, nil
 }
 
 func (r *ChainReader) GetOperatorAVSSplit(

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -104,6 +104,7 @@ type DigestHashResponse struct {
 	DigestHash [32]byte
 }
 
+// This should be an specific struct like BlockNumberRequest?
 type RootRequest struct {
 	BlockNumer *big.Int
 }
@@ -112,6 +113,7 @@ type RootLengthResponse struct {
 	Length *big.Int
 }
 
+// This should be an specific struct like BlockNumberRequest?
 type RewardsEndTimestampRequest struct {
 	BlockNumber *big.Int
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -83,8 +83,8 @@ type RemovePendingAdminRequest struct {
 	WaitForReceipt bool
 }
 
-// ApprovalDigestHashRequest represents the request parameters required
-// to calculate the delegation approval digest hash.
+// ApprovalDigestHashRequest represents the request parameters required to calculate the delegation approval digest
+// hash. If `BlockNumber` is nil, the latest block will be used.
 type ApprovalDigestHashRequest struct {
 	BlockNumber       *big.Int
 	StakerAddress     common.Address
@@ -95,7 +95,7 @@ type ApprovalDigestHashRequest struct {
 }
 
 // AVSRegistrationDigestHashRequest represents the request required to calculate the operator AVS registration digest
-// hash
+// hash. If `BlockNumber` is nil, the latest block will be used
 type AVSRegistrationDigestHashRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
@@ -110,6 +110,7 @@ type DigestHashResponse struct {
 }
 
 // This should be an specific struct like BlockNumberRequest?
+// If `BlockNumber` is nil, the latest block will be used
 type RootRequest struct {
 	BlockNumer *big.Int
 }
@@ -120,6 +121,7 @@ type RootLengthResponse struct {
 }
 
 // This should be an specific struct like BlockNumberRequest?
+// If `BlockNumber` is nil, the latest block will be used
 type RewardsEndTimestampRequest struct {
 	BlockNumber *big.Int
 }
@@ -134,7 +136,8 @@ type ClaimableDistributionRootResponse struct {
 	DistributionRoot rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot
 }
 
-// RootHashRequest represents a request to retrieve the index of a root hash
+// RootHashRequest represents a request to retrieve the index of a root hash. If `BlockNumber` is nil, the latest block
+// will be used
 type RootHashRequest struct {
 	BlockNumber *big.Int
 	RootHash    [32]byte
@@ -146,7 +149,7 @@ type RootIndexResponse struct {
 }
 
 // CumulativeClaimedRequest represents a request to fetch the cumulative claimed rewards
-// for a specific earner address and token address
+// for a specific earner address and token address. If `BlockNumber` is nil, the latest block will be used
 type CumulativeClaimedRequest struct {
 	BlockNumber   *big.Int
 	EarnerAddress common.Address
@@ -158,7 +161,8 @@ type CumulativeClaimedResponse struct {
 	CumulativeClaimed *big.Int
 }
 
-// ClaimRequest represents a request to verify a claim.
+// ClaimRequest represents a request to verify a claim
+// If `BlockNumber` is nil, the latest block will be used
 type ClaimRequest struct {
 	BlockNumber *big.Int
 	Claim       rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -123,7 +123,7 @@ type EndTimestampResponse struct {
 }
 
 type ClaimableDistributionRootResponse struct {
-	Root rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot
+	DistributionRoot rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot
 }
 
 type RootHashRequest struct {
@@ -151,5 +151,5 @@ type ClaimRequest struct {
 }
 
 type ClaimResponse struct {
-	ValidClaim bool
+	CheckClaim bool
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -83,6 +83,8 @@ type RemovePendingAdminRequest struct {
 	WaitForReceipt bool
 }
 
+// ApprovalDigestHashRequest represents the request parameters required
+// to calculate the delegation approval digest hash.
 type ApprovalDigestHashRequest struct {
 	BlockNumber       *big.Int
 	StakerAddress     common.Address
@@ -92,6 +94,8 @@ type ApprovalDigestHashRequest struct {
 	Expiry            *big.Int
 }
 
+// AVSRegistrationDigestHashRequest represents the request required to calculate the operator AVS registration digest
+// hash
 type AVSRegistrationDigestHashRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
@@ -100,6 +104,7 @@ type AVSRegistrationDigestHashRequest struct {
 	Expiry          *big.Int
 }
 
+// DigestHashResponse contains the calculated digest hash.
 type DigestHashResponse struct {
 	DigestHash [32]byte
 }
@@ -109,6 +114,7 @@ type RootRequest struct {
 	BlockNumer *big.Int
 }
 
+// RootLengthResponse contains the length of the distribution roots.
 type RootLengthResponse struct {
 	Length *big.Int
 }
@@ -118,38 +124,47 @@ type RewardsEndTimestampRequest struct {
 	BlockNumber *big.Int
 }
 
+// EndTimestampResponse contains the rewards calculation end timestamp
 type EndTimestampResponse struct {
 	EndTimestamp uint32
 }
 
+// ClaimableDistributionRootResponse contains the current claimable distribution root
 type ClaimableDistributionRootResponse struct {
 	DistributionRoot rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot
 }
 
+// RootHashRequest represents a request to retrieve the index of a root hash
 type RootHashRequest struct {
 	BlockNumber *big.Int
 	RootHash    [32]byte
 }
 
+// RootIndexResponse contains the index corresponding to a given root hash
 type RootIndexResponse struct {
 	Index uint32
 }
 
+// CumulativeClaimedRequest represents a request to fetch the cumulative claimed rewards
+// for a specific earner address and token address
 type CumulativeClaimedRequest struct {
 	BlockNumber   *big.Int
 	EarnerAddress common.Address
 	TokenAddress  common.Address
 }
 
+// CumulativeClaimedResponse contains the cumulative claimed amount
 type CumulativeClaimedResponse struct {
 	CumulativeClaimed *big.Int
 }
 
+// ClaimRequest represents a request to verify a claim.
 type ClaimRequest struct {
 	BlockNumber *big.Int
 	Claim       rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
 }
 
+// ClaimResponse contains the verification result of a claim
 type ClaimResponse struct {
 	CheckClaim bool
 }

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
+	rewardscoordinator "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IRewardsCoordinator"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -80,4 +81,73 @@ type RemovePendingAdminRequest struct {
 	AccountAddress common.Address
 	AdminAddress   common.Address
 	WaitForReceipt bool
+}
+
+type ApprovalDigestHashRequest struct {
+	BlockNumber       *big.Int
+	StakerAddress     common.Address
+	OperatorAddress   common.Address
+	DelegationAddress common.Address
+	ApproverSalt      [32]byte
+	Expiry            *big.Int
+}
+
+type AVSRegistrationDigestHashRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+	AVSAddress      common.Address
+	Salt            [32]byte
+	Expiry          *big.Int
+}
+
+type DigestHashResponse struct {
+	DigestHash [32]byte
+}
+
+type RootRequest struct {
+	BlockNumer *big.Int
+}
+
+type RootLengthResponse struct {
+	Length *big.Int
+}
+
+type RewardsEndTimestampRequest struct {
+	BlockNumber *big.Int
+}
+
+type EndTimestampResponse struct {
+	EndTimestamp uint32
+}
+
+type ClaimableDistributionRootResponse struct {
+	Root rewardscoordinator.IRewardsCoordinatorTypesDistributionRoot
+}
+
+type RootHashRequest struct {
+	BlockNumber *big.Int
+	RootHash    [32]byte
+}
+
+type RootIndexResponse struct {
+	Index uint32
+}
+
+type CumulativeClaimedRequest struct {
+	BlockNumber   *big.Int
+	EarnerAddress common.Address
+	TokenAddress  common.Address
+}
+
+type CumulativeClaimedResponse struct {
+	CumulativeClaimed *big.Int
+}
+
+type ClaimRequest struct {
+	BlockNumber *big.Int
+	Claim       rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
+}
+
+type ClaimResponse struct {
+	ValidClaim bool
 }


### PR DESCRIPTION
### What Changed?
This PR is part of an incremental refactor to improve  the `elcontracts/reader` interface by implementing a request-response pattern. For the exposed functions, we create structs that represent the request (specific fields + `BlockNumber`) and the response.

Because the function signatures change, we also refactor the tests to align with the new pattern.

Methods updated in this PR: `CalculateDelegationApprovalDigestHash`, `CalculateOperatorAVSRegistrationDigestHash`, `GetDistributionRootsLength`, `CurrRewardsCalculationEndTimestamp`, `GetCurrentClaimableDistributionRoot`, `GetRootIndexFromHash`, `GetCumulativeClaimed` and `CheckClaim`

> Tracking methods in #494 

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it