### PR TITLE
refactor: `elcontracts/reader` new interface for operator and strategy

### DIFF
--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -390,6 +390,7 @@ func (r *ChainReader) GetAllocatableMagnitude(
 	return AllocatableResponse{Allocatable: allocatable}, nil
 }
 
+// GetMaxMagnitudes returns the max magnitudes that an operator can allocate to a list of strategies
 func (r *ChainReader) GetMaxMagnitudes(
 	ctx context.Context,
 	request OperatorStrategiesRequest,
@@ -410,6 +411,7 @@ func (r *ChainReader) GetMaxMagnitudes(
 	return MaxMagnitudesResponse{MaxMagnitudes: maxMagnitudes}, nil
 }
 
+// GetAllocationInfo returns the allocation info for a specific operator and strategy
 func (r *ChainReader) GetAllocationInfo(
 	ctx context.Context,
 	request OperatorStrategyRequest,
@@ -442,6 +444,7 @@ func (r *ChainReader) GetAllocationInfo(
 	return AllocationResponse{AllocationInfo: allocationsInfo}, nil
 }
 
+// GetOperatorShares returns the shares that an operator has in a set of strategies
 func (r *ChainReader) GetOperatorShares(
 	ctx context.Context,
 	request OperatorStrategiesRequest,
@@ -460,6 +463,7 @@ func (r *ChainReader) GetOperatorShares(
 	return OperatorSharesResponse{Shares: shares}, nil
 }
 
+// GetOperatorsShares returns the shares that a list of operators have in a set of strategies
 func (r *ChainReader) GetOperatorsShares(
 	ctx context.Context,
 	request OperatorsStrategiesRequest,

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -81,3 +81,56 @@ type RemovePendingAdminRequest struct {
 	AdminAddress   common.Address
 	WaitForReceipt bool
 }
+
+type OperatorAVSSplitRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+	AVSAddress      common.Address
+}
+
+type SplitResponse struct {
+	Split uint16
+}
+
+type OperatorRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+}
+
+type OperatorStrategyRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+	StrategyAddress common.Address
+}
+
+type AllocatableResponse struct {
+	Allocatable uint64
+}
+
+type OperatorStrategiesRequest struct {
+	BlockNumber       *big.Int
+	OperatorAddress   common.Address
+	StrategyAddresses []common.Address
+}
+
+type MaxMagnitudesResponse struct {
+	MaxMagnitudes []uint64
+}
+
+type AllocationResponse struct {
+	AllocationInfo []AllocationInfo
+}
+
+type OperatorSharesResponse struct {
+	Shares []*big.Int
+}
+
+type OperatorsStrategiesRequest struct {
+	BlockNumber       *big.Int
+	OperatorAddresses []common.Address
+	StrategyAddresses []common.Address
+}
+
+type OperatorsSharesResponse struct {
+	Shares [][]*big.Int
+}

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -82,7 +82,8 @@ type RemovePendingAdminRequest struct {
 	WaitForReceipt bool
 }
 
-// OperatorAVSSplitRequest is used to request the split of an operator for a specific AVS
+// OperatorAVSSplitRequest is used to request the split of an operator for a specific AVS.
+// If `BlockNumber` is nil, the latest block will be used
 type OperatorAVSSplitRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
@@ -94,13 +95,15 @@ type SplitResponse struct {
 	Split uint16
 }
 
-// OperatorRequest is used to represent the address of an operator
+// OperatorRequest is used to represent the address of an operator.
+// If `BlockNumber` is nil, the latest block will be used
 type OperatorRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
-// OperatorStrategyRequest is used to represent the address of an operator and a strategy
+// OperatorStrategyRequest is used to represent the address of an operator and a strategy.
+// If `BlockNumber` is nil, the latest block will be used
 type OperatorStrategyRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
@@ -112,6 +115,8 @@ type AllocatableResponse struct {
 	Allocatable uint64
 }
 
+// OperatorStrategiesRequest is used to represent the addresses of an operator and strategies.
+// If `BlockNumber` is nil, the latest block will be used
 type OperatorStrategiesRequest struct {
 	BlockNumber       *big.Int
 	OperatorAddress   common.Address
@@ -133,7 +138,8 @@ type OperatorSharesResponse struct {
 	Shares []*big.Int
 }
 
-// OperatorsStrategiesRequest represents the addresses of operators and strategies
+// OperatorsStrategiesRequest represents the addresses of operators and strategies.
+// If `BlockNumber` is nil, the latest block will be used
 type OperatorsStrategiesRequest struct {
 	BlockNumber       *big.Int
 	OperatorAddresses []common.Address

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -82,27 +82,32 @@ type RemovePendingAdminRequest struct {
 	WaitForReceipt bool
 }
 
+// OperatorAVSSplitRequest is used to request the split of an operator for a specific AVS
 type OperatorAVSSplitRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	AVSAddress      common.Address
 }
 
+// SplitResponse represents the split of an operator
 type SplitResponse struct {
 	Split uint16
 }
 
+// OperatorRequest is used to represent the address of an operator
 type OperatorRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
 }
 
+// OperatorStrategyRequest is used to represent the address of an operator and a strategy
 type OperatorStrategyRequest struct {
 	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	StrategyAddress common.Address
 }
 
+// AllocatableResponse shows the amount of allocatable magnitude for an operator
 type AllocatableResponse struct {
 	Allocatable uint64
 }
@@ -113,24 +118,29 @@ type OperatorStrategiesRequest struct {
 	StrategyAddresses []common.Address
 }
 
+// MaxMagnitudesResponse is used to represent the max magnitudes for an operator for each strategy
 type MaxMagnitudesResponse struct {
 	MaxMagnitudes []uint64
 }
 
+// AllocationResponse is used to represent the allocation info for specific operator and strategy
 type AllocationResponse struct {
 	AllocationInfo []AllocationInfo
 }
 
+// OperatorSharesResponse is used to represent the shares of an operator for each strategy
 type OperatorSharesResponse struct {
 	Shares []*big.Int
 }
 
+// OperatorsStrategiesRequest represents the addresses of operators and strategies
 type OperatorsStrategiesRequest struct {
 	BlockNumber       *big.Int
 	OperatorAddresses []common.Address
 	StrategyAddresses []common.Address
 }
 
+// OperatorsSharesResponse shows the shares of operators for each strategy
 type OperatorsSharesResponse struct {
 	Shares [][]*big.Int
 }


### PR DESCRIPTION
### What Changed?
This PR is part of an incremental refactor to improve  the `elcontracts/reader` interface by implementing a request-response pattern. For the exposed functions, we create structs that represent the request (specific fields + `BlockNumber`) and the response.

Because the function signatures change, we also refactor the tests to align with the new pattern.

Methods updated in this PR: `GetOperatorAVSSplit`, `GetOperatorPISplit`, `GetAllocatableMagnitude`, `GetMaxMagnitudes`, `GetAllocationInfo`, `GetOperatorShares` and `GetOperatorsShares`

> Tracking methods in #494 

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it