### PR TITLE
feate: implement method `RemoveStrategies`

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -679,6 +679,32 @@ func (w *ChainWriter) UpdateAVSMetadataURI(
 	return receipt, nil
 }
 
+// Removes strategies and their associated weights from the specified quorum.
+func (w *ChainWriter) RemoveStrategies(
+	ctx context.Context,
+	quorumNumber types.QuorumNum,
+	indicesToRemove []*big.Int,
+	waitForReceipt bool,
+) (*gethtypes.Receipt, error) {
+	w.logger.Info("removing strategies from quorum ", quorumNumber)
+
+	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := w.stakeRegistry.RemoveStrategies(noSendTxOpts, quorumNumber.UnderlyingType(), indicesToRemove)
+	if err != nil {
+		return nil, err
+	}
+
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	if err != nil {
+		return nil, utils.WrapError("failed to remove strategies form quorum", err.Error())
+	}
+	return receipt, nil
+}
+
 // Creates a new rewards submission to the EigenLayer RewardsCoordinator contract,
 // to be split amongst the set of stakers delegated to operators who are registered
 // to this `avs`. Returns the receipt of the transaction in case of success.

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -864,7 +864,7 @@ func (w *ChainWriter) RemoveStrategies(
 
 	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
 	if err != nil {
-		return nil, utils.WrapError("failed to remove strategies form quorum", err.Error())
+		return nil, utils.WrapError("failed to remove strategies from quorum", err)
 	}
 	return receipt, nil
 }

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -643,6 +643,34 @@ func TestSetAccountIdentifier(t *testing.T) {
 	assert.Equal(t, newAccountIdentifier.String(), testutils.ANVIL_SECOND_ADDRESS)
 }
 
+func TestRemoveStrategies(t *testing.T) {
+	clients, _ := testclients.BuildTestClients(t)
+	chainWriter := clients.AvsRegistryChainWriter
+
+	quorumNumber := types.QuorumNum(0)
+	indices := []*big.Int{big.NewInt(0)}
+
+	_, err := clients.AvsRegistryChainReader.GetStrategyParamsAtIndex(
+		&bind.CallOpts{Context: context.Background()},
+		quorumNumber.UnderlyingType(),
+		indices[0],
+	)
+	require.NoError(t, err)
+
+	// There is a strategy at index 0. We will remove it
+	receipt, err := chainWriter.RemoveStrategies(context.Background(), quorumNumber, indices, true)
+	require.NoError(t, err)
+	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
+
+	// After removing, there are no strategies in quorum
+	_, err = clients.AvsRegistryChainReader.GetStrategyParamsAtIndex(
+		&bind.CallOpts{Context: context.Background()},
+		quorumNumber.UnderlyingType(),
+		indices[0],
+	)
+	require.Error(t, err)
+}
+
 func TestSetEjectionCooldown(t *testing.T) {
 	// Test set up
 	clients, anvilHttpEndpoint := testclients.BuildTestClients(t)

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -764,6 +764,7 @@ func TestSetAccountIdentifier(t *testing.T) {
 func TestRemoveStrategies(t *testing.T) {
 	clients, _ := testclients.BuildTestClients(t)
 	chainWriter := clients.AvsRegistryChainWriter
+	chainReader := clients.AvsRegistryChainReader
 
 	quorumNumber := types.QuorumNum(0)
 	indices := []*big.Int{big.NewInt(0)}
@@ -781,12 +782,9 @@ func TestRemoveStrategies(t *testing.T) {
 	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 
 	// After removing, there are no strategies in quorum
-	_, err = clients.AvsRegistryChainReader.GetStrategyParamsAtIndex(
-		&bind.CallOpts{Context: context.Background()},
-		quorumNumber.UnderlyingType(),
-		indices[0],
-	)
-	require.Error(t, err)
+	length, err := chainReader.StrategyParamsLength(&bind.CallOpts{}, quorumNumber.UnderlyingType())
+	require.NoError(t, err)
+	require.Zero(t, length.Cmp(big.NewInt(0)))
 }
 
 func TestSetEjectionCooldown(t *testing.T) {


### PR DESCRIPTION
### What Changed?
This PR implements `RemoveStrategies` in `avsregistry/writer`

Related to https://github.com/Layr-Labs/eigensdk-go/issues/521

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it