### PR TITLE
feat: add missing contract addresses on `BuildAllConfig`

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -58,7 +58,6 @@ jobs:
           filters: |
             contracts:
               - 'contracts/lib/**'
-              - 'contracts/script/**'
               - 'contracts/src/**'
             bindings:
               - 'contracts/bindings/**'

--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -22,12 +22,15 @@ import (
 )
 
 type BuildAllConfig struct {
-	EthHttpUrl                 string
-	EthWsUrl                   string
-	RegistryCoordinatorAddr    string
-	OperatorStateRetrieverAddr string
-	AvsName                    string
-	PromMetricsIpPortAddress   string
+	EthHttpUrl               string
+	EthWsUrl                 string
+	AvsName                  string
+	PromMetricsIpPortAddress string
+
+	RegistryCoordinatorAddr     string
+	OperatorStateRetrieverAddr  string
+	RewardsCoordinatorAddress   string
+	PermissionControllerAddress string
 
 	/// The address of the ServiceManager contract.
 	ServiceManagerAddress string
@@ -196,12 +199,20 @@ func BuildAll(
 		return nil, utils.WrapError("Failed to create AVS Registry Reader and Writer", err)
 	}
 
+	elcontractsCfg := elcontracts.Config{
+		DelegationManagerAddress: avsRegistryContractBindings.DelegationManagerAddr,
+		AvsDirectoryAddress:      avsRegistryContractBindings.AvsDirectoryAddr,
+	}
+	if config.RewardsCoordinatorAddress != "" {
+		elcontractsCfg.RewardsCoordinatorAddress = gethcommon.HexToAddress(config.RewardsCoordinatorAddress)
+	}
+	if config.PermissionControllerAddress != "" {
+		elcontractsCfg.PermissionControllerAddress = gethcommon.HexToAddress(config.PermissionControllerAddress)
+	}
+
 	// creating EL clients: Reader, Writer and EigenLayer Contract Bindings
 	elChainReader, elChainWriter, elContractBindings, err := elcontracts.BuildClients(
-		elcontracts.Config{
-			DelegationManagerAddress: avsRegistryContractBindings.DelegationManagerAddr,
-			AvsDirectoryAddress:      avsRegistryContractBindings.AvsDirectoryAddr,
-		},
+		elcontractsCfg,
 		ethHttpClient,
 		txMgr,
 		logger,
@@ -244,17 +255,6 @@ func (config *BuildAllConfig) validate(logger logging.Logger) error {
 		logger.Error("BuildAllConfig.validate: Missing eth ws url")
 		return fmt.Errorf("BuildAllConfig.validate: Missing eth ws url")
 	}
-	if config.RegistryCoordinatorAddr == "" {
-		logger.Error("BuildAllConfig.validate: Missing bls registry coordinator address")
-		return fmt.Errorf("BuildAllConfig.validate: Missing bls registry coordinator address")
-	}
-	if config.ServiceManagerAddress == "" {
-		logger.Info("BuildAllConfig.validate: Missing optional service manager address")
-	}
-	if config.OperatorStateRetrieverAddr == "" {
-		logger.Error("BuildAllConfig.validate: Missing bls operator state retriever address")
-		return fmt.Errorf("BuildAllConfig.validate: Missing bls operator state retriever address")
-	}
 	if config.AvsName == "" {
 		logger.Error("BuildAllConfig.validate: Missing avs name")
 		return fmt.Errorf("BuildAllConfig.validate: Missing avs name")
@@ -262,6 +262,23 @@ func (config *BuildAllConfig) validate(logger logging.Logger) error {
 	if config.PromMetricsIpPortAddress == "" {
 		logger.Error("BuildAllConfig.validate: Missing prometheus metrics ip port address")
 		return fmt.Errorf("BuildAllConfig.validate: Missing prometheus metrics ip port address")
+	}
+	if config.RegistryCoordinatorAddr == "" {
+		logger.Error("BuildAllConfig.validate: Missing bls registry coordinator address")
+		return fmt.Errorf("BuildAllConfig.validate: Missing bls registry coordinator address")
+	}
+	if config.OperatorStateRetrieverAddr == "" {
+		logger.Error("BuildAllConfig.validate: Missing bls operator state retriever address")
+		return fmt.Errorf("BuildAllConfig.validate: Missing bls operator state retriever address")
+	}
+	if config.RewardsCoordinatorAddress == "" {
+		logger.Info("BuildAllConfig.validate: Missing optional rewards coordinator address")
+	}
+	if config.PermissionControllerAddress == "" {
+		logger.Info("BuildAllConfig.validate: Missing optional permission controller address")
+	}
+	if config.ServiceManagerAddress == "" {
+		logger.Info("BuildAllConfig.validate: Missing optional service manager address")
 	}
 	return nil
 }

--- a/chainio/clients/elcontracts/bindings.go
+++ b/chainio/clients/elcontracts/bindings.go
@@ -80,11 +80,11 @@ func NewBindingsFromConfig(
 		}
 	}
 
-	if isZeroAddress(cfg.PermissionsControllerAddress) {
+	if isZeroAddress(cfg.PermissionControllerAddress) {
 		logger.Debug("PermissionController address not provided, the calls to the contract will not work")
 	} else {
 		permissionController, err = permissioncontroller.NewContractPermissionController(
-			cfg.PermissionsControllerAddress,
+			cfg.PermissionControllerAddress,
 			client,
 		)
 		if err != nil {

--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -23,10 +23,10 @@ import (
 )
 
 type Config struct {
-	DelegationManagerAddress     gethcommon.Address
-	AvsDirectoryAddress          gethcommon.Address
-	RewardsCoordinatorAddress    gethcommon.Address
-	PermissionsControllerAddress gethcommon.Address
+	DelegationManagerAddress    gethcommon.Address
+	AvsDirectoryAddress         gethcommon.Address
+	RewardsCoordinatorAddress   gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
 }
 
 type ChainReader struct {

--- a/chainio/clients/elcontracts/reader_test.go
+++ b/chainio/clients/elcontracts/reader_test.go
@@ -502,7 +502,7 @@ func TestCheckClaim(t *testing.T) {
 }
 
 func TestGetAllocatableMagnitudeAndGetMaxMagnitudes(t *testing.T) {
-	// Without changes, Allocable magnitude is max magnitude
+	// Without changes, Allocatable magnitude is max magnitude
 
 	// Test setup
 	ctx := context.Background()
@@ -601,10 +601,9 @@ func TestAdminFunctions(t *testing.T) {
 	anvilHttpEndpoint, err := anvilC.Endpoint(context.Background(), "http")
 	assert.NoError(t, err)
 
-	permissionControllerAddr := common.HexToAddress(testutils.PERMISSION_CONTROLLER_ADDRESS)
-	config := elcontracts.Config{
-		PermissionsControllerAddress: permissionControllerAddr,
-	}
+	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
+
+	config := elcontracts.Config{PermissionControllerAddress: contractAddrs.PermissionController}
 
 	operatorAddr := common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
 	privateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
@@ -690,10 +689,9 @@ func TestAppointeesFunctions(t *testing.T) {
 	anvilHttpEndpoint, err := anvilC.Endpoint(context.Background(), "http")
 	assert.NoError(t, err)
 
-	permissionControllerAddr := common.HexToAddress(testutils.PERMISSION_CONTROLLER_ADDRESS)
-	config := elcontracts.Config{
-		PermissionsControllerAddress: permissionControllerAddr,
-	}
+	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
+
+	config := elcontracts.Config{PermissionControllerAddress: contractAddrs.PermissionController}
 
 	chainReader, err := testclients.NewTestChainReaderFromConfig(anvilHttpEndpoint, config)
 	assert.NoError(t, err)

--- a/chainio/clients/elcontracts/writer_test.go
+++ b/chainio/clients/elcontracts/writer_test.go
@@ -696,12 +696,11 @@ func TestSetAndRemovePermission(t *testing.T) {
 	anvilHttpEndpoint, err := anvilC.Endpoint(context.Background(), "http")
 	require.NoError(t, err)
 	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
-	permissionControllerAddr := common.HexToAddress(testutils.PERMISSION_CONTROLLER_ADDRESS)
 
 	privateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
 	config := elcontracts.Config{
-		DelegationManagerAddress:     contractAddrs.DelegationManager,
-		PermissionsControllerAddress: permissionControllerAddr,
+		DelegationManagerAddress:    contractAddrs.DelegationManager,
+		PermissionControllerAddress: contractAddrs.PermissionController,
 	}
 	chainWriter, err := testclients.NewTestChainWriterFromConfig(anvilHttpEndpoint, privateKeyHex, config)
 	require.NoError(t, err)
@@ -942,13 +941,11 @@ func TestAddAndRemovePendingAdmin(t *testing.T) {
 	require.NoError(t, err)
 	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
 
-	permissionControllerAddr := common.HexToAddress(testutils.PERMISSION_CONTROLLER_ADDRESS)
-
 	operatorAddr := common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
 	privateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
 	config := elcontracts.Config{
-		DelegationManagerAddress:     contractAddrs.DelegationManager,
-		PermissionsControllerAddress: permissionControllerAddr,
+		DelegationManagerAddress:    contractAddrs.DelegationManager,
+		PermissionControllerAddress: contractAddrs.PermissionController,
 	}
 	chainWriter, err := testclients.NewTestChainWriterFromConfig(anvilHttpEndpoint, privateKeyHex, config)
 	require.NoError(t, err)
@@ -1007,13 +1004,12 @@ func TestAcceptAdmin(t *testing.T) {
 	anvilHttpEndpoint, err := anvilC.Endpoint(context.Background(), "http")
 	require.NoError(t, err)
 	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
-	permissionControllerAddr := common.HexToAddress(testutils.PERMISSION_CONTROLLER_ADDRESS)
 
 	accountAddr := common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
 	accountPrivateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
 	config := elcontracts.Config{
-		DelegationManagerAddress:     contractAddrs.DelegationManager,
-		PermissionsControllerAddress: permissionControllerAddr,
+		DelegationManagerAddress:    contractAddrs.DelegationManager,
+		PermissionControllerAddress: contractAddrs.PermissionController,
 	}
 	accountChainWriter, err := testclients.NewTestChainWriterFromConfig(anvilHttpEndpoint, accountPrivateKeyHex, config)
 	require.NoError(t, err)
@@ -1068,13 +1064,11 @@ func TestRemoveAdmin(t *testing.T) {
 	require.NoError(t, err)
 	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
 
-	permissionControllerAddr := common.HexToAddress(testutils.PERMISSION_CONTROLLER_ADDRESS)
-
 	accountAddr := common.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
 	accountPrivateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
 	config := elcontracts.Config{
-		DelegationManagerAddress:     contractAddrs.DelegationManager,
-		PermissionsControllerAddress: permissionControllerAddr,
+		DelegationManagerAddress:    contractAddrs.DelegationManager,
+		PermissionControllerAddress: contractAddrs.PermissionController,
 	}
 	accountChainWriter, err := testclients.NewTestChainWriterFromConfig(anvilHttpEndpoint, accountPrivateKeyHex, config)
 	require.NoError(t, err)

--- a/contracts/script/DeployMockAvsRegistries.s.sol
+++ b/contracts/script/DeployMockAvsRegistries.s.sol
@@ -215,5 +215,6 @@ contract DeployMockAvsRegistries is Script, ConfigsReadWriter, EigenlayerContrac
         registry.registerContract("delegationManager", address(eigen.delegationManager));
         registry.registerContract("strategyManager", address(eigen.strategyManager));
         registry.registerContract("rewardsCoordinator", address(eigen.rewardsCoordinator));
+        registry.registerContract("permissionController", address(eigen.permissionController));
     }
 }

--- a/contracts/script/output/31337/token_and_strategy_deployment_output.json
+++ b/contracts/script/output/31337/token_and_strategy_deployment_output.json
@@ -1,6 +1,6 @@
 {
   "addresses": {
-    "erc20mock": "0xDC11f7E700A4c898AE5CAddB1082cFfa76512aDD",
-    "erc20mockstrategy": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB"
+    "erc20mock": "0x51A1ceB83B83F1985a81C295d1fF28Afef186E02",
+    "erc20mockstrategy": "0x8198f5d8F8CfFE8f9C413d98a0A55aEB8ab9FbB7"
   }
 }

--- a/testutils/anvil.go
+++ b/testutils/anvil.go
@@ -79,6 +79,7 @@ type ContractAddresses struct {
 	DelegationManager      common.Address
 	Erc20MockStrategy      common.Address
 	RewardsCoordinator     common.Address
+	PermissionController   common.Address
 }
 
 func GetContractAddressesFromContractRegistry(ethHttpUrl string) (mockAvsContracts ContractAddresses) {
@@ -142,6 +143,13 @@ func GetContractAddressesFromContractRegistry(ethHttpUrl string) (mockAvsContrac
 	if rewardsCoordinatorAddr == (common.Address{}) {
 		panic("rewardsCoordinatorAddr is empty")
 	}
+	permissionControllerAddr, err := contractsRegistry.Contracts(&bind.CallOpts{}, "permissionController")
+	if err != nil {
+		panic(err)
+	}
+	if permissionControllerAddr == (common.Address{}) {
+		panic("permissionControllerAddr is empty")
+	}
 	mockAvsContracts = ContractAddresses{
 		ServiceManager:         mockAvsServiceManagerAddr,
 		RegistryCoordinator:    mockAvsRegistryCoordinatorAddr,
@@ -149,6 +157,7 @@ func GetContractAddressesFromContractRegistry(ethHttpUrl string) (mockAvsContrac
 		DelegationManager:      delegationManagerAddr,
 		Erc20MockStrategy:      erc20MockStrategyAddr,
 		RewardsCoordinator:     rewardsCoordinatorAddr,
+		PermissionController:   permissionControllerAddr,
 	}
 	return mockAvsContracts
 }

--- a/testutils/anvil.go
+++ b/testutils/anvil.go
@@ -28,10 +28,6 @@ const (
 	ANVIL_THIRD_PRIVATE_KEY  = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
 )
 
-// This address is hardcoded because it is required by the elcontracts tests but is not
-// registered in the ContractRegistry in the contracts-deployed-anvil-state.json anvil state.
-const PERMISSION_CONTROLLER_ADDRESS = "610178dA211FEF7D417bC0e6FeD39F05609AD788"
-
 func StartAnvilContainer(anvilStateFileName string) (testcontainers.Container, error) {
 
 	ctx := context.Background()

--- a/testutils/testclients/testclients.go
+++ b/testutils/testclients/testclients.go
@@ -42,13 +42,15 @@ func BuildTestClients(t *testing.T) (*clients.Clients, string) {
 	require.NoError(t, err)
 
 	chainioConfig := clients.BuildAllConfig{
-		EthHttpUrl:                 anvilHttpEndpoint,
-		EthWsUrl:                   anvilWsEndpoint,
-		RegistryCoordinatorAddr:    contractAddrs.RegistryCoordinator.String(),
-		OperatorStateRetrieverAddr: contractAddrs.OperatorStateRetriever.String(),
-		AvsName:                    "exampleAvs",
-		PromMetricsIpPortAddress:   ":9090",
-		ServiceManagerAddress:      contractAddrs.ServiceManager.String(),
+		EthHttpUrl:                  anvilHttpEndpoint,
+		EthWsUrl:                    anvilWsEndpoint,
+		RegistryCoordinatorAddr:     contractAddrs.RegistryCoordinator.String(),
+		OperatorStateRetrieverAddr:  contractAddrs.OperatorStateRetriever.String(),
+		AvsName:                     "exampleAvs",
+		PromMetricsIpPortAddress:    ":9090",
+		ServiceManagerAddress:       contractAddrs.ServiceManager.String(),
+		RewardsCoordinatorAddress:   contractAddrs.RewardsCoordinator.String(),
+		PermissionControllerAddress: contractAddrs.PermissionController.String(),
 	}
 
 	clients, err := clients.BuildAll(


### PR DESCRIPTION
Fixes # .

### What Changed?

This PR adds `PermissionController` and `RewardsCoordinator` addresses to the `BuildAllConfig`. It also sets these new fields in the `StartAnvilContainer` function to make them available and registers the `PermissionController` in the `ContractRegistry` so we can remove an address constant we had.

This also modifies the "bindings" workflow to ignore changes to deploy scripts, since those don't modify interfaces, and thus, bindings.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it