### PR TITLE
fix: change PR url in Changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 env:
-  PR_URL: https://github.com/Layr-Labs/eigensdk-rs/pull/${{ github.event.number }}
+  PR_URL: https://github.com/Layr-Labs/eigensdk-go/pull/${{ github.event.number }}
 
 jobs:
   # Enforces the update of a changelog file on every pull request 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 ## [Unreleased]
 ### Added
 ### Changed
+* fix: change requested pr url in changelog's workflow by @maximopalopoli in <https://github.com/Layr-Labs/eigensdk-go/pull/575>
+
 ### Breaking changes
 ### Removed


### PR DESCRIPTION
### What Changed?
Change requested PR url in Changelog workflow of CI, perviously was eigensdk-rs and now is eigensdk-go.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it