### PR TITLE
feat: add eject operator function

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -552,3 +552,26 @@ func (w *ChainWriter) SetSlashableStakeLookahead(
 	}
 	return receipt, nil
 }
+
+func (w *ChainWriter) EjectOperator(
+	ctx context.Context,
+	operatorAddress gethcommon.Address,
+	quorumNumbers []byte,
+	waitForReceipt bool,
+) (*gethtypes.Receipt, error) {
+	w.logger.Info("ejecting operator with address ", operatorAddress, " from quorum numbers ", quorumNumbers)
+
+	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
+	if err != nil {
+		return nil, err
+	}
+	tx, err := w.registryCoordinator.EjectOperator(noSendTxOpts, operatorAddress, quorumNumbers)
+	if err != nil {
+		return nil, err
+	}
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	if err != nil {
+		return nil, utils.WrapError("failed to send EjectOperator tx with err", err.Error())
+	}
+	return receipt, nil
+}

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -558,7 +558,7 @@ func (w *ChainWriter) SetSlashableStakeLookahead(
 func (w *ChainWriter) EjectOperator(
 	ctx context.Context,
 	operatorAddress gethcommon.Address,
-	quorumNumbers []byte,
+	quorumNumbers types.QuorumNums,
 	waitForReceipt bool,
 ) (*gethtypes.Receipt, error) {
 	w.logger.Info("ejecting operator with address ", operatorAddress, " from quorum numbers ", quorumNumbers)
@@ -567,7 +567,7 @@ func (w *ChainWriter) EjectOperator(
 	if err != nil {
 		return nil, err
 	}
-	tx, err := w.registryCoordinator.EjectOperator(noSendTxOpts, operatorAddress, quorumNumbers)
+	tx, err := w.registryCoordinator.EjectOperator(noSendTxOpts, operatorAddress, quorumNumbers.UnderlyingType())
 	if err != nil {
 		return nil, err
 	}

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -553,6 +553,8 @@ func (w *ChainWriter) SetSlashableStakeLookahead(
 	return receipt, nil
 }
 
+// Receives an operator address and quorum numbers and ejects the operator from the given quorums.
+// Note: if the operator is not registered, the call will not fail, but will do nothing.
 func (w *ChainWriter) EjectOperator(
 	ctx context.Context,
 	operatorAddress gethcommon.Address,

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
@@ -326,4 +327,46 @@ func TestBlsSignature(t *testing.T) {
 	// Values taken from previous run of this test
 	assert.Equal(t, x, "15790168376429033610067099039091292283117017641532256477437243974517959682102")
 	assert.Equal(t, y, "4960450323239587206117776989095741074887370703941588742100855592356200866613")
+}
+
+func TestEjectOperator(t *testing.T) {
+	// Test set up
+	clients, _ := testclients.BuildTestClients(t)
+
+	chainReader := clients.ReadClients.AvsRegistryChainReader
+	chainWriter := clients.AvsRegistryChainWriter
+
+	keypair, err := bls.NewKeyPairFromString("0x01")
+	require.NoError(t, err)
+
+	ecdsaPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
+	require.NoError(t, err)
+
+	operatorAddr := gethcommon.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
+
+	quorumNumbers := types.QuorumNums{0}
+
+	// At the beginning, operator is not registered
+	isRegisterd, err := chainReader.IsOperatorRegistered(&bind.CallOpts{}, operatorAddr)
+	require.NoError(t, err)
+	require.False(t, isRegisterd)
+
+	// After registration, operator is registered
+	receipt, err := chainWriter.RegisterOperator(context.Background(), ecdsaPrivateKey, keypair, quorumNumbers, "", true)
+	require.NoError(t, err)
+	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
+
+	isRegisterd, err = chainReader.IsOperatorRegistered(&bind.CallOpts{}, operatorAddr)
+	require.NoError(t, err)
+	require.True(t, isRegisterd)
+
+	// After being ejected, operator is not registered anymore
+	receipt, err = chainWriter.EjectOperator(context.Background(), operatorAddr, quorumNumbers.UnderlyingType(), true)
+	require.NoError(t, err)
+	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
+
+	isRegisterd, err = chainReader.IsOperatorRegistered(&bind.CallOpts{}, operatorAddr)
+	require.NoError(t, err)
+	require.False(t, isRegisterd)
+	// Maybe we could do something better than just checking if is registered, but did not found something more
 }

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -361,7 +361,7 @@ func TestEjectOperator(t *testing.T) {
 	require.True(t, isRegisterd)
 
 	// After being ejected, operator is not registered anymore
-	receipt, err = chainWriter.EjectOperator(context.Background(), operatorAddr, quorumNumbers.UnderlyingType(), true)
+	receipt, err = chainWriter.EjectOperator(context.Background(), operatorAddr, quorumNumbers, true)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -352,7 +352,14 @@ func TestEjectOperator(t *testing.T) {
 	require.False(t, isRegisterd)
 
 	// After registration, operator is registered
-	receipt, err := chainWriter.RegisterOperator(context.Background(), ecdsaPrivateKey, keypair, quorumNumbers, "", true)
+	receipt, err := chainWriter.RegisterOperator(
+		context.Background(),
+		ecdsaPrivateKey,
+		keypair,
+		quorumNumbers,
+		"",
+		true,
+	)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -375,5 +375,4 @@ func TestEjectOperator(t *testing.T) {
 	isRegisterd, err = chainReader.IsOperatorRegistered(&bind.CallOpts{}, operatorAddr)
 	require.NoError(t, err)
 	require.False(t, isRegisterd)
-	// Maybe we could do something better than just checking if is registered, but did not found something more
 }


### PR DESCRIPTION
### What Changed?
Adds EjectOperator and a test case adding an operator to a quorum and then ejecting it.

Also aims to fix partially issue #518

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it