### PR TITLE
feat: implement new method `registerOperatorWithChurn`

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -271,6 +271,8 @@ func (w *ChainWriter) UpdateStakesOfEntireOperatorSetForQuorums(
 
 }
 
+// Registers an operator while replacing existing operators in full quorums. If any quorum reaches its maximum
+// operator capacity, `operatorKickParams` is used to replace an old operator with the new one.
 func (w *ChainWriter) RegisterOperatorWithChurn(
 	ctx context.Context,
 	operatorEcdsaPrivateKey *ecdsa.PrivateKey,

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -359,7 +359,7 @@ func (w *ChainWriter) RegisterOperatorWithChurn(
 		return nil, err
 	}
 	churnMsgToSign, err := w.registryCoordinator.CalculateOperatorChurnApprovalDigestHash(
-		&bind.CallOpts{},
+		&bind.CallOpts{Context: ctx},
 		operatorAddr,
 		operatorId,
 		operatorKickParams,

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -360,7 +360,8 @@ func (w *ChainWriter) RegisterOperatorWithChurn(
 
 	var operatorIdBytes [32]byte
 
-	// Remove the 0x prefix from the operator ID
+	// `GetOperatorID()`` returns the operator ID with the 0x prefix.
+	// We need to remove the prefix and decode the hex string to bytes.
 	operatorId := blsKeyPair.GetPubKeyG1().GetOperatorID()
 	operatorIdNoPrefix := strings.TrimPrefix(operatorId, "0x")
 	operatorIdBytesDecoded, err := hex.DecodeString(operatorIdNoPrefix)

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
+	"encoding/hex"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -354,14 +356,21 @@ func (w *ChainWriter) RegisterOperatorWithChurn(
 		return nil, err
 	}
 
-	operatorId, err := w.registryCoordinator.GetOperatorId(&bind.CallOpts{}, operatorAddr)
+	var operatorIdBytes [32]byte
+
+	// Remove the 0x prefix from the operator ID
+	operatorId := blsKeyPair.GetPubKeyG1().GetOperatorID()
+	operatorIdNoPrefix := strings.TrimPrefix(operatorId, "0x")
+	operatorIdBytesDecoded, err := hex.DecodeString(operatorIdNoPrefix)
 	if err != nil {
 		return nil, err
 	}
+	copy(operatorIdBytes[:], operatorIdBytesDecoded)
+
 	churnMsgToSign, err := w.registryCoordinator.CalculateOperatorChurnApprovalDigestHash(
 		&bind.CallOpts{Context: ctx},
 		operatorAddr,
-		operatorId,
+		operatorIdBytes,
 		operatorKickParams,
 		churnSignatureSalt,
 		signatureExpiry,
@@ -369,17 +378,19 @@ func (w *ChainWriter) RegisterOperatorWithChurn(
 	if err != nil {
 		return nil, err
 	}
+
 	churnApprovalSignature, err := crypto.Sign(churnMsgToSign[:], churnApprovalEcdsaPrivateKey)
 	if err != nil {
 		return nil, err
 	}
+
 	// the crypto library is low level and deals with 0/1 v values, whereas ethereum expects 27/28, so we add 27
 	// see https://github.com/ethereum/go-ethereum/issues/28757#issuecomment-1874525854
 	// and https://twitter.com/pcaversaccio/status/1671488928262529031
 	churnApprovalSignature[64] += 27
 	churnApproverSignatureWithSaltAndExpiry := regcoord.ISignatureUtilsSignatureWithSaltAndExpiry{
 		Signature: churnApprovalSignature,
-		Salt:      signatureSalt,
+		Salt:      churnSignatureSalt,
 		Expiry:    signatureExpiry,
 	}
 

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -269,6 +269,156 @@ func (w *ChainWriter) UpdateStakesOfEntireOperatorSetForQuorums(
 
 }
 
+func (w *ChainWriter) RegisterOperatorWithChurn(
+	ctx context.Context,
+	operatorEcdsaPrivateKey *ecdsa.PrivateKey,
+	churnApprovalEcdsaPrivateKey *ecdsa.PrivateKey,
+	blsKeyPair *bls.KeyPair,
+	quorumNumbers types.QuorumNums,
+	quorumNumbersToKick types.QuorumNums,
+	operatorsToKick []gethcommon.Address,
+	socket string,
+	waitForReceipt bool,
+) (*gethtypes.Receipt, error) {
+	operatorAddr := crypto.PubkeyToAddress(operatorEcdsaPrivateKey.PublicKey)
+	g1HashedMsgToSign, err := w.registryCoordinator.PubkeyRegistrationMessageHash(&bind.CallOpts{}, operatorAddr)
+	if err != nil {
+		return nil, err
+	}
+	signedMsg := chainioutils.ConvertToBN254G1Point(
+		blsKeyPair.SignHashedToCurveMessage(chainioutils.ConvertBn254GethToGnark(g1HashedMsgToSign)).G1Point,
+	)
+	G1pubkeyBN254 := chainioutils.ConvertToBN254G1Point(blsKeyPair.GetPubKeyG1())
+	G2pubkeyBN254 := chainioutils.ConvertToBN254G2Point(blsKeyPair.GetPubKeyG2())
+	pubkeyRegParams := regcoord.IBLSApkRegistryTypesPubkeyRegistrationParams{
+		PubkeyRegistrationSignature: signedMsg,
+		PubkeyG1:                    G1pubkeyBN254,
+		PubkeyG2:                    G2pubkeyBN254,
+	}
+
+	// generate a random salt and 1 hour expiry for the signature
+	var signatureSalt [32]byte
+	_, err = rand.Read(signatureSalt[:])
+	if err != nil {
+		return nil, err
+	}
+
+	curBlockNum, err := w.ethClient.BlockNumber(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	curBlock, err := w.ethClient.BlockByNumber(context.Background(), new(big.Int).SetUint64(curBlockNum))
+	if err != nil {
+		return nil, err
+	}
+	sigValidForSeconds := int64(60 * 60) // 1 hour
+
+	curTime := new(big.Int).SetUint64(curBlock.Time())
+	signatureExpiry := new(big.Int).Add(curTime, big.NewInt(sigValidForSeconds))
+
+	// params to register operator in delegation manager's operator-avs mapping
+	msgToSign, err := w.elReader.CalculateOperatorAVSRegistrationDigestHash(
+		ctx,
+		operatorAddr,
+		w.serviceManagerAddr,
+		signatureSalt,
+		signatureExpiry,
+	)
+	if err != nil {
+		return nil, err
+	}
+	operatorSignature, err := crypto.Sign(msgToSign[:], operatorEcdsaPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	// the crypto library is low level and deals with 0/1 v values, whereas ethereum expects 27/28, so we add 27
+	// see https://github.com/ethereum/go-ethereum/issues/28757#issuecomment-1874525854
+	// and https://twitter.com/pcaversaccio/status/1671488928262529031
+	operatorSignature[64] += 27
+	operatorSignatureWithSaltAndExpiry := regcoord.ISignatureUtilsSignatureWithSaltAndExpiry{
+		Signature: operatorSignature,
+		Salt:      signatureSalt,
+		Expiry:    signatureExpiry,
+	}
+
+	var operatorKickParams []regcoord.ISlashingRegistryCoordinatorTypesOperatorKickParam
+	for i, operatorToKick := range operatorsToKick {
+		operatorKickParams = append(operatorKickParams, regcoord.ISlashingRegistryCoordinatorTypesOperatorKickParam{
+			Operator:     operatorToKick,
+			QuorumNumber: quorumNumbersToKick[i].UnderlyingType(),
+		})
+	}
+	var churnSignatureSalt [32]byte
+	_, err = rand.Read(churnSignatureSalt[:])
+	if err != nil {
+		return nil, err
+	}
+
+	operatorId, err := w.registryCoordinator.GetOperatorId(&bind.CallOpts{}, operatorAddr)
+	if err != nil {
+		return nil, err
+	}
+	churnMsgToSign, err := w.registryCoordinator.CalculateOperatorChurnApprovalDigestHash(
+		&bind.CallOpts{},
+		operatorAddr,
+		operatorId,
+		operatorKickParams,
+		churnSignatureSalt,
+		signatureExpiry,
+	)
+	if err != nil {
+		return nil, err
+	}
+	churnApprovalSignature, err := crypto.Sign(churnMsgToSign[:], churnApprovalEcdsaPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	// the crypto library is low level and deals with 0/1 v values, whereas ethereum expects 27/28, so we add 27
+	// see https://github.com/ethereum/go-ethereum/issues/28757#issuecomment-1874525854
+	// and https://twitter.com/pcaversaccio/status/1671488928262529031
+	churnApprovalSignature[64] += 27
+	churnApproverSignatureWithSaltAndExpiry := regcoord.ISignatureUtilsSignatureWithSaltAndExpiry{
+		Signature: churnApprovalSignature,
+		Salt:      signatureSalt,
+		Expiry:    signatureExpiry,
+	}
+
+	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := w.registryCoordinator.RegisterOperatorWithChurn(
+		noSendTxOpts,
+		quorumNumbers.UnderlyingType(),
+		socket,
+		pubkeyRegParams,
+		operatorKickParams,
+		operatorSignatureWithSaltAndExpiry,
+		churnApproverSignatureWithSaltAndExpiry,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	if err != nil {
+		return nil, utils.WrapError("failed to send tx with err", err.Error())
+	}
+	w.logger.Info(
+		"successfully registered operator with AVS registry coordinator",
+		"txHash",
+		receipt.TxHash.String(),
+		"avs-service-manager",
+		w.serviceManagerAddr,
+		"operator",
+		operatorAddr,
+		"quorumNumbers",
+		quorumNumbers,
+	)
+	return receipt, nil
+}
+
 // Updates the stakes of a the given `operators` for all the quorums.
 // On success, returns the receipt of the transaction.
 func (w *ChainWriter) UpdateStakesOfOperatorSubsetForAllQuorums(

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -360,7 +360,7 @@ func (w *ChainWriter) RegisterOperatorWithChurn(
 
 	var operatorIdBytes [32]byte
 
-	// `GetOperatorID()`` returns the operator ID with the 0x prefix.
+	// `GetOperatorID()` returns the operator ID with `0x` prefix.
 	// We need to remove the prefix and decode the hex string to bytes.
 	operatorId := blsKeyPair.GetPubKeyG1().GetOperatorID()
 	operatorIdNoPrefix := strings.TrimPrefix(operatorId, "0x")

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -394,8 +394,8 @@ func (w *ChainWriter) RegisterOperatorWithChurn(
 		socket,
 		pubkeyRegParams,
 		operatorKickParams,
-		operatorSignatureWithSaltAndExpiry,
 		churnApproverSignatureWithSaltAndExpiry,
+		operatorSignatureWithSaltAndExpiry,
 	)
 
 	if err != nil {

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -80,6 +80,41 @@ func TestWriterMethods(t *testing.T) {
 		require.NotNil(t, receipt)
 	})
 
+	t.Run("register operator with churn", func(t *testing.T) {
+		firstOperatorAddress := gethcommon.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
+		firstOperatorPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
+
+		//register once
+		receipt, err := chainWriter.RegisterOperator(
+			context.Background(),
+			firstOperatorPrivateKey,
+			keypair,
+			quorumNumbers,
+			"",
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+
+		secondOperatorPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
+		operatorsToKick := []gethcommon.Address{firstOperatorAddress}
+
+		churnApprovalPrivateKey := testutils.ANVIL_THIRD_PRIVATE_KEY
+
+		receipt, err = chainWriter.RegisterOperatorWithChurn(
+			context.Background(),
+			secondOperatorPrivateKey,
+			keypair,
+			quorumNumbers,
+			quorumNumbers,
+			operatorsToKick,
+			"",
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+	})
+
 	t.Run("update stake of operator subset", func(t *testing.T) {
 		receipt, err := chainWriter.UpdateStakesOfOperatorSubsetForAllQuorums(
 			context.Background(),

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -35,15 +35,6 @@ func TestWriterMethods(t *testing.T) {
 
 	operatorPrivateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
 
-	// secondOperatorAddress := gethcommon.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
-	secondOperatorPrivateKeyHex := testutils.ANVIL_SECOND_PRIVATE_KEY
-	secondOperatorPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
-	require.NoError(t, err)
-
-	churnApprovalPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
-	require.NoError(t, err)
-	churnApproverAddress := gethcommon.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
-
 	config := avsregistry.Config{
 		RegistryCoordinatorAddress:    contractAddrs.RegistryCoordinator,
 		OperatorStateRetrieverAddress: contractAddrs.OperatorStateRetriever,
@@ -51,13 +42,6 @@ func TestWriterMethods(t *testing.T) {
 	}
 
 	chainWriter, err := testclients.NewTestAvsRegistryWriterFromConfig(anvilHttpEndpoint, operatorPrivateKeyHex, config)
-	require.NoError(t, err)
-
-	chainWriter2, err := testclients.NewTestAvsRegistryWriterFromConfig(
-		anvilHttpEndpoint,
-		secondOperatorPrivateKeyHex,
-		config,
-	)
 	require.NoError(t, err)
 
 	keypair, err := bls.NewKeyPairFromString("0x01")
@@ -89,71 +73,6 @@ func TestWriterMethods(t *testing.T) {
 			ecdsaPrivateKey,
 			keypair,
 			quorumNumbers,
-			"",
-			true,
-		)
-		require.NoError(t, err)
-		require.NotNil(t, receipt)
-	})
-
-	t.Run("register operator with churn", func(t *testing.T) {
-		clients, anvilHttpEndpoint := testclients.BuildTestClients(t)
-
-		contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
-
-		chainWriter := clients.AvsRegistryChainWriter
-
-		firstOperatorAddress := addr
-		firstOperatorPrivateKey := ecdsaPrivateKey
-		require.NoError(t, err)
-
-		ethHttpClient := clients.EthHttpClient
-
-		registryCoordinatorContract, err := regcoord.NewContractRegistryCoordinator(
-			contractAddrs.RegistryCoordinator,
-			ethHttpClient,
-		)
-		require.NoError(t, err)
-
-		// At first, churnApprover is anvil first address
-		approver, err := registryCoordinatorContract.ChurnApprover(&bind.CallOpts{})
-		require.NoError(t, err)
-		assert.Equal(t, approver.String(), testutils.ANVIL_FIRST_ADDRESS)
-
-		// Set a new churnApprover
-		receipt, err := chainWriter.SetChurnApprover(context.Background(), churnApproverAddress, true)
-		require.NoError(t, err)
-		require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
-
-		// After change, churnApprover is the setted value
-		newApprover, err := registryCoordinatorContract.ChurnApprover(&bind.CallOpts{})
-		require.NoError(t, err)
-		assert.Equal(t, newApprover.String(), testutils.ANVIL_SECOND_ADDRESS)
-
-		//register once
-		receipt, err = chainWriter.RegisterOperator(
-			context.Background(),
-			firstOperatorPrivateKey,
-			keypair,
-			quorumNumbers,
-			"",
-			true,
-		)
-		require.NoError(t, err)
-		require.NotNil(t, receipt)
-
-		operatorsToKick := []gethcommon.Address{firstOperatorAddress}
-		newKeyPair, err := bls.NewKeyPairFromString("0x02")
-		require.NoError(t, err)
-
-		receipt, err = chainWriter2.RegisterOperatorWithChurn(
-			context.Background(),
-			secondOperatorPrivateKey,
-			churnApprovalPrivateKey,
-			newKeyPair,
-			quorumNumbers,
-			quorumNumbers,
-			operatorsToKick,
 			"",
 			true,
 		)

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -53,7 +53,11 @@ func TestWriterMethods(t *testing.T) {
 	chainWriter, err := testclients.NewTestAvsRegistryWriterFromConfig(anvilHttpEndpoint, operatorPrivateKeyHex, config)
 	require.NoError(t, err)
 
-	chainWriter2, err := testclients.NewTestAvsRegistryWriterFromConfig(anvilHttpEndpoint, secondOperatorPrivateKeyHex, config)
+	chainWriter2, err := testclients.NewTestAvsRegistryWriterFromConfig(
+		anvilHttpEndpoint,
+		secondOperatorPrivateKeyHex,
+		config,
+	)
 	require.NoError(t, err)
 
 	keypair, err := bls.NewKeyPairFromString("0x01")
@@ -139,12 +143,14 @@ func TestWriterMethods(t *testing.T) {
 		require.NotNil(t, receipt)
 
 		operatorsToKick := []gethcommon.Address{firstOperatorAddress}
+		newKeyPair, err := bls.NewKeyPairFromString("0x02")
+		require.NoError(t, err)
 
 		receipt, err = chainWriter2.RegisterOperatorWithChurn(
 			context.Background(),
 			secondOperatorPrivateKey,
 			churnApprovalPrivateKey,
-			keypair,
+			newKeyPair,
 			quorumNumbers,
 			quorumNumbers,
 			operatorsToKick,
@@ -408,6 +414,117 @@ func TestWriterMethods(t *testing.T) {
 
 		assert.Equal(t, newMinimumStakeForQuorum, big.NewInt(100))
 	})
+}
+
+func TestRegisterOperatorWithChurn(t *testing.T) {
+	clients, anvilHttpEndpoint := testclients.BuildTestClients(t)
+
+	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
+
+	chainWriter := clients.AvsRegistryChainWriter
+	chainReader := clients.AvsRegistryChainReader
+
+	firstOperatorAddress := gethcommon.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
+	firstOperatorECDSAPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
+	require.NoError(t, err)
+	firstOperatorKeyPair, err := bls.NewKeyPairFromString("0x01")
+	require.NoError(t, err)
+
+	quorumNumbers := types.QuorumNums{0}
+
+	ethHttpClient := clients.EthHttpClient
+
+	registryCoordinatorContract, err := regcoord.NewContractRegistryCoordinator(
+		contractAddrs.RegistryCoordinator,
+		ethHttpClient,
+	)
+	require.NoError(t, err)
+
+	// At first, churnApprover is anvil first address
+	approver, err := registryCoordinatorContract.ChurnApprover(&bind.CallOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, approver.String(), testutils.ANVIL_FIRST_ADDRESS)
+
+	// Set a new churnApprover
+	churnApproverAddress := gethcommon.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
+	receipt, err := chainWriter.SetChurnApprover(context.Background(), churnApproverAddress, true)
+	require.NoError(t, err)
+	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
+
+	// After change, churnApprover is the setted value
+	newApprover, err := registryCoordinatorContract.ChurnApprover(&bind.CallOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, newApprover.String(), testutils.ANVIL_SECOND_ADDRESS)
+
+	//register once
+	receipt, err = chainWriter.RegisterOperator(
+		context.Background(),
+		firstOperatorECDSAPrivateKey,
+		firstOperatorKeyPair,
+		quorumNumbers,
+		"",
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	receipt, err = chainWriter.SetOperatorSetParams(
+		context.Background(),
+		0,
+		regcoord.ISlashingRegistryCoordinatorTypesOperatorSetParam{
+			MaxOperatorCount:        1,
+			KickBIPsOfOperatorStake: 10,
+			KickBIPsOfTotalStake:    10000,
+		},
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	churnECDSAPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
+	require.NoError(t, err)
+	operatorsToKick := []gethcommon.Address{firstOperatorAddress}
+
+	thirdOperatorAddress := gethcommon.HexToAddress(testutils.ANVIL_THIRD_ADDRESS)
+	thirdOperatorECDSAPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_THIRD_PRIVATE_KEY)
+	require.NoError(t, err)
+	thirdOperatorPrivateKey := testutils.ANVIL_THIRD_PRIVATE_KEY
+	newKeyPair, err := bls.NewKeyPairFromString("0x03")
+	require.NoError(t, err)
+
+	config := avsregistry.Config{
+		RegistryCoordinatorAddress:    contractAddrs.RegistryCoordinator,
+		OperatorStateRetrieverAddress: contractAddrs.OperatorStateRetriever,
+		ServiceManagerAddress:         contractAddrs.ServiceManager,
+	}
+	chainWriter3, err := testclients.NewTestAvsRegistryWriterFromConfig(
+		anvilHttpEndpoint,
+		thirdOperatorPrivateKey,
+		config,
+	)
+	require.NoError(t, err)
+
+	receipt, err = chainWriter3.RegisterOperatorWithChurn(
+		context.Background(),
+		thirdOperatorECDSAPrivateKey,
+		churnECDSAPrivateKey,
+		newKeyPair,
+		quorumNumbers,
+		quorumNumbers,
+		operatorsToKick,
+		"",
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	deregisteredOperatorWithChurn, err := chainReader.IsOperatorRegistered(&bind.CallOpts{}, firstOperatorAddress)
+	require.NoError(t, err)
+	require.False(t, deregisteredOperatorWithChurn)
+
+	registeredOperatorWithChurn, err := chainReader.IsOperatorRegistered(&bind.CallOpts{}, thirdOperatorAddress)
+	require.NoError(t, err)
+	require.True(t, registeredOperatorWithChurn)
 }
 
 // Compliance test for BLS signature

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -35,6 +35,15 @@ func TestWriterMethods(t *testing.T) {
 
 	operatorPrivateKeyHex := testutils.ANVIL_FIRST_PRIVATE_KEY
 
+	// secondOperatorAddress := gethcommon.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
+	secondOperatorPrivateKeyHex := testutils.ANVIL_SECOND_PRIVATE_KEY
+	secondOperatorPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
+	require.NoError(t, err)
+
+	churnApprovalPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
+	require.NoError(t, err)
+	churnApproverAddress := gethcommon.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
+
 	config := avsregistry.Config{
 		RegistryCoordinatorAddress:    contractAddrs.RegistryCoordinator,
 		OperatorStateRetrieverAddress: contractAddrs.OperatorStateRetriever,
@@ -42,6 +51,9 @@ func TestWriterMethods(t *testing.T) {
 	}
 
 	chainWriter, err := testclients.NewTestAvsRegistryWriterFromConfig(anvilHttpEndpoint, operatorPrivateKeyHex, config)
+	require.NoError(t, err)
+
+	chainWriter2, err := testclients.NewTestAvsRegistryWriterFromConfig(anvilHttpEndpoint, secondOperatorPrivateKeyHex, config)
 	require.NoError(t, err)
 
 	keypair, err := bls.NewKeyPairFromString("0x01")
@@ -81,11 +93,41 @@ func TestWriterMethods(t *testing.T) {
 	})
 
 	t.Run("register operator with churn", func(t *testing.T) {
-		firstOperatorAddress := gethcommon.HexToAddress(testutils.ANVIL_FIRST_ADDRESS)
-		firstOperatorPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
+		clients, anvilHttpEndpoint := testclients.BuildTestClients(t)
+
+		contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
+
+		chainWriter := clients.AvsRegistryChainWriter
+
+		firstOperatorAddress := addr
+		firstOperatorPrivateKey := ecdsaPrivateKey
+		require.NoError(t, err)
+
+		ethHttpClient := clients.EthHttpClient
+
+		registryCoordinatorContract, err := regcoord.NewContractRegistryCoordinator(
+			contractAddrs.RegistryCoordinator,
+			ethHttpClient,
+		)
+		require.NoError(t, err)
+
+		// At first, churnApprover is anvil first address
+		approver, err := registryCoordinatorContract.ChurnApprover(&bind.CallOpts{})
+		require.NoError(t, err)
+		assert.Equal(t, approver.String(), testutils.ANVIL_FIRST_ADDRESS)
+
+		// Set a new churnApprover
+		receipt, err := chainWriter.SetChurnApprover(context.Background(), churnApproverAddress, true)
+		require.NoError(t, err)
+		require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
+
+		// After change, churnApprover is the setted value
+		newApprover, err := registryCoordinatorContract.ChurnApprover(&bind.CallOpts{})
+		require.NoError(t, err)
+		assert.Equal(t, newApprover.String(), testutils.ANVIL_SECOND_ADDRESS)
 
 		//register once
-		receipt, err := chainWriter.RegisterOperator(
+		receipt, err = chainWriter.RegisterOperator(
 			context.Background(),
 			firstOperatorPrivateKey,
 			keypair,
@@ -96,14 +138,12 @@ func TestWriterMethods(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, receipt)
 
-		secondOperatorPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
 		operatorsToKick := []gethcommon.Address{firstOperatorAddress}
 
-		churnApprovalPrivateKey := testutils.ANVIL_THIRD_PRIVATE_KEY
-
-		receipt, err = chainWriter.RegisterOperatorWithChurn(
+		receipt, err = chainWriter2.RegisterOperatorWithChurn(
 			context.Background(),
 			secondOperatorPrivateKey,
+			churnApprovalPrivateKey,
 			keypair,
 			quorumNumbers,
 			quorumNumbers,

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -359,23 +359,26 @@ func TestRegisterOperatorWithChurn(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// At first, churnApprover is anvil first address
+	// At first, churnApprover is ANVIL_FIRST_ADDRESS
 	approver, err := registryCoordinatorContract.ChurnApprover(&bind.CallOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, approver.String(), testutils.ANVIL_FIRST_ADDRESS)
 
-	// Set a new churnApprover
+	// Set ANVIL_SECOND_ADDRESS as the new churnApprover
 	churnApproverAddress := gethcommon.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
+	churnECDSAPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
+	require.NoError(t, err)
+
 	receipt, err := chainWriter.SetChurnApprover(context.Background(), churnApproverAddress, true)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 
-	// After change, churnApprover is the setted value
+	// After change, churnApprover is ANVIL_SECOND_ADDRESS
 	newApprover, err := registryCoordinatorContract.ChurnApprover(&bind.CallOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, newApprover.String(), testutils.ANVIL_SECOND_ADDRESS)
 
-	//register once
+	//Register ANVIL_FIRST_ADDRESS as operator
 	receipt, err = chainWriter.RegisterOperator(
 		context.Background(),
 		firstOperatorECDSAPrivateKey,
@@ -387,6 +390,7 @@ func TestRegisterOperatorWithChurn(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 
+	// Change the OperatorSetParams to allow only 1 operator
 	receipt, err = chainWriter.SetOperatorSetParams(
 		context.Background(),
 		0,
@@ -400,8 +404,7 @@ func TestRegisterOperatorWithChurn(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 
-	churnECDSAPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_SECOND_PRIVATE_KEY)
-	require.NoError(t, err)
+	// We want to kick the first operator
 	operatorsToKick := []gethcommon.Address{firstOperatorAddress}
 
 	thirdOperatorAddress := gethcommon.HexToAddress(testutils.ANVIL_THIRD_ADDRESS)
@@ -423,6 +426,8 @@ func TestRegisterOperatorWithChurn(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// Register ANVIL_THIRD_ADDRESS as operator. Since there is only one slot available, ANVIL_FIRST_ADDRESS should be
+	// kicked
 	receipt, err = chainWriter3.RegisterOperatorWithChurn(
 		context.Background(),
 		thirdOperatorECDSAPrivateKey,
@@ -437,10 +442,12 @@ func TestRegisterOperatorWithChurn(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 
+	// ANVIL_FIRST_ADDRESS should be deregistered
 	deregisteredOperatorWithChurn, err := chainReader.IsOperatorRegistered(&bind.CallOpts{}, firstOperatorAddress)
 	require.NoError(t, err)
 	require.False(t, deregisteredOperatorWithChurn)
 
+	// ANVIL_THIRD_ADDRESS should be registered
 	registeredOperatorWithChurn, err := chainReader.IsOperatorRegistered(&bind.CallOpts{}, thirdOperatorAddress)
 	require.NoError(t, err)
 	require.True(t, registeredOperatorWithChurn)


### PR DESCRIPTION
### What Changed?
This PR implements `registerOperatorWithChurn` in `avsregistry/writer`

Close #535 

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it