### PR TITLE
feat: add create slashable stake quorum func

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -529,6 +529,11 @@ func (w *ChainWriter) SetRewardsInitiator(
 	return receipt, nil
 }
 
+// This function creates a new Quorum from the new flow (with staking). The operator set params contains
+// the max operator count for that quorum and some churn options, the strategy params contains the specified
+// strategy for that quorum and its corresponding multiplier, the minimum stake is the minimum required
+// to the operator to be in the quorum and the lookAheadPeriod is the period in days for checking operator
+// shares for a specific quorum. Returns the transaction receipt in case of success.
 func (w *ChainWriter) CreateSlashableStakeQuorum(
 	ctx context.Context,
 	operatorSetParams regcoord.ISlashingRegistryCoordinatorTypesOperatorSetParam,

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -528,3 +528,35 @@ func (w *ChainWriter) SetRewardsInitiator(
 	}
 	return receipt, nil
 }
+
+func (w *ChainWriter) CreateSlashableStakeQuorum(
+	ctx context.Context,
+	operatorSetParams regcoord.ISlashingRegistryCoordinatorTypesOperatorSetParam,
+	minimumStakeRequired *big.Int,
+	strategyParams []regcoord.IStakeRegistryTypesStrategyParams,
+	lookAheadPeriod uint32,
+	waitForReceipt bool,
+) (*gethtypes.Receipt, error) {
+	w.logger.Info("Creating slashable stake quorum")
+
+	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := w.registryCoordinator.CreateSlashableStakeQuorum(
+		noSendTxOpts,
+		operatorSetParams,
+		minimumStakeRequired,
+		strategyParams,
+		lookAheadPeriod,
+	)
+	if err != nil {
+		return nil, err
+	}
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	if err != nil {
+		return nil, utils.WrapError("failed to send CreateSlashableStakeQuorum tx with err", err.Error())
+	}
+	return receipt, nil
+}

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -553,11 +553,11 @@ func (w *ChainWriter) SetSlashableStakeLookahead(
 	return receipt, nil
 }
 
-// This function creates a new Quorum from the new flow (with staking). The operator set params contains
-// the max operator count for that quorum and some churn options, the strategy params contains the specified
-// strategy for that quorum and its corresponding multiplier, the minimum stake is the minimum required
-// to the operator to be in the quorum and the lookAheadPeriod is the period in days for checking operator
-// shares for a specific quorum. Returns the transaction receipt in case of success.
+// Creates a new quorum that tracks slashable stake for operators.
+// It receives the operator set parameters for the given quorum, the minimum stake required to register,
+// and the number of blocks to look ahead when calculating slashable stake.
+// Returns the transaction receipt in case of success.
+// Note: This function does not work on M2 AVSs.
 func (w *ChainWriter) CreateSlashableStakeQuorum(
 	ctx context.Context,
 	operatorSetParams regcoord.ISlashingRegistryCoordinatorTypesOperatorSetParam,

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -529,6 +529,30 @@ func (w *ChainWriter) SetRewardsInitiator(
 	return receipt, nil
 }
 
+// Receives the quorum number to modify and the new look ahead period to set. Sets the look ahead
+// time for checking operator shares for a specific quorum, and returns the receipt of the
+// transaction in case of success.
+func (w *ChainWriter) SetSlashableStakeLookahead(
+	ctx context.Context,
+	quorumNumber uint8,
+	lookAheadPeriod uint32,
+	waitForReceipt bool,
+) (*gethtypes.Receipt, error) {
+	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
+	if err != nil {
+		return nil, err
+	}
+	tx, err := w.stakeRegistry.SetSlashableStakeLookahead(noSendTxOpts, quorumNumber, lookAheadPeriod)
+	if err != nil {
+		return nil, err
+	}
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	if err != nil {
+		return nil, utils.WrapError("failed to send SetSlashableStakeLookahead tx with err", err.Error())
+	}
+	return receipt, nil
+}
+
 // This function creates a new Quorum from the new flow (with staking). The operator set params contains
 // the max operator count for that quorum and some churn options, the strategy params contains the specified
 // strategy for that quorum and its corresponding multiplier, the minimum stake is the minimum required

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -332,6 +332,7 @@ func TestBlsSignature(t *testing.T) {
 }
 
 func TestCreateSlashableStakeQuorum(t *testing.T) {
+	// Test set up
 	clients, anvilHttpEndpoint := testclients.BuildTestClients(t)
 	chainReader := clients.ReadClients.AvsRegistryChainReader
 
@@ -355,6 +356,7 @@ func TestCreateSlashableStakeQuorum(t *testing.T) {
 
 	lookAheadPeriod := uint32(0)
 
+	// First, quorum count is 1 because Registry is initialized with 1 quorum
 	count, err := chainReader.GetQuorumCount(&bind.CallOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, count, uint8(1))
@@ -376,6 +378,7 @@ func TestCreateSlashableStakeQuorum(t *testing.T) {
 	_, err = txManager.Send(context.Background(), tx, true)
 	require.NoError(t, err)
 
+	// Create a new slashable stake quorum
 	receipt, err := chainWriter.CreateSlashableStakeQuorum(
 		context.Background(),
 		operatorSetParams,
@@ -387,6 +390,7 @@ func TestCreateSlashableStakeQuorum(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 
+	// After creating a new one, quorum count is 2
 	count, err = chainReader.GetQuorumCount(&bind.CallOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, count, uint8(2))

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -9,6 +9,7 @@ import (
 	chainioutils "github.com/Layr-Labs/eigensdk-go/chainio/utils"
 	regcoord "github.com/Layr-Labs/eigensdk-go/contracts/bindings/RegistryCoordinator"
 	servicemanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/ServiceManagerBase"
+	stakeregistry "github.com/Layr-Labs/eigensdk-go/contracts/bindings/StakeRegistry"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/testutils"
 	"github.com/Layr-Labs/eigensdk-go/testutils/testclients"
@@ -249,6 +250,49 @@ func TestWriterMethods(t *testing.T) {
 		)
 		assert.Error(t, err)
 		assert.Nil(t, receipt)
+	})
+
+	t.Run("set slashable stake lookahead", func(t *testing.T) {
+		// Create stakeRegistry contract
+		ethHttpClient, err := ethclient.Dial(anvilHttpEndpoint)
+		require.NoError(t, err)
+
+		contractBlsRegistryCoordinator, err := regcoord.NewContractRegistryCoordinator(
+			contractAddrs.RegistryCoordinator,
+			ethHttpClient,
+		)
+		require.NoError(t, err)
+
+		stakeRegistryAddr, err := contractBlsRegistryCoordinator.StakeRegistry(&bind.CallOpts{})
+		require.NoError(t, err)
+
+		stakeRegistry, err := stakeregistry.NewContractStakeRegistry(
+			stakeRegistryAddr,
+			ethHttpClient,
+		)
+		require.NoError(t, err)
+
+		// When not set, lookAheadPeriod is Zero
+		lookAheadPeriod, err := stakeRegistry.SlashableStakeLookAheadPerQuorum(&bind.CallOpts{}, 0)
+		require.NoError(t, err)
+		assert.Zero(t, lookAheadPeriod)
+
+		// Modify lookAheadPeriod, set it as 32
+		newLookAheadPeriod := 32
+		receipt, err := chainWriter.SetSlashableStakeLookahead(
+			context.Background(),
+			0,
+			uint32(newLookAheadPeriod),
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+
+		// After modify, lookAheadPeriod's value is 32
+		lookAheadPeriod, err = stakeRegistry.SlashableStakeLookAheadPerQuorum(&bind.CallOpts{}, 0)
+		require.NoError(t, err)
+
+		assert.Equal(t, lookAheadPeriod, uint32(newLookAheadPeriod))
 	})
 }
 


### PR DESCRIPTION
### What Changed?
Adds CreateSlashableStakeQuorum and a test case adding a slashable stake quorum and verifying registry coordinator's quorum number has increased.

Also aims to fix partially issue #518 

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it