### PR TITLE
refactor: `elcontracts/writer` new interface for selected methods

### DIFF
--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -442,7 +442,16 @@ func TestGetCumulativeClaimedRewards(t *testing.T) {
 	claim, err := newTestClaim(chainReader, anvilHttpEndpoint, cumulativeEarnings, privateKeyHex)
 	require.NoError(t, err)
 
-	receipt, err = chainWriter.ProcessClaim(context.Background(), *claim, rewardsCoordinatorAddr, true)
+	opts, err := clients.TxManager.GetNoSendTxOpts()
+	require.NoError(t, err)
+	txOpts := &elcontracts.TxOption{Opts: opts}
+
+	claimRequest := elcontracts.ClaimProcessRequest{
+		Claim:            *claim,
+		RecipientAddress: rewardsCoordinatorAddr,
+		WaitForReceipt:   true,
+	}
+	receipt, err = chainWriter.ProcessClaim(context.Background(), claimRequest, txOpts)
 	require.NoError(t, err)
 	require.True(t, receipt.Status == gethtypes.ReceiptStatusSuccessful)
 
@@ -482,7 +491,16 @@ func TestCheckClaim(t *testing.T) {
 	claim, err := newTestClaim(chainReader, anvilHttpEndpoint, cumulativeEarnings, privateKeyHex)
 	require.NoError(t, err)
 
-	receipt, err = chainWriter.ProcessClaim(context.Background(), *claim, rewardsCoordinatorAddr, true)
+	opts, err := clients.TxManager.GetNoSendTxOpts()
+	require.NoError(t, err)
+	txOpts := &elcontracts.TxOption{Opts: opts}
+
+	claimRequest := elcontracts.ClaimProcessRequest{
+		Claim:            *claim,
+		RecipientAddress: rewardsCoordinatorAddr,
+		WaitForReceipt:   true,
+	}
+	receipt, err = chainWriter.ProcessClaim(context.Background(), claimRequest, txOpts)
 	require.NoError(t, err)
 	require.True(t, receipt.Status == gethtypes.ReceiptStatusSuccessful)
 

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -85,12 +85,12 @@ type RemovePendingAdminRequest struct {
 	WaitForReceipt bool
 }
 
+// TxOption represents a Ethereum transaction option.
 type TxOption struct {
 	Opts *bind.TransactOpts
 }
 
 // OperatorRequest represents a request that requires an operator's address.
-// If `BlockNumber` is nil, the latest block will be used
 type OperatorRequest struct {
 	BlockNumber    *big.Int
 	Operator       types.Operator
@@ -98,25 +98,20 @@ type OperatorRequest struct {
 }
 
 // OperatorMetadataRequest represents a request that updates operator metadata.
-// If `BlockNumber` is nil, the latest block will be used
 type OperatorMetadataRequest struct {
-	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	Uri             string
 	WaitForReceipt  bool
 }
 
 // DepositRequest represents a request to deposit funds into a strategy.
-// If `BlockNumber` is nil, the latest block will be used
 type DepositRequest struct {
-	BlockNumber     *big.Int
 	StrategyAddress common.Address
 	Amount          *big.Int
 	WaitForReceipt  bool
 }
 
 // ClaimerRequest represents a request to set a claimer
-// If `BlockNumber` is nil, the latest block will be used
 type ClaimerRequest struct {
 	BlockNumber    *big.Int
 	ClaimerAddress common.Address
@@ -124,7 +119,6 @@ type ClaimerRequest struct {
 }
 
 // ClaimProcessRequest represents a request to process a claim for rewards.
-// If `BlockNumber` is nil, the latest block will be used
 type ClaimProcessRequest struct {
 	BlockNumber      *big.Int
 	Claim            rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
@@ -140,9 +134,7 @@ type ClaimsProcessRequest struct {
 }
 
 // OperatorAVSSplitRequest represents a request to set an operator's AVS split.
-// If `BlockNumber` is nil, the latest block will be used
 type OperatorAVSSplitRequest struct {
-	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	AVSAddress      common.Address
 	Split           uint16
@@ -150,9 +142,7 @@ type OperatorAVSSplitRequest struct {
 }
 
 // OperatorPISplitRequest represents a request to set an operator's Programmatic Incentive split.
-// If `BlockNumber` is nil, the latest block will be used
 type OperatorPISplitRequest struct {
-	BlockNumber     *big.Int
 	OperatorAddress common.Address
 	Split           uint16
 	WaitForReceipt  bool

--- a/chainio/clients/elcontracts/types.go
+++ b/chainio/clients/elcontracts/types.go
@@ -4,8 +4,11 @@ import (
 	"math/big"
 
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
+	rewardscoordinator "github.com/Layr-Labs/eigensdk-go/contracts/bindings/IRewardsCoordinator"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	"github.com/Layr-Labs/eigensdk-go/types"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -80,4 +83,77 @@ type RemovePendingAdminRequest struct {
 	AccountAddress common.Address
 	AdminAddress   common.Address
 	WaitForReceipt bool
+}
+
+type TxOption struct {
+	Opts *bind.TransactOpts
+}
+
+// OperatorRequest represents a request that requires an operator's address.
+// If `BlockNumber` is nil, the latest block will be used
+type OperatorRequest struct {
+	BlockNumber    *big.Int
+	Operator       types.Operator
+	WaitForReceipt bool
+}
+
+// OperatorMetadataRequest represents a request that updates operator metadata.
+// If `BlockNumber` is nil, the latest block will be used
+type OperatorMetadataRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+	Uri             string
+	WaitForReceipt  bool
+}
+
+// DepositRequest represents a request to deposit funds into a strategy.
+// If `BlockNumber` is nil, the latest block will be used
+type DepositRequest struct {
+	BlockNumber     *big.Int
+	StrategyAddress common.Address
+	Amount          *big.Int
+	WaitForReceipt  bool
+}
+
+// ClaimerRequest represents a request to set a claimer
+// If `BlockNumber` is nil, the latest block will be used
+type ClaimerRequest struct {
+	BlockNumber    *big.Int
+	ClaimerAddress common.Address
+	WaitForReceipt bool
+}
+
+// ClaimProcessRequest represents a request to process a claim for rewards.
+// If `BlockNumber` is nil, the latest block will be used
+type ClaimProcessRequest struct {
+	BlockNumber      *big.Int
+	Claim            rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
+	RecipientAddress common.Address
+	WaitForReceipt   bool
+}
+
+type ClaimsProcessRequest struct {
+	BlockNumber      *big.Int
+	Claims           []rewardscoordinator.IRewardsCoordinatorTypesRewardsMerkleClaim
+	RecipientAddress common.Address
+	WaitForReceipt   bool
+}
+
+// OperatorAVSSplitRequest represents a request to set an operator's AVS split.
+// If `BlockNumber` is nil, the latest block will be used
+type OperatorAVSSplitRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+	AVSAddress      common.Address
+	Split           uint16
+	WaitForReceipt  bool
+}
+
+// OperatorPISplitRequest represents a request to set an operator's Programmatic Incentive split.
+// If `BlockNumber` is nil, the latest block will be used
+type OperatorPISplitRequest struct {
+	BlockNumber     *big.Int
+	OperatorAddress common.Address
+	Split           uint16
+	WaitForReceipt  bool
 }


### PR DESCRIPTION
### What Changed?
This PR is part of an incremental refactor to improve  the `elcontracts/writer` interface by implementing a request-response pattern. For the exposed functions, we create a struct that represent the request (specific fields + `WaitForReceipt`). 

Because the function signatures change, we also refactor the tests to align with the new pattern.

Methods updated in this PR: `RegisterAsOperator`, `UpdateOperatorDetails`, `UpdateMetadataURI`, `DepositERC20IntoStrategy`, `SetClaimerFor`, `ProcessClaim`, `SetOperatorAVSSplit`, `SetOperatorPISplit` and `ProcessClaims`

> Tracking methods in #506  

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it