### PR TITLE
feat: implement method `ModifyStrategyParams`

### DIFF
--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -598,6 +598,35 @@ func (w *ChainWriter) SetEjector(
 	return receipt, nil
 }
 
+func (w *ChainWriter) ModifyStrategyParams(
+	ctx context.Context,
+	quorumNumber types.QuorumNum,
+	strategyIndices []*big.Int,
+	multipliers []*big.Int,
+	waitForReceipt bool,
+) (*gethtypes.Receipt, error) {
+	w.logger.Info("modifying strategy params for quorum ", quorumNumber)
+
+	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
+	if err != nil {
+		return nil, err
+	}
+	tx, err := w.stakeRegistry.ModifyStrategyParams(
+		noSendTxOpts,
+		quorumNumber.UnderlyingType(),
+		strategyIndices,
+		multipliers,
+	)
+	if err != nil {
+		return nil, err
+	}
+	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
+	if err != nil {
+		return nil, utils.WrapError("failed to send ModifyStrategyParams tx with err", err)
+	}
+	return receipt, nil
+}
+
 // Sets the accountIdentifier as the address received as parameter. Identifier should only be set once, since
 // changing it could break existing operator sets. Returns the receipt of the transaction in case of success.
 func (w *ChainWriter) SetAccountIdentifier(

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -762,6 +762,7 @@ func (w *ChainWriter) SetEjector(
 	return receipt, nil
 }
 
+// Modifies the multiplier of existing strategies for the given quorum number.
 func (w *ChainWriter) ModifyStrategyParams(
 	ctx context.Context,
 	quorumNumber types.QuorumNum,

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -719,6 +719,23 @@ func TestCreateAVSRewardsSubmission(t *testing.T) {
 	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
 }
 
+func TestModifyStrategyParams(t *testing.T) {
+	clients, _ := testclients.BuildTestClients(t)
+	chainWriter := clients.AvsRegistryChainWriter
+	chainReader := clients.AvsRegistryChainReader
+
+	indices := []*big.Int{big.NewInt(0)}
+	multiplier := []*big.Int{big.NewInt(5e18)}
+
+	receipt, err := chainWriter.ModifyStrategyParams(context.Background(), 0, indices, multiplier, true)
+	require.NoError(t, err)
+	require.Equal(t, gethtypes.ReceiptStatusSuccessful, receipt.Status)
+
+	strategies, err := chainReader.StrategyParamsByIndex(nil, 0, indices[0])
+	require.NoError(t, err)
+	require.Equal(t, strategies.Multiplier, multiplier[0])
+}
+
 func TestCreateOperatorDirectedAVSRewardsSubmission(t *testing.T) {
 	clients, _ := testclients.BuildTestClients(t)
 	chainWriter := clients.AvsRegistryChainWriter


### PR DESCRIPTION
### What Changed?
This PR implements `ModifyStrategyParams` in `avsregistry/writer`

Related to https://github.com/Layr-Labs/eigensdk-go/issues/521

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it