### PR TITLE
feat: new BLS aggregation service interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 
 ### Added 🎉
 
+* feat: new BLS aggregation service interface by @maximopalopoli in <https://github.com/Layr-Labs/eigensdk-go/pull/578>
+  * The new interface implies starting the service before using it, interact with it using a handler and receiving the aggregated responses in a separate channel.
+  * An example using the interface is:
+
+    ```Go
+    // initialize service
+    blsAgg := NewBlsAggregatorBuilder(fakeAvsRegistryService, hashFunction, logger)
+    handler, aggResponsesC := blsAgg.Start()
+
+    // Initialize task
+    metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+    err := handler.InitializeNewTask(metadata)
+
+    // Process signature
+    taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
+    err = handler.ProcessNewSignature(
+      context.Background(),
+      taskSignature,
+    )
+
+    // Receive responses
+    aggregationServiceResponse := <-aggResponsesC
+    ```
+
 * Added field `DontUseAllocationManager` to `BuildAllConfig` in [#580](https://github.com/Layr-Labs/eigensdk-go/pull/580)
 
 ### Changed
@@ -92,50 +116,6 @@ Each version will have a separate `Breaking Changes` section as well. To describ
         tasksTimeToExpiry,
     ).WithWindowDuration(windowDuration)
     blsAggServ.InitializeNewTask(metadata)
-    ```
-    
-* refactor: bls aggregation service by @maximopalopoli in <https://github.com/Layr-Labs/eigensdk-go/pull/578>
-  * The new interface implies starting the service before using it, interact with it using a handler and receiving the aggregated responses in a separate channel.
-  
-  * Before, the worflow was the following:
-    ```Go
-    // initialize service
-    blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-
-    // Initialize task
-    metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-    err := blsAggServ.InitializeNewTask(metadata)
-
-    // Process signature
-    taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-    err = blsAggServ.ProcessNewSignature(
-      context.Background(),
-      taskSignature,
-    )
-
-    // Receive responses
-    aggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
-    ```
-
-    Now, the workflow is this one:
-    ```Go
-    // initialize service
-    blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-    handler, aggResponsesC := blsAggServ.Start()
-
-    // Initialize task
-    metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-    err := handler.InitializeNewTask(metadata)
-
-    // Process signature
-    taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-    err = handler.ProcessNewSignature(
-      context.Background(),
-      taskSignature,
-    )
-
-    // Receive responses
-    aggregationServiceResponse := <-aggResponsesC
     ```
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
     ```Go
     // initialize service
     blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-    handler, receiver := blsAggServ.Start()
+    handler, aggResponsesC := blsAggServ.Start()
 
     // Initialize task
     metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
@@ -129,7 +129,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
     )
 
     // Receive responses
-    aggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+    aggregationServiceResponse := <-aggResponsesC
     ```
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,5 +132,4 @@ Each version will have a separate `Breaking Changes` section as well. To describ
     aggregationServiceResponse := <-aggResponsesC
     ```
 
-
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,4 +88,49 @@ Each version will have a separate `Breaking Changes` section as well. To describ
     blsAggServ.InitializeNewTask(metadata)
     ```
     
+* refactor: bls aggregation service by @maximopalopoli in <https://github.com/Layr-Labs/eigensdk-go/pull/578>
+  * The new interface implies starting the service before using it, interact with it using a handler and receiving the aggregated responses in a separate channel.
+  
+  * Before, the worflow was the following:
+    ```Go
+    // initialize service
+    blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+
+    // Initialize task
+    metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+    err = blsAggServ.InitializeNewTask(metadata)
+
+    // Process signature
+    taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
+    err = blsAggServ.ProcessNewSignature(
+      context.Background(),
+      taskSignature,
+    )
+
+    // Receive responses
+    aggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+    ```
+
+    Now, the workflow is this one:
+    ```Go
+    // initialize service
+    blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+    handler, receiver, err := blsAggServ.Start()
+
+    // Initialize task
+    metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+    err = handler.InitializeNewTask(metadata)
+
+    // Process signature
+    taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
+    err = handler.ProcessNewSignature(
+      context.Background(),
+      taskSignature,
+    )
+
+    // Receive responses
+    aggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+    ```
+
+
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 
     // Initialize task
     metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-    err = blsAggServ.InitializeNewTask(metadata)
+    err := blsAggServ.InitializeNewTask(metadata)
 
     // Process signature
     taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
@@ -115,11 +115,11 @@ Each version will have a separate `Breaking Changes` section as well. To describ
     ```Go
     // initialize service
     blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-    handler, receiver, err := blsAggServ.Start()
+    handler, receiver := blsAggServ.Start()
 
     // Initialize task
     metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-    err = handler.InitializeNewTask(metadata)
+    err := handler.InitializeNewTask(metadata)
 
     // Process signature
     taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -202,7 +202,7 @@ func NewBlsAggregatorService(
 type ServiceHandler struct {
 	//This channels are used to send messages (requests) to the service.
 	TaskInitC         chan InitializeTaskRequest
-	processSignatureC chan ProcessSignatureRequest // The type of the channel is being discussed
+	processSignatureC chan ProcessSignatureRequest
 }
 
 type InitializeTaskRequest struct {
@@ -282,6 +282,8 @@ func (a *BlsAggregatorService) run(
 				signedTaskRespsC <- signedDigest
 				result := <-errC
 				signatureReq.errC <- result
+			} else {
+				signatureReq.errC <- TaskNotFoundErrorFn(taskIndex)
 			}
 		}
 	}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -203,16 +203,16 @@ func NewBlsAggregatorService(
 // The service handler is a structure used to use the service without the complexity of it.
 type ServiceHandler struct {
 	//This channels are used to send messages (requests) to the service.
-	taskInitC         chan InitializeTaskRequest
-	processSignatureC chan ProcessSignatureRequest
+	taskInitC         chan initializeTaskRequest
+	processSignatureC chan processSignatureRequest
 }
 
-type InitializeTaskRequest struct {
+type initializeTaskRequest struct {
 	metadata TaskMetadata
 	errC     chan error
 }
 
-type ProcessSignatureRequest struct {
+type processSignatureRequest struct {
 	metadata TaskSignature
 	errC     chan error
 }
@@ -222,8 +222,8 @@ type ProcessSignatureRequest struct {
 // aggregate receiver channel to interact with the service thread.
 func (a *BlsAggregatorService) Start() (ServiceHandler, <-chan BlsAggregationServiceResponse) {
 	// Create channels to handle requests
-	initializeTaskC := make(chan InitializeTaskRequest)
-	processSignatureC := make(chan ProcessSignatureRequest)
+	initializeTaskC := make(chan initializeTaskRequest)
+	processSignatureC := make(chan processSignatureRequest)
 
 	aggResponsesC := make(chan BlsAggregationServiceResponse)
 
@@ -243,8 +243,8 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, <-chan BlsAggregationSer
 // single task aggregator goroutine, where the initialization of the task is done an notified.
 // The loop ends if one of the request channels is closed.
 func (a *BlsAggregatorService) run(
-	initializeTaskChannel chan InitializeTaskRequest,
-	processSignatureChannel chan ProcessSignatureRequest,
+	initializeTaskChannel chan initializeTaskRequest,
+	processSignatureChannel chan processSignatureRequest,
 	aggResponsesC chan BlsAggregationServiceResponse,
 ) {
 	taskChannels := make(map[types.TaskIndex]chan types.SignedTaskResponseDigest)
@@ -318,7 +318,7 @@ func (a *ServiceHandler) InitializeNewTask(
 	metadata TaskMetadata,
 ) error {
 	errChan := make(chan error)
-	a.taskInitC <- InitializeTaskRequest{metadata, errChan}
+	a.taskInitC <- initializeTaskRequest{metadata, errChan}
 	select {
 	case err := <-errChan:
 		return err
@@ -341,7 +341,7 @@ func (a *ServiceHandler) ProcessNewSignature(
 	metadata TaskSignature,
 ) error {
 	errChan := make(chan error)
-	a.processSignatureC <- ProcessSignatureRequest{metadata, errChan}
+	a.processSignatureC <- processSignatureRequest{metadata, errChan}
 
 	// Doing this we let the goroutine consume the result of the operation, but allow
 	// the operation to end early if the context is cancelled

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -286,6 +286,57 @@ func (a *BlsAggregatorService) Start(
 	return ServiceHandler{initializeTaskC, processSignatureC}, AggregateReceiver{aggregate_receiver: aggResponsesC}, nil
 }
 
+func (a *BlsAggregatorService) run(
+	initializeTaskChannel chan InitializeTaskRequest,
+	processSignatureChannel chan ProcessSignatureRequest,
+	aggResponsesC chan types.SignedTaskResponseDigest,
+) {
+	taskChannels := make(map[types.TaskIndex]chan types.SignedTaskResponseDigest)
+
+	for {
+		select {
+		case taskInitReq, ok := <-initializeTaskChannel:
+			// Initialize task
+			if !ok {
+				return
+			}
+			taskIndex := taskInitReq.metadata.taskIndex
+
+			if _, taskExists := taskChannels[taskIndex]; taskExists {
+				continue
+			}
+			signedTaskRespsC := make(chan types.SignedTaskResponseDigest)
+			taskChannels[taskIndex] = signedTaskRespsC
+
+			go a.singleTaskAggregatorGoroutineFunc(
+				taskInitReq.metadata,
+				aggResponsesC,
+			)
+
+		case signatureReq, ok := <-processSignatureChannel:
+			// Process signature
+			if !ok {
+				return
+			}
+			taskIndex := signatureReq.metadata.taskIndex
+
+			if signedTaskRespsC, taskExists := taskChannels[taskIndex]; taskExists {
+				errC := make(chan error, 1)
+				signedDigest := types.SignedTaskResponseDigest{
+					TaskResponse:                signatureReq.metadata.taskResponse,
+					BlsSignature:                signatureReq.metadata.blsSignature,
+					OperatorId:                  signatureReq.metadata.operatorId,
+					SignatureVerificationErrorC: errC,
+				}
+
+				signedTaskRespsC <- signedDigest
+				result := <-errC
+				signatureReq.errC <- result
+			}
+		}
+	}
+}
+
 func (a *BlsAggregatorService) GetResponseChannel() <-chan BlsAggregationServiceResponse {
 	return a.aggregatedResponsesC
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -145,7 +145,7 @@ func (t TaskMetadata) WithWindowDuration(windowDuration time.Duration) TaskMetad
 // BlsAggregationService is the interface provided to avs aggregator code for doing bls aggregation
 // Currently its only implementation is the BlsAggregatorService, so see the comment there for more details
 type BlsAggregationService interface {
-	// Starts the aggregation service, and returns the handler, to interact with, it and the response channel,
+	// Starts the aggregation service, returning a handler to interact with it and a response channel
 	// to receive the aggregated responses.
 	Start() (ServiceHandler, <-chan BlsAggregationServiceResponse)
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -145,9 +145,37 @@ func (t TaskMetadata) WithWindowDuration(windowDuration time.Duration) TaskMetad
 // BlsAggregationService is the interface provided to avs aggregator code for doing bls aggregation
 // Currently its only implementation is the BlsAggregatorService, so see the comment there for more details
 type BlsAggregationService interface {
-	// Starts the aggregation service, returning a handler to interact with it and a response channel
-	// to receive the aggregated responses.
-	Start() (ServiceHandler, <-chan BlsAggregationServiceResponse)
+	// InitializeNewTask creates a new task goroutine meant to process new signed task responses for that task
+	// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to
+	// it. The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered
+	// complete, which
+	// happens when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers
+	// whose stake in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in
+	// that quorum.
+	// Once the quorum is reached, the task is still open for a window of `windowDuration` time (default 0) to receive
+	// more signatures, before sending the aggregation response through the aggregatedResponsesC channel.
+	// If the task expiration is reached before the window finishes, the task response will still be sent to the
+	// aggregatedResponsesC channel.
+	InitializeNewTask(
+		metadata TaskMetadata,
+	) error
+
+	// ProcessNewSignature processes a new signature over a taskResponseDigest for a particular taskIndex by a
+	// particular operator It verifies that the signature is correct and returns an error if it is not, and then
+	// aggregates the signature and stake of
+	// the operator with all other signatures for the same taskIndex and taskResponseDigest pair.
+	// Note: This function currently only verifies signatures over the taskResponseDigest directly, so avs code needs to
+	// verify that the digest passed to ProcessNewSignature is indeed the digest of a valid taskResponse (that is,
+	// BlsAggregationService does not verify semantic integrity of the taskResponses)
+	ProcessNewSignature(
+		ctx context.Context,
+		task TaskSignature,
+	) error
+
+	// GetResponseChannel returns the single channel that meant to be used as the response channel
+	// Any task that is completed (see the completion criterion in the comment above InitializeNewTask)
+	// will be sent on this channel along with all the necessary information to call BLSSignatureChecker onchain
+	GetResponseChannel() <-chan BlsAggregationServiceResponse
 }
 
 // BlsAggregatorService is a service that performs BLS signature aggregation for an AVS' tasks

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -245,7 +245,7 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, <-chan BlsAggregationSer
 func (a *BlsAggregatorService) run(
 	initializeTaskChannel <-chan initializeTaskRequest,
 	processSignatureChannel <-chan processSignatureRequest,
-	aggResponsesC chan BlsAggregationServiceResponse,
+	aggResponsesC chan<- BlsAggregationServiceResponse,
 ) {
 	taskChannels := make(map[types.TaskIndex]chan types.SignedTaskResponseDigest)
 
@@ -352,7 +352,7 @@ func (a *ServiceHandler) ProcessNewSignature(
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	metadata TaskMetadata,
 	signedTaskRespsC <-chan types.SignedTaskResponseDigest,
-	aggregatedResponsesC chan BlsAggregationServiceResponse,
+	aggregatedResponsesC chan<- BlsAggregationServiceResponse,
 ) {
 	a.logger.Debug("AggregatorService goroutine processing new task",
 		"taskIndex", metadata.taskIndex,
@@ -573,7 +573,7 @@ func (a *BlsAggregatorService) sendAggregatedResponse(
 	quorumNumbers types.QuorumNums,
 	taskResponseDigest types.TaskResponseDigest,
 	quorumApksG1 []*bls.G1Point,
-	aggregatedResponsesC chan BlsAggregationServiceResponse,
+	aggregatedResponsesC chan<- BlsAggregationServiceResponse,
 ) {
 	nonSignersOperatorIds := []types.OperatorId{}
 	for operatorId := range operatorsAvsStateDict {

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
@@ -22,7 +21,7 @@ var (
 	// error string directly.
 	//       see https://go.dev/blog/go1.13-errors
 	TaskInitializationErrorFn = func(err error, taskIndex types.TaskIndex) error {
-		return fmt.Errorf("Failed to initialize task %d: %w", taskIndex, err)
+		return fmt.Errorf("failed to initialize task %d: %w", taskIndex, err)
 	}
 	TaskAlreadyInitializedErrorFn = func(taskIndex types.TaskIndex) error {
 		return fmt.Errorf("task %d already initialized", taskIndex)
@@ -37,12 +36,12 @@ var (
 		return fmt.Errorf("operator %x not part of task %d's quorum", operatorId, taskIndex)
 	}
 	HashFunctionError = func(err error) error {
-		return fmt.Errorf("Failed to hash task response: %w", err)
+		return fmt.Errorf("failed to hash task response: %w", err)
 	}
 	SignatureVerificationError = func(err error) error {
-		return fmt.Errorf("Failed to verify signature: %w", err)
+		return fmt.Errorf("failed to verify signature: %w", err)
 	}
-	IncorrectSignatureError = errors.New("Signature verification failed. Incorrect Signature.")
+	ErrIncorrectSignature = errors.New("signature verification failed. incorrect signature")
 )
 
 // BlsAggregationServiceResponse is the response from the bls aggregation service
@@ -751,7 +750,7 @@ func (a *BlsAggregatorService) verifySignature(
 		return SignatureVerificationError(err)
 	}
 	if !signatureVerified {
-		return IncorrectSignatureError
+		return ErrIncorrectSignature
 	}
 	return nil
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -279,17 +279,14 @@ func (a *BlsAggregatorService) run(
 
 			signedTaskRespsC, taskExists := taskChannels[taskIndex]
 			if taskExists {
-				errC := make(chan error, 1)
 				signedDigest := types.SignedTaskResponseDigest{
 					TaskResponse:                signatureReq.metadata.taskResponse,
 					BlsSignature:                signatureReq.metadata.blsSignature,
 					OperatorId:                  signatureReq.metadata.operatorId,
-					SignatureVerificationErrorC: errC,
+					SignatureVerificationErrorC: signatureReq.errC,
 				}
 
 				signedTaskRespsC <- signedDigest
-				result := <-errC
-				signatureReq.errC <- result
 			} else {
 				signatureReq.errC <- TaskNotFoundErrorFn(taskIndex)
 			}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -220,6 +220,9 @@ type AggregateReceiver struct {
 	aggregateReceiver chan BlsAggregationServiceResponse
 }
 
+// This function starts the service thread, initializing the aggregateResponses, initializeTask and processSignature
+// channels, passing them to the run method (where the main loop is executed) and returns the service handler an the
+// aggregate receiver to interact with the service thread.
 func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error) {
 	// Create channels to handle requests
 	initializeTaskC := make(chan InitializeTaskRequest)
@@ -235,6 +238,10 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error
 	return ServiceHandler{initializeTaskC, processSignatureC}, AggregateReceiver{aggregateReceiver: aggResponsesC}, nil
 }
 
+// Here is executed the main loop, where the requests are received from the initialize task and process signature
+// channels, executing the corresponding logic in each case. The aggregated responses channel is passed to the
+// single task aggregator goroutine, where the initialization of the task is done an notified.
+// The loop ends if one of the request channels is closed.
 func (a *BlsAggregatorService) run(
 	initializeTaskChannel chan InitializeTaskRequest,
 	processSignatureChannel chan ProcessSignatureRequest,
@@ -348,6 +355,7 @@ func (a *ServiceHandler) ProcessNewSignature(
 	}
 }
 
+// Returns the aggregated response from the channel connected to the service thread
 func (a *AggregateReceiver) ReceiveAggregatedResponse() BlsAggregationServiceResponse {
 	return <-a.aggregateReceiver
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -203,8 +203,8 @@ func NewBlsAggregatorService(
 // The service handler is a structure used to use the service without the complexity of it.
 type ServiceHandler struct {
 	//This channels are used to send messages (requests) to the service.
-	taskInitC         chan initializeTaskRequest
-	processSignatureC chan processSignatureRequest
+	taskInitC         chan<- initializeTaskRequest
+	processSignatureC chan<- processSignatureRequest
 }
 
 type initializeTaskRequest struct {

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -221,6 +221,18 @@ type BlsAggregatorBuilder struct {
 	hashFunction types.TaskResponseHashFunction
 }
 
+func NewBlsAggregatorBuilder(
+	avsRegistryService avsregistry.AvsRegistryService,
+	hashFunction types.TaskResponseHashFunction,
+	logger logging.Logger,
+) *BlsAggregatorBuilder {
+	return &BlsAggregatorBuilder{
+		avsRegistryService: avsRegistryService,
+		logger:             logger,
+		hashFunction:       hashFunction,
+	}
+}
+
 // NewBlsAggregatorService creates a new BlsAggregatorService
 // avsRegistryService is the AVS registry service to use
 // hashFunction is the hash function to use to compute the taskResponseDigest from the taskResponse
@@ -244,11 +256,7 @@ func NewBlsAggregatorService(
 	logger logging.Logger,
 ) *BlsAggregatorService {
 	// Instantiate builder and save handler and receiver.
-	builder := BlsAggregatorBuilder{
-		avsRegistryService: avsRegistryService,
-		logger:             logger,
-		hashFunction:       hashFunction,
-	}
+	builder := NewBlsAggregatorBuilder(avsRegistryService, hashFunction, logger)
 
 	handler, receiver := builder.Start()
 

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -243,6 +243,49 @@ func NewBlsAggregatorService(
 	}
 }
 
+// The service handler is a structure used to use the service without the complexity of it.
+type ServiceHandler struct {
+	//This channels are used to send messages (requests) to the service.
+	TaskInitC         chan InitializeTaskRequest
+	processSignatureC chan ProcessSignatureRequest // The type of the channel is being discussed
+}
+
+type InitializeTaskRequest struct {
+	metadata TaskMetadata
+	errC     chan error
+}
+
+type ProcessSignatureRequest struct {
+	metadata TaskSignature
+	errC     chan error
+}
+
+type AggregateReceiver struct {
+	/// Channel to receive the aggregated responses from the BLS Aggregator Service
+	aggregate_receiver chan types.SignedTaskResponseDigest
+}
+
+func (a *BlsAggregatorService) Start(
+	taskIndex types.TaskIndex,
+	taskCreatedBlock uint32,
+	quorumNumbers types.QuorumNums,
+	quorumThresholdPercentages types.QuorumThresholdPercentages,
+	timeToExpiry time.Duration,
+) (ServiceHandler, AggregateReceiver, error) {
+	// Create channels to handle requests
+	initializeTaskC := make(chan InitializeTaskRequest)
+	processSignatureC := make(chan ProcessSignatureRequest)
+
+	aggResponsesC := make(chan types.SignedTaskResponseDigest)
+
+	go func() {
+		a.run(initializeTaskC, processSignatureC, aggResponsesC)
+		close(aggResponsesC)
+	}()
+
+	return ServiceHandler{initializeTaskC, processSignatureC}, AggregateReceiver{aggregate_receiver: aggResponsesC}, nil
+}
+
 func (a *BlsAggregatorService) GetResponseChannel() <-chan BlsAggregationServiceResponse {
 	return a.aggregatedResponsesC
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -350,7 +350,18 @@ func (a *ServiceHandler) InitializeNewTask(
 	}
 }
 
-// TODO: continue by adding the process signature option
+func (a *ServiceHandler) ProcessNewSignature(
+	metadata TaskSignature,
+) error {
+	errChan := make(chan error)
+	a.processSignatureC <- ProcessSignatureRequest{metadata, errChan}
+	select {
+	case err := <-errChan:
+		return err
+	default:
+		return nil
+	}
+}
 
 func (a *BlsAggregatorService) GetResponseChannel() <-chan BlsAggregationServiceResponse {
 	return a.aggregatedResponsesC

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -290,6 +290,25 @@ func (a *BlsAggregatorService) run(
 	}
 }
 
+// InitializeNewTask sends to the service thread a request to process new signed task responses for that task
+// (that are sent via ProcessNewSignature).
+//
+// The metadata parameter contains:
+//   - taskIndex: Unique identifier for the task
+//   - taskCreatedBlock: Block number at which the task was created
+//   - quorumNumbers: 	Quorum numbers which should respond to the task
+//   - quorumThresholdPercentages: Threshold percentage required per quorum
+//   - timeToExpiry: Time before expiry of the task response aggregation
+//   - windowDuration: Additional time window to collect signatures after reaching quorum (default 0)
+//
+// The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered complete, which
+// happens when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers
+// whose stake in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in
+// that quorum.
+// Once the quorum is reached, the task is still open for a window of `windowDuration` time (default 0) to receive more
+// signatures, before sending the aggregation response through the aggregatedResponsesC channel.
+// If the task expiration is reached before the window finishes, the task response will still be sent to the
+// aggregatedResponsesC channel.
 func (a *ServiceHandler) InitializeNewTask(
 	metadata TaskMetadata,
 ) error {
@@ -309,6 +328,9 @@ func (a *ServiceHandler) ProcessNewSignature(
 ) error {
 	errChan := make(chan error)
 	a.processSignatureC <- ProcessSignatureRequest{metadata, errChan}
+
+	// Doing this we let the goroutine consume the result of the operation, but allow
+	// the operation to end early if the context is cancelled
 	select {
 	case err := <-errChan:
 		return err
@@ -320,104 +342,6 @@ func (a *ServiceHandler) ProcessNewSignature(
 func (a *AggregateReceiver) ReceiveAggregatedResponse() BlsAggregationServiceResponse {
 	return <-a.aggregate_receiver // Maybe can add a select with a timer
 }
-
-/*
-// InitializeNewTask creates a new task goroutine meant to process new signed task responses for that task
-// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to it.
-//
-// The metadata parameter contains:
-//   - taskIndex: Unique identifier for the task
-//   - taskCreatedBlock: Block number at which the task was created
-//   - quorumNumbers: 	Quorum numbers which should respond to the task
-//   - quorumThresholdPercentages: Threshold percentage required per quorum
-//   - timeToExpiry: Time before expiry of the task response aggregation
-//   - windowDuration: Additional time window to collect signatures after reaching quorum (default 0)
-//
-// The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered complete, which
-// happens when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers
-// whose stake in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in
-// that quorum.
-// Once the quorum is reached, the task is still open for a window of `windowDuration` time (default 0) to receive more
-// signatures, before sending the aggregation response through the aggregatedResponsesC channel.
-// If the task expiration is reached before the window finishes, the task response will still be sent to the
-// aggregatedResponsesC channel.
-func (a *BlsAggregatorService) InitializeNewTask(
-	metadata TaskMetadata,
-) error {
-	a.logger.Debug(
-		"AggregatorService initializing new task",
-		"taskIndex",
-		metadata.taskIndex,
-		"taskCreatedBlock",
-		metadata.taskCreatedBlock,
-		"quorumNumbers",
-		metadata.quorumNumbers,
-		"quorumThresholdPercentages",
-		metadata.quorumThresholdPercentages,
-		"timeToExpiry",
-		metadata.timeToExpiry,
-		"windowDuration",
-		metadata.windowDuration,
-	)
-
-	a.taskChansMutex.Lock()
-	defer a.taskChansMutex.Unlock()
-	if _, taskExists := a.signedTaskRespsCs[metadata.taskIndex]; taskExists {
-		return TaskAlreadyInitializedErrorFn(metadata.taskIndex)
-	}
-	signedTaskRespsC := make(chan types.SignedTaskResponseDigest)
-	a.signedTaskRespsCs[metadata.taskIndex] = signedTaskRespsC
-
-	go a.singleTaskAggregatorGoroutineFunc(
-		metadata,
-		signedTaskRespsC,
-	)
-	return nil
-}
-
-func (a *BlsAggregatorService) ProcessNewSignature(
-	ctx context.Context,
-	taskSignature TaskSignature,
-) error {
-	respC := make(chan error)
-	go func() {
-		respC <- a.processNewSignature(taskSignature)
-	}()
-
-	// NOTE: we do this to let the goroutine consume the result of the operation
-	//   but allow the operation to end early if the context is cancelled
-	select {
-	case err := <-respC:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-func (a *BlsAggregatorService) processNewSignature(
-	taskSignature TaskSignature,
-) error {
-	// TODO: move this to a goroutine to avoid sharing state
-	a.taskChansMutex.Lock()
-	taskC, taskInitialized := a.signedTaskRespsCs[taskSignature.taskIndex]
-	a.taskChansMutex.Unlock()
-	if !taskInitialized {
-		return TaskNotFoundErrorFn(taskSignature.taskIndex)
-	}
-
-	signatureVerificationErrorC := make(chan error)
-	// send the task to the goroutine processing this task
-	// and return the error (if any) returned by the signature verification routine
-
-	taskC <- types.SignedTaskResponseDigest{
-		TaskResponse:                taskSignature.taskResponse,
-		BlsSignature:                taskSignature.blsSignature,
-		OperatorId:                  taskSignature.operatorId,
-		SignatureVerificationErrorC: signatureVerificationErrorC,
-	}
-	return <-signatureVerificationErrorC
-}
-*/
 
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	metadata TaskMetadata,

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -203,7 +203,7 @@ func NewBlsAggregatorService(
 // The service handler is a structure used to use the service without the complexity of it.
 type ServiceHandler struct {
 	//This channels are used to send messages (requests) to the service.
-	TaskInitC         chan InitializeTaskRequest
+	taskInitC         chan InitializeTaskRequest
 	processSignatureC chan ProcessSignatureRequest
 }
 
@@ -318,7 +318,7 @@ func (a *ServiceHandler) InitializeNewTask(
 	metadata TaskMetadata,
 ) error {
 	errChan := make(chan error)
-	a.TaskInitC <- InitializeTaskRequest{metadata, errChan}
+	a.taskInitC <- InitializeTaskRequest{metadata, errChan}
 	select {
 	case err := <-errChan:
 		return err

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -270,6 +270,7 @@ func (a *BlsAggregatorService) run(
 				signedTaskRespC,
 				aggResponsesC,
 			)
+			taskInitReq.errC <- nil
 
 		case signatureReq, ok := <-processSignatureChannel:
 			if !ok {
@@ -318,12 +319,8 @@ func (a *ServiceHandler) InitializeNewTask(
 ) error {
 	errChan := make(chan error)
 	a.taskInitC <- initializeTaskRequest{metadata, errChan}
-	select {
-	case err := <-errChan:
-		return err
-	default:
-		return nil
-	}
+	err := <-errChan
+	return err
 }
 
 // ProcessNewSignature sends to the service thread a request to process a new signature for a previous initialize task.

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -217,7 +217,7 @@ type ProcessSignatureRequest struct {
 
 type AggregateReceiver struct {
 	/// Channel to receive the aggregated responses from the BLS Aggregator Service
-	aggregate_receiver chan BlsAggregationServiceResponse
+	aggregateReceiver chan BlsAggregationServiceResponse
 }
 
 func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error) {
@@ -232,7 +232,7 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error
 		close(aggResponsesC)
 	}()
 
-	return ServiceHandler{initializeTaskC, processSignatureC}, AggregateReceiver{aggregate_receiver: aggResponsesC}, nil
+	return ServiceHandler{initializeTaskC, processSignatureC}, AggregateReceiver{aggregateReceiver: aggResponsesC}, nil
 }
 
 func (a *BlsAggregatorService) run(
@@ -349,7 +349,7 @@ func (a *ServiceHandler) ProcessNewSignature(
 }
 
 func (a *AggregateReceiver) ReceiveAggregatedResponse() BlsAggregationServiceResponse {
-	return <-a.aggregate_receiver
+	return <-a.aggregateReceiver
 }
 
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -145,7 +145,7 @@ func (t TaskMetadata) WithWindowDuration(windowDuration time.Duration) TaskMetad
 // BlsAggregationService is the interface provided to avs aggregator code for doing bls aggregation
 // Currently its only implementation is the BlsAggregatorService, so see the comment there for more details
 type BlsAggregationService interface {
-	Start() (ServiceHandler, AggregateReceiver, error)
+	Start() (ServiceHandler, AggregateReceiver)
 }
 
 // BlsAggregatorService is a service that performs BLS signature aggregation for an AVS' tasks
@@ -223,7 +223,7 @@ type AggregateReceiver struct {
 // This function starts the service thread, initializing the aggregateResponses, initializeTask and processSignature
 // channels, passing them to the run method (where the main loop is executed) and returns the service handler an the
 // aggregate receiver to interact with the service thread.
-func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error) {
+func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver) {
 	// Create channels to handle requests
 	initializeTaskC := make(chan InitializeTaskRequest)
 	processSignatureC := make(chan ProcessSignatureRequest)
@@ -235,7 +235,7 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error
 		close(aggResponsesC)
 	}()
 
-	return ServiceHandler{initializeTaskC, processSignatureC}, AggregateReceiver{aggregateReceiver: aggResponsesC}, nil
+	return ServiceHandler{initializeTaskC, processSignatureC}, AggregateReceiver{aggregateReceiver: aggResponsesC}
 }
 
 // Here is executed the main loop, where the requests are received from the initialize task and process signature

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -145,9 +145,9 @@ func (t TaskMetadata) WithWindowDuration(windowDuration time.Duration) TaskMetad
 // BlsAggregationService is the interface provided to avs aggregator code for doing bls aggregation
 // Currently its only implementation is the BlsAggregatorService, so see the comment there for more details
 type BlsAggregationService interface {
-	// Starts the aggregation service, and returns the handler, to interact with, it and the receiver,
+	// Starts the aggregation service, and returns the handler, to interact with, it and the response channel,
 	// to receive the aggregated responses.
-	Start() (ServiceHandler, AggregateReceiver)
+	Start() (ServiceHandler, <-chan BlsAggregationServiceResponse)
 }
 
 // BlsAggregatorService is a service that performs BLS signature aggregation for an AVS' tasks
@@ -217,15 +217,10 @@ type ProcessSignatureRequest struct {
 	errC     chan error
 }
 
-type AggregateReceiver struct {
-	/// Channel to receive the aggregated responses from the BLS Aggregator Service
-	aggregateReceiver chan BlsAggregationServiceResponse
-}
-
 // This function starts the service thread, initializing the aggregateResponses, initializeTask and processSignature
 // channels, passing them to the run method (where the main loop is executed) and returns the service handler an the
-// aggregate receiver to interact with the service thread.
-func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver) {
+// aggregate receiver channel to interact with the service thread.
+func (a *BlsAggregatorService) Start() (ServiceHandler, <-chan BlsAggregationServiceResponse) {
 	// Create channels to handle requests
 	initializeTaskC := make(chan InitializeTaskRequest)
 	processSignatureC := make(chan ProcessSignatureRequest)
@@ -237,7 +232,10 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver) {
 		close(aggResponsesC)
 	}()
 
-	return ServiceHandler{initializeTaskC, processSignatureC}, AggregateReceiver{aggregateReceiver: aggResponsesC}
+	// Note: here we return the channel instead of a type with a receive function (different than rust
+	// implementation) because for users is more useful to use select on the channel directly instead
+	// of running a thread on a goroutine and using other channel
+	return ServiceHandler{initializeTaskC, processSignatureC}, aggResponsesC
 }
 
 // Here is executed the main loop, where the requests are received from the initialize task and process signature
@@ -353,11 +351,6 @@ func (a *ServiceHandler) ProcessNewSignature(
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-}
-
-// Returns the aggregated response from the channel connected to the service thread
-func (a *AggregateReceiver) ReceiveAggregatedResponse() BlsAggregationServiceResponse {
-	return <-a.aggregateReceiver
 }
 
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -257,7 +257,8 @@ func (a *BlsAggregatorService) run(
 			}
 			taskIndex := taskInitReq.metadata.taskIndex
 
-			if _, taskExists := taskChannels[taskIndex]; taskExists {
+			_, taskExists := taskChannels[taskIndex]
+			if taskExists {
 				taskInitReq.errC <- TaskAlreadyInitializedErrorFn(taskInitReq.metadata.taskIndex)
 				continue
 			}
@@ -276,7 +277,8 @@ func (a *BlsAggregatorService) run(
 			}
 			taskIndex := signatureReq.metadata.taskIndex
 
-			if signedTaskRespsC, taskExists := taskChannels[taskIndex]; taskExists {
+			signedTaskRespsC, taskExists := taskChannels[taskIndex]
+			if taskExists {
 				errC := make(chan error, 1)
 				signedDigest := types.SignedTaskResponseDigest{
 					TaskResponse:                signatureReq.metadata.taskResponse,

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -337,6 +337,21 @@ func (a *BlsAggregatorService) run(
 	}
 }
 
+func (a *ServiceHandler) InitializeNewTask(
+	metadata TaskMetadata,
+) error {
+	errChan := make(chan error)
+	a.TaskInitC <- InitializeTaskRequest{metadata, errChan}
+	select {
+	case err := <-errChan:
+		return err
+	default:
+		return nil
+	}
+}
+
+// TODO: continue by adding the process signature option
+
 func (a *BlsAggregatorService) GetResponseChannel() <-chan BlsAggregationServiceResponse {
 	return a.aggregatedResponsesC
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -145,6 +145,8 @@ func (t TaskMetadata) WithWindowDuration(windowDuration time.Duration) TaskMetad
 // BlsAggregationService is the interface provided to avs aggregator code for doing bls aggregation
 // Currently its only implementation is the BlsAggregatorService, so see the comment there for more details
 type BlsAggregationService interface {
+	// Starts the aggregation service, and returns the handler, to interact with, it and the receiver,
+	// to receive the aggregated responses.
 	Start() (ServiceHandler, AggregateReceiver)
 }
 

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -363,6 +363,12 @@ func (a *ServiceHandler) ProcessNewSignature(
 	}
 }
 
+func (a *AggregateReceiver) ReceiveAggregatedResponse(
+	metadata TaskSignature,
+) types.SignedTaskResponseDigest {
+	return <-a.aggregate_receiver // Maybe can add a select with a timer
+}
+
 func (a *BlsAggregatorService) GetResponseChannel() <-chan BlsAggregationServiceResponse {
 	return a.aggregatedResponsesC
 }

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -254,7 +254,6 @@ func (a *BlsAggregatorService) run(
 	for {
 		select {
 		case taskInitReq, ok := <-initializeTaskChannel:
-			// Initialize task
 			if !ok {
 				return
 			}
@@ -274,7 +273,6 @@ func (a *BlsAggregatorService) run(
 			)
 
 		case signatureReq, ok := <-processSignatureChannel:
-			// Process signature
 			if !ok {
 				return
 			}

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -322,6 +322,15 @@ func (a *ServiceHandler) InitializeNewTask(
 	}
 }
 
+// ProcessNewSignature sends to the service thread a request to process a new signature for a previous initialize task.
+//
+// The metadata parameter contains:
+//   - taskIndex: Unique identifier for the task
+//   - taskResponse: Response data that has been signed
+//   - blsSignature: BLS cryptographic signature for the task response
+//   - operatorId: id of the operator who signed the task response
+//
+// The last three attributes are used to make the response digest.
 func (a *ServiceHandler) ProcessNewSignature(
 	ctx context.Context,
 	metadata TaskSignature,
@@ -340,7 +349,7 @@ func (a *ServiceHandler) ProcessNewSignature(
 }
 
 func (a *AggregateReceiver) ReceiveAggregatedResponse() BlsAggregationServiceResponse {
-	return <-a.aggregate_receiver // Maybe can add a select with a timer
+	return <-a.aggregate_receiver
 }
 
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
@@ -352,7 +361,6 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 		"taskIndex", metadata.taskIndex,
 		"taskCreatedBlock", metadata.taskCreatedBlock)
 
-	// defer a.closeTaskGoroutine(metadata.taskIndex)
 	quorumThresholdPercentagesMap := make(map[types.QuorumNum]types.QuorumThresholdPercentage)
 	for i, quorumNumber := range metadata.quorumNumbers {
 		quorumThresholdPercentagesMap[quorumNumber] = metadata.quorumThresholdPercentages[i]

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -146,37 +146,7 @@ func (t TaskMetadata) WithWindowDuration(windowDuration time.Duration) TaskMetad
 // BlsAggregationService is the interface provided to avs aggregator code for doing bls aggregation
 // Currently its only implementation is the BlsAggregatorService, so see the comment there for more details
 type BlsAggregationService interface {
-	// InitializeNewTask creates a new task goroutine meant to process new signed task responses for that task
-	// (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to
-	// it. The quorumNumbers and quorumThresholdPercentages set the requirements for this task to be considered
-	// complete, which
-	// happens when a particular TaskResponseDigest (received via the a.taskChans[taskIndex]) has been signed by signers
-	// whose stake in each of the listed quorums adds up to at least quorumThresholdPercentages[i] of the total stake in
-	// that quorum.
-	// Once the quorum is reached, the task is still open for a window of `windowDuration` time (default 0) to receive
-	// more signatures, before sending the aggregation response through the aggregatedResponsesC channel.
-	// If the task expiration is reached before the window finishes, the task response will still be sent to the
-	// aggregatedResponsesC channel.
-	InitializeNewTask(
-		metadata TaskMetadata,
-	) error
-
-	// ProcessNewSignature processes a new signature over a taskResponseDigest for a particular taskIndex by a
-	// particular operator It verifies that the signature is correct and returns an error if it is not, and then
-	// aggregates the signature and stake of
-	// the operator with all other signatures for the same taskIndex and taskResponseDigest pair.
-	// Note: This function currently only verifies signatures over the taskResponseDigest directly, so avs code needs to
-	// verify that the digest passed to ProcessNewSignature is indeed the digest of a valid taskResponse (that is,
-	// BlsAggregationService does not verify semantic integrity of the taskResponses)
-	ProcessNewSignature(
-		ctx context.Context,
-		task TaskSignature,
-	) error
-
-	// GetResponseChannel returns the single channel that meant to be used as the response channel
-	// Any task that is completed (see the completion criterion in the comment above InitializeNewTask)
-	// will be sent on this channel along with all the necessary information to call BLSSignatureChecker onchain
-	GetResponseChannel() <-chan BlsAggregationServiceResponse
+	Start() (ServiceHandler, AggregateReceiver, error)
 }
 
 // BlsAggregatorService is a service that performs BLS signature aggregation for an AVS' tasks
@@ -251,13 +221,7 @@ type AggregateReceiver struct {
 	aggregate_receiver chan types.SignedTaskResponseDigest
 }
 
-func (a *BlsAggregatorService) Start(
-	taskIndex types.TaskIndex,
-	taskCreatedBlock uint32,
-	quorumNumbers types.QuorumNums,
-	quorumThresholdPercentages types.QuorumThresholdPercentages,
-	timeToExpiry time.Duration,
-) (ServiceHandler, AggregateReceiver, error) {
+func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error) {
 	// Create channels to handle requests
 	initializeTaskC := make(chan InitializeTaskRequest)
 	processSignatureC := make(chan ProcessSignatureRequest)
@@ -349,16 +313,11 @@ func (a *ServiceHandler) ProcessNewSignature(
 	}
 }
 
-func (a *AggregateReceiver) ReceiveAggregatedResponse(
-	metadata TaskSignature,
-) types.SignedTaskResponseDigest {
+func (a *AggregateReceiver) ReceiveAggregatedResponse() BlsAggregationServiceResponse {
 	return <-a.aggregate_receiver // Maybe can add a select with a timer
 }
 
-func (a *BlsAggregatorService) GetResponseChannel() <-chan BlsAggregationServiceResponse {
-	return a.aggregatedResponsesC
-}
-
+/*
 // InitializeNewTask creates a new task goroutine meant to process new signed task responses for that task
 // (that are sent via ProcessNewSignature) and adds a channel to a.taskChans to send the signed task responses to it.
 //
@@ -454,6 +413,7 @@ func (a *BlsAggregatorService) processNewSignature(
 	}
 	return <-signatureVerificationErrorC
 }
+*/
 
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	metadata TaskMetadata,

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -192,17 +192,6 @@ type BlsAggregationService interface {
 //     only submitted after the previous one's response has been aggregated and responded onchain, could have
 //     a much simpler AggregationService without all the complicated parallel goroutines.
 type BlsAggregatorService struct {
-	// aggregatedResponsesC is the channel which all goroutines share to send their responses back to the
-	// main thread after they are done aggregating (either they reached the threshold, or timeout expired)
-	aggregatedResponsesC chan BlsAggregationServiceResponse
-	// signedTaskRespsCs are the channels to send the signed task responses to the goroutines processing them
-	// each new task is assigned a new goroutine and a new channel
-	signedTaskRespsCs map[types.TaskIndex]chan types.SignedTaskResponseDigest
-	// we add chans to taskChans from the main thread (InitializeNewTask) when we create new tasks,
-	// we read them in ProcessNewSignature from the main thread when we receive new signed tasks,
-	// and remove them from its respective goroutine when the task is completed or reached timeout
-	// we thus need a mutex to protect taskChans
-	taskChansMutex     sync.RWMutex
 	avsRegistryService avsregistry.AvsRegistryService
 	logger             logging.Logger
 
@@ -234,12 +223,9 @@ func NewBlsAggregatorService(
 	logger logging.Logger,
 ) *BlsAggregatorService {
 	return &BlsAggregatorService{
-		aggregatedResponsesC: make(chan BlsAggregationServiceResponse),
-		signedTaskRespsCs:    make(map[types.TaskIndex]chan types.SignedTaskResponseDigest),
-		taskChansMutex:       sync.RWMutex{},
-		avsRegistryService:   avsRegistryService,
-		logger:               logger,
-		hashFunction:         hashFunction,
+		avsRegistryService: avsRegistryService,
+		logger:             logger,
+		hashFunction:       hashFunction,
 	}
 }
 

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -191,13 +191,35 @@ type BlsAggregationService interface {
 //     only submitted after the previous one's response has been aggregated and responded onchain, could have
 //     a much simpler AggregationService without all the complicated parallel goroutines.
 type BlsAggregatorService struct {
+	handler  ServiceHandler
+	receiver <-chan BlsAggregationServiceResponse
+}
+
+var _ BlsAggregationService = (*BlsAggregatorService)(nil)
+
+func (a *BlsAggregatorService) InitializeNewTask(
+	metadata TaskMetadata,
+) error {
+	return a.handler.InitializeNewTask(metadata)
+}
+
+func (a *BlsAggregatorService) ProcessNewSignature(
+	ctx context.Context,
+	task TaskSignature,
+) error {
+	return a.handler.ProcessNewSignature(ctx, task)
+}
+
+func (a *BlsAggregatorService) GetResponseChannel() <-chan BlsAggregationServiceResponse {
+	return a.receiver
+}
+
+type BlsAggregatorBuilder struct {
 	avsRegistryService avsregistry.AvsRegistryService
 	logger             logging.Logger
 
 	hashFunction types.TaskResponseHashFunction
 }
-
-var _ BlsAggregationService = (*BlsAggregatorService)(nil)
 
 // NewBlsAggregatorService creates a new BlsAggregatorService
 // avsRegistryService is the AVS registry service to use
@@ -221,10 +243,18 @@ func NewBlsAggregatorService(
 	hashFunction types.TaskResponseHashFunction,
 	logger logging.Logger,
 ) *BlsAggregatorService {
-	return &BlsAggregatorService{
+	// Instantiate builder and save handler and receiver.
+	builder := BlsAggregatorBuilder{
 		avsRegistryService: avsRegistryService,
 		logger:             logger,
 		hashFunction:       hashFunction,
+	}
+
+	handler, receiver := builder.Start()
+
+	return &BlsAggregatorService{
+		handler:  handler,
+		receiver: receiver,
 	}
 }
 
@@ -248,7 +278,7 @@ type processSignatureRequest struct {
 // This function starts the service thread, initializing the aggregateResponses, initializeTask and processSignature
 // channels, passing them to the run method (where the main loop is executed) and returns the service handler an the
 // aggregate receiver channel to interact with the service thread.
-func (a *BlsAggregatorService) Start() (ServiceHandler, <-chan BlsAggregationServiceResponse) {
+func (a *BlsAggregatorBuilder) Start() (ServiceHandler, <-chan BlsAggregationServiceResponse) {
 	// Create channels to handle requests
 	initializeTaskC := make(chan initializeTaskRequest)
 	processSignatureC := make(chan processSignatureRequest)
@@ -270,7 +300,7 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, <-chan BlsAggregationSer
 // channels, executing the corresponding logic in each case. The aggregated responses channel is passed to the
 // single task aggregator goroutine, where the initialization of the task is done an notified.
 // The loop ends if one of the request channels is closed.
-func (a *BlsAggregatorService) run(
+func (a *BlsAggregatorBuilder) run(
 	initializeTaskChannel <-chan initializeTaskRequest,
 	processSignatureChannel <-chan processSignatureRequest,
 	aggResponsesC chan<- BlsAggregationServiceResponse,
@@ -377,7 +407,7 @@ func (a *ServiceHandler) ProcessNewSignature(
 	}
 }
 
-func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
+func (a *BlsAggregatorBuilder) singleTaskAggregatorGoroutineFunc(
 	metadata TaskMetadata,
 	signedTaskRespsC <-chan types.SignedTaskResponseDigest,
 	aggregatedResponsesC chan<- BlsAggregationServiceResponse,
@@ -592,7 +622,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	}
 }
 
-func (a *BlsAggregatorService) sendAggregatedResponse(
+func (a *BlsAggregatorBuilder) sendAggregatedResponse(
 	operatorsAvsStateDict map[types.OperatorId]types.OperatorAvsState,
 	taskIndex types.TaskIndex,
 	taskCreatedBlock uint32,
@@ -656,7 +686,7 @@ func (a *BlsAggregatorService) sendAggregatedResponse(
 
 // verifySignature verifies that a signature is valid against the operator pubkey stored in the
 // operatorsAvsStateDict for that particular task
-func (a *BlsAggregatorService) verifySignature(
+func (a *BlsAggregatorBuilder) verifySignature(
 	taskIndex types.TaskIndex,
 	signedTaskResponseDigest types.SignedTaskResponseDigest,
 	operatorsAvsStateDict map[types.OperatorId]types.OperatorAvsState,

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -252,6 +252,7 @@ func (a *BlsAggregatorService) run(
 			taskIndex := taskInitReq.metadata.taskIndex
 
 			if _, taskExists := taskChannels[taskIndex]; taskExists {
+				taskInitReq.errC <- TaskAlreadyInitializedErrorFn(taskInitReq.metadata.taskIndex)
 				continue
 			}
 			signedTaskRespC := make(chan types.SignedTaskResponseDigest)

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -243,8 +243,8 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, <-chan BlsAggregationSer
 // single task aggregator goroutine, where the initialization of the task is done an notified.
 // The loop ends if one of the request channels is closed.
 func (a *BlsAggregatorService) run(
-	initializeTaskChannel chan initializeTaskRequest,
-	processSignatureChannel chan processSignatureRequest,
+	initializeTaskChannel <-chan initializeTaskRequest,
+	processSignatureChannel <-chan processSignatureRequest,
 	aggResponsesC chan BlsAggregationServiceResponse,
 ) {
 	taskChannels := make(map[types.TaskIndex]chan types.SignedTaskResponseDigest)

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -218,7 +218,7 @@ type ProcessSignatureRequest struct {
 
 type AggregateReceiver struct {
 	/// Channel to receive the aggregated responses from the BLS Aggregator Service
-	aggregate_receiver chan types.SignedTaskResponseDigest
+	aggregate_receiver chan BlsAggregationServiceResponse
 }
 
 func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error) {
@@ -226,7 +226,7 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error
 	initializeTaskC := make(chan InitializeTaskRequest)
 	processSignatureC := make(chan ProcessSignatureRequest)
 
-	aggResponsesC := make(chan types.SignedTaskResponseDigest)
+	aggResponsesC := make(chan BlsAggregationServiceResponse)
 
 	go func() {
 		a.run(initializeTaskC, processSignatureC, aggResponsesC)
@@ -239,7 +239,7 @@ func (a *BlsAggregatorService) Start() (ServiceHandler, AggregateReceiver, error
 func (a *BlsAggregatorService) run(
 	initializeTaskChannel chan InitializeTaskRequest,
 	processSignatureChannel chan ProcessSignatureRequest,
-	aggResponsesC chan types.SignedTaskResponseDigest,
+	aggResponsesC chan BlsAggregationServiceResponse,
 ) {
 	taskChannels := make(map[types.TaskIndex]chan types.SignedTaskResponseDigest)
 
@@ -255,11 +255,12 @@ func (a *BlsAggregatorService) run(
 			if _, taskExists := taskChannels[taskIndex]; taskExists {
 				continue
 			}
-			signedTaskRespsC := make(chan types.SignedTaskResponseDigest)
-			taskChannels[taskIndex] = signedTaskRespsC
+			signedTaskRespC := make(chan types.SignedTaskResponseDigest)
+			taskChannels[taskIndex] = signedTaskRespC
 
 			go a.singleTaskAggregatorGoroutineFunc(
 				taskInitReq.metadata,
+				signedTaskRespC,
 				aggResponsesC,
 			)
 
@@ -301,6 +302,7 @@ func (a *ServiceHandler) InitializeNewTask(
 }
 
 func (a *ServiceHandler) ProcessNewSignature(
+	ctx context.Context,
 	metadata TaskSignature,
 ) error {
 	errChan := make(chan error)
@@ -308,8 +310,8 @@ func (a *ServiceHandler) ProcessNewSignature(
 	select {
 	case err := <-errChan:
 		return err
-	default:
-		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -418,12 +420,13 @@ func (a *BlsAggregatorService) processNewSignature(
 func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 	metadata TaskMetadata,
 	signedTaskRespsC <-chan types.SignedTaskResponseDigest,
+	aggregatedResponsesC chan BlsAggregationServiceResponse,
 ) {
 	a.logger.Debug("AggregatorService goroutine processing new task",
 		"taskIndex", metadata.taskIndex,
 		"taskCreatedBlock", metadata.taskCreatedBlock)
 
-	defer a.closeTaskGoroutine(metadata.taskIndex)
+	// defer a.closeTaskGoroutine(metadata.taskIndex)
 	quorumThresholdPercentagesMap := make(map[types.QuorumNum]types.QuorumThresholdPercentage)
 	for i, quorumNumber := range metadata.quorumNumbers {
 		quorumThresholdPercentagesMap[quorumNumber] = metadata.quorumThresholdPercentages[i]
@@ -445,7 +448,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			"err",
 			err,
 		)
-		a.aggregatedResponsesC <- BlsAggregationServiceResponse{
+		aggregatedResponsesC <- BlsAggregationServiceResponse{
 			Err:       TaskInitializationErrorFn(fmt.Errorf("AggregatorService failed to get operators state from avs registry at blockNum %d: %w", metadata.taskCreatedBlock, err), metadata.taskIndex),
 			TaskIndex: metadata.taskIndex,
 		}
@@ -464,8 +467,8 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 			"err",
 			err,
 		)
-		a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-			Err:       TaskInitializationErrorFn(fmt.Errorf("Aggregator failed to get quorums state from avs registry: %w", err), metadata.taskIndex),
+		aggregatedResponsesC <- BlsAggregationServiceResponse{
+			Err:       TaskInitializationErrorFn(fmt.Errorf("aggregator failed to get quorums state from avs registry: %w", err), metadata.taskIndex),
 			TaskIndex: metadata.taskIndex,
 		}
 		return
@@ -603,10 +606,11 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 					metadata.quorumNumbers,
 					lastTaskResponseDigest,
 					quorumApksG1,
+					aggregatedResponsesC,
 				)
 			}
 
-			a.aggregatedResponsesC <- BlsAggregationServiceResponse{
+			aggregatedResponsesC <- BlsAggregationServiceResponse{
 				Err:       TaskExpiredErrorFn(metadata.taskIndex),
 				TaskIndex: metadata.taskIndex,
 			}
@@ -622,6 +626,7 @@ func (a *BlsAggregatorService) singleTaskAggregatorGoroutineFunc(
 				metadata.quorumNumbers,
 				lastTaskResponseDigest,
 				quorumApksG1,
+				aggregatedResponsesC,
 			)
 			return
 		}
@@ -637,6 +642,7 @@ func (a *BlsAggregatorService) sendAggregatedResponse(
 	quorumNumbers types.QuorumNums,
 	taskResponseDigest types.TaskResponseDigest,
 	quorumApksG1 []*bls.G1Point,
+	aggregatedResponsesC chan BlsAggregationServiceResponse,
 ) {
 	nonSignersOperatorIds := []types.OperatorId{}
 	for operatorId := range operatorsAvsStateDict {
@@ -665,8 +671,8 @@ func (a *BlsAggregatorService) sendAggregatedResponse(
 		nonSignersOperatorIds,
 	)
 	if err != nil {
-		a.aggregatedResponsesC <- BlsAggregationServiceResponse{
-			Err:       utils.WrapError(errors.New("Failed to get check signatures indices"), err),
+		aggregatedResponsesC <- BlsAggregationServiceResponse{
+			Err:       utils.WrapError(errors.New("failed to get check signatures indices"), err),
 			TaskIndex: taskIndex,
 		}
 		return
@@ -686,17 +692,7 @@ func (a *BlsAggregatorService) sendAggregatedResponse(
 		TotalStakeIndices:            indices.TotalStakeIndices,
 		NonSignerStakeIndices:        indices.NonSignerStakeIndices,
 	}
-	a.aggregatedResponsesC <- blsAggregationServiceResponse
-}
-
-// closeTaskGoroutine is run when the goroutine processing taskIndex's task responses ends (for whatever reason)
-// it deletes the response channel for taskIndex from a.taskChans
-// so that the main thread knows that this task goroutine is no longer running
-// and doesn't try to send new signatures to it
-func (a *BlsAggregatorService) closeTaskGoroutine(taskIndex types.TaskIndex) {
-	a.taskChansMutex.Lock()
-	delete(a.signedTaskRespsCs, taskIndex)
-	a.taskChansMutex.Unlock()
+	aggregatedResponsesC <- blsAggregationServiceResponse
 }
 
 // verifySignature verifies that a signature is valid against the operator pubkey stored in the

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -209,12 +209,12 @@ type ServiceHandler struct {
 
 type initializeTaskRequest struct {
 	metadata TaskMetadata
-	errC     chan error
+	errC     chan<- error
 }
 
 type processSignatureRequest struct {
 	metadata TaskSignature
-	errC     chan error
+	errC     chan<- error
 }
 
 // This function starts the service thread, initializing the aggregateResponses, initializeTask and processSignature

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -958,7 +958,8 @@ func TestBlsAgg(t *testing.T) {
 
 	// this is an edge case as typically we would send new tasks and listen for task responses in a for select loop
 	// but this test makes sure the context deadline exceeded can get us out of a deadlock
-	t.Run("send new signedTaskDigest before listen on responseChan - context timeout cancels the request to prevent deadlock",
+	t.Run(
+		"send new signedTaskDigest before listen on responseChan - context timeout cancels the request to prevent deadlock",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId:     types.OperatorId{1},

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -959,7 +959,8 @@ func TestBlsAgg(t *testing.T) {
 
 	// this is an edge case as typically we would send new tasks and listen for task responses in a for select loop
 	// but this test makes sure the context deadline exceeded can get us out of a deadlock
-	t.Run("send new signedTaskDigest before listen on responseChan - context timeout cancels the request to prevent deadlock",
+	t.Run(
+		"send new signedTaskDigest before listen on responseChan - context timeout cancels the request to prevent deadlock",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId:     types.OperatorId{1},

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -80,15 +80,21 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err = blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
-		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature,
+			taskIndex,
+			taskResponse,
+			blsSig,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
@@ -101,7 +107,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersApkG2:        testOperator1.BlsKeypair.GetPubKeyG2(),
 			SignersAggSigG1:     testOperator1.BlsKeypair.SignMessage(taskResponseDigest),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -140,30 +146,40 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err = blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature3,
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
 		)
 		require.Nil(t, err)
 
@@ -184,7 +200,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -216,23 +232,31 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err = blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 
@@ -254,7 +278,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -281,50 +305,67 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
 		// initialize 2 concurrent tasks
 		task1Index := types.TaskIndex(1)
 		task1Response := mockTaskResponse{123}
 		task1ResponseDigest, err := hashFunction(task1Response)
 		require.Nil(t, err)
-		metadata1 := NewTaskMetadata(task1Index, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata1)
+		err = blsAggServ.InitializeNewTask(
+			task1Index,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
 		task2Index := types.TaskIndex(2)
 		task2Response := mockTaskResponse{234}
 		task2ResponseDigest, err := hashFunction(task2Response)
 		require.Nil(t, err)
-		metadata2 := NewTaskMetadata(task2Index, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata2)
+		err = blsAggServ.InitializeNewTask(
+			task2Index,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
 
 		blsSigTask1Op1 := testOperator1.BlsKeypair.SignMessage(task1ResponseDigest)
-		taskSignature1Op1 := NewTaskSignature(task1Index, task1Response, blsSigTask1Op1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1Op1,
+			task1Index,
+			task1Response,
+			blsSigTask1Op1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigTask2Op1 := testOperator1.BlsKeypair.SignMessage(task2ResponseDigest)
-		taskSignature2Op1 := NewTaskSignature(task2Index, task2Response, blsSigTask2Op1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2Op1,
+			task2Index,
+			task2Response,
+			blsSigTask2Op1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigTask1Op2 := testOperator2.BlsKeypair.SignMessage(task1ResponseDigest)
-		taskSignature1Op2 := NewTaskSignature(task1Index, task1Response, blsSigTask1Op2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1Op2,
+			task1Index,
+			task1Response,
+			blsSigTask1Op2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigTask2Op2 := testOperator2.BlsKeypair.SignMessage(task2ResponseDigest)
-		taskSignature2Op2 := NewTaskSignature(task2Index, task2Response, blsSigTask2Op2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2Op2,
+			task2Index,
+			task2Response,
+			blsSigTask2Op2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 
@@ -367,8 +408,8 @@ func TestBlsAgg(t *testing.T) {
 		}
 
 		// we don't know which of task1 or task2 responses will be received first
-		gotAggregationServiceResponseTaskFirstReceived := <-aggResponsesC
-		gotAggregationServiceResponseTaskSecondReceived := <-aggResponsesC
+		gotAggregationServiceResponseTaskFirstReceived := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponseTaskSecondReceived := <-blsAggServ.aggregatedResponsesC
 
 		if gotAggregationServiceResponseTaskFirstReceived.TaskIndex == task1Index {
 			require.EqualValues(t, wantAggregationServiceResponseTask1, gotAggregationServiceResponseTaskFirstReceived)
@@ -405,12 +446,15 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
 		logger.Info("Initializing new task", "taskIndex", taskIndex)
-		timeToExpire := 10 * time.Second
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, timeToExpire)
-		err := handler.InitializeNewTask(metadata)
+		err := blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			10*time.Second, // Longer expiry time for testing
+		)
 		require.NoError(t, err)
 
 		taskResponseDigest, err := hashFunction(taskResponse)
@@ -418,19 +462,23 @@ func TestBlsAgg(t *testing.T) {
 
 		logger.Info("Processing first signature", "operatorId", testOperator1.OperatorId)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.NoError(t, err)
 
 		logger.Info("Processing second signature (Operator 1 double sign)", "operatorId", testOperator1.OperatorId)
 		blsSigOp1Dup := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1Dup := NewTaskSignature(taskIndex, taskResponse, blsSigOp1Dup, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1Dup,
+			taskIndex,
+			taskResponse,
+			blsSigOp1Dup,
+			testOperator1.OperatorId,
 		)
 
 		if err != nil {
@@ -442,10 +490,12 @@ func TestBlsAgg(t *testing.T) {
 
 		logger.Info("Processing second signature", "operatorId", testOperator2.OperatorId)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		require.NoError(t, err)
 
@@ -463,7 +513,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 
 	})
@@ -482,15 +532,19 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err := handler.InitializeNewTask(metadata)
+		err := blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -522,15 +576,21 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err = blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
-		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature,
+			taskIndex,
+			taskResponse,
+			blsSig,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
@@ -545,7 +605,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersApkG2:    testOperator1.BlsKeypair.GetPubKeyG2(),
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -577,21 +637,27 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err = blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
-		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature,
+			taskIndex,
+			taskResponse,
+			blsSig,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -624,23 +690,31 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err = blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 
@@ -658,11 +732,12 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
-	t.Run("2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 50% - verified",
+	t.Run(
+		"2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 50% - verified",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -698,29 +773,31 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, aggResponsesC := blsAggServ.Start()
 
-			metadata := NewTaskMetadata(
+			err = blsAggServ.InitializeNewTask(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-			taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-			err = handler.ProcessNewSignature(
+			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskSignature1,
+				taskIndex,
+				taskResponse,
+				blsSigOp1,
+				testOperator1.OperatorId,
 			)
 			require.Nil(t, err)
 			blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-			taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-			err = handler.ProcessNewSignature(
+			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskSignature2,
+				taskIndex,
+				taskResponse,
+				blsSigOp2,
+				testOperator2.OperatorId,
 			)
 			require.Nil(t, err)
 
@@ -744,12 +821,13 @@ func TestBlsAgg(t *testing.T) {
 				SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 					Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 			}
-			gotAggregationServiceResponse := <-aggResponsesC
+			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		},
 	)
 
-	t.Run("2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 60% - task expired",
+	t.Run(
+		"2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 60% - task expired",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -785,36 +863,38 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, aggResponsesC := blsAggServ.Start()
 
-			metadata := NewTaskMetadata(
+			err = blsAggServ.InitializeNewTask(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-			taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-			err = handler.ProcessNewSignature(
+			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskSignature1,
+				taskIndex,
+				taskResponse,
+				blsSigOp1,
+				testOperator1.OperatorId,
 			)
 			require.Nil(t, err)
 			blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-			taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-			err = handler.ProcessNewSignature(
+			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskSignature2,
+				taskIndex,
+				taskResponse,
+				blsSigOp2,
+				testOperator2.OperatorId,
 			)
 			require.Nil(t, err)
 
 			wantAggregationServiceResponse := BlsAggregationServiceResponse{
 				Err: TaskExpiredErrorFn(taskIndex),
 			}
-			gotAggregationServiceResponse := <-aggResponsesC
+			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -838,28 +918,35 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err = blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
-	t.Run("2 quorums 2 operators, 1 operator which just stake one quorum; 1 signatures - task expired",
+	t.Run(
+		"2 quorums 2 operators, 1 operator which just stake one quorum; 1 signatures - task expired",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -888,29 +975,29 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, aggResponsesC := blsAggServ.Start()
 
-			metadata := NewTaskMetadata(
+			err = blsAggServ.InitializeNewTask(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-			taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-			err = handler.ProcessNewSignature(
+			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskSignature,
+				taskIndex,
+				taskResponse,
+				blsSigOp1,
+				testOperator1.OperatorId,
 			)
 			require.Nil(t, err)
 
 			wantAggregationServiceResponse := BlsAggregationServiceResponse{
 				Err: TaskExpiredErrorFn(taskIndex),
 			}
-			gotAggregationServiceResponse := <-aggResponsesC
+			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -932,12 +1019,13 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, _ := blsAggServ.Start()
 
-		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature,
+			taskIndex,
+			taskResponse,
+			blsSig,
+			testOperator1.OperatorId,
 		)
 		require.Equal(t, TaskNotFoundErrorFn(taskIndex), err)
 	})
@@ -970,25 +1058,25 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, aggResponsesC := blsAggServ.Start()
 
-			metadata := NewTaskMetadata(
+			err := blsAggServ.InitializeNewTask(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err := handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			taskResponse1 := mockTaskResponse{1}
 			taskResponseDigest1, err := hashFunction(taskResponse1)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest1)
-			taskSignature1 := NewTaskSignature(taskIndex, taskResponse1, blsSigOp1, testOperator1.OperatorId)
-			err = handler.ProcessNewSignature(
+			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskSignature1,
+				taskIndex,
+				taskResponse1,
+				blsSigOp1,
+				testOperator1.OperatorId,
 			)
 			require.Nil(t, err)
 
@@ -998,11 +1086,7 @@ func TestBlsAgg(t *testing.T) {
 			blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest2)
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			taskSignature2 := NewTaskSignature(taskIndex, taskResponse2, blsSigOp2, testOperator2.OperatorId)
-			err = handler.ProcessNewSignature(
-				ctx,
-				taskSignature2,
-			)
+			err = blsAggServ.ProcessNewSignature(ctx, taskIndex, taskResponse2, blsSigOp2, testOperator2.OperatorId)
 			// this should timeout because the task goroutine is blocked on the response channel (since we only listen
 			// for it below)
 			require.Equal(t, context.DeadlineExceeded, err)
@@ -1017,7 +1101,7 @@ func TestBlsAgg(t *testing.T) {
 				SignersApkG2:        testOperator1.BlsKeypair.GetPubKeyG2(),
 				SignersAggSigG1:     testOperator1.BlsKeypair.SignMessage(taskResponseDigest1),
 			}
-			gotAggregationServiceResponse := <-aggResponsesC
+			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 			require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -1047,40 +1131,49 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err := handler.InitializeNewTask(metadata)
+		err := blsAggServ.InitializeNewTask(
+			taskIndex,
+			blockNum,
+			quorumNumbers,
+			quorumThresholdPercentages,
+			tasksTimeToExpiry,
+		)
 		require.Nil(t, err)
 		taskResponse1 := mockTaskResponse{1}
 		taskResponseDigest1, err := hashFunction(taskResponse1)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest1)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse1, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse1,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		taskResponse2 := mockTaskResponse{2}
 		taskResponseDigest2, err := hashFunction(taskResponse2)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest2)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse2, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse2,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
-	t.Run("1 quorum 1 operator 1 invalid signature (TaskResponseDigest does not match TaskResponse)",
+	t.Run(
+		"1 quorum 1 operator 1 invalid signature (TaskResponseDigest does not match TaskResponse)",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId:     types.OperatorId{1},
@@ -1104,23 +1197,23 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, _ := blsAggServ.Start()
 
-			metadata := NewTaskMetadata(
+			err = blsAggServ.InitializeNewTask(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
-			taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-			err = handler.ProcessNewSignature(
+			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskSignature,
+				taskIndex,
+				taskResponse,
+				blsSig,
+				testOperator1.OperatorId,
 			)
-			require.EqualError(t, err, "signature verification failed. incorrect signature")
+			require.EqualError(t, err, "Signature verification failed. Incorrect Signature.")
 		},
 	)
 
@@ -1161,39 +1254,44 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
 		start := time.Now()
-		metadata := NewTaskMetadata(
+		err = blsAggServ.InitializeNewTaskWithWindow(
 			taskIndex,
 			blockNum,
 			quorumNumbers,
 			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		).WithWindowDuration(windowDuration)
-		err = handler.InitializeNewTask(metadata)
+			timeToExpiry,
+			windowDuration,
+		)
 		require.Nil(t, err)
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		// quorum has already been reached, but window should still be open
 		require.Nil(t, err)
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature3,
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
 		)
 		require.Nil(t, err)
 
@@ -1214,7 +1312,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1264,41 +1362,46 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
 		start := time.Now()
-		metadata := NewTaskMetadata(
+		err = blsAggServ.InitializeNewTaskWithWindow(
 			taskIndex,
 			blockNum,
 			quorumNumbers,
 			quorumThresholdPercentages,
 			timeToExpiry,
-		).WithWindowDuration(windowDuration)
-		err = handler.InitializeNewTask(metadata)
+			windowDuration,
+		)
 		require.Nil(t, err)
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 
 		// quorum has already been reached, window will be open and receiving signature until the task expires
 
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature3,
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
 		)
 		require.Nil(t, err)
 
@@ -1319,7 +1422,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1362,32 +1465,35 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(
+		err = blsAggServ.InitializeNewTaskWithWindow(
 			taskIndex,
 			blockNum,
 			quorumNumbers,
 			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		).WithWindowDuration(windowDuration)
-		err = handler.InitializeNewTask(metadata)
+			timeToExpiry,
+			windowDuration,
+		)
 		require.Nil(t, err)
 
 		start := time.Now()
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 
@@ -1397,10 +1503,12 @@ func TestBlsAgg(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			ctx,
-			taskSignature3,
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
 		)
 		require.Equal(t, context.DeadlineExceeded, err)
 
@@ -1419,7 +1527,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1464,32 +1572,35 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
-		metadata := NewTaskMetadata(
+		err = blsAggServ.InitializeNewTaskWithWindow(
 			taskIndex,
 			blockNum,
 			quorumNumbers,
 			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		).WithWindowDuration(windowDuration)
-		err = handler.InitializeNewTask(metadata)
+			timeToExpiry,
+			windowDuration,
+		)
 		require.Nil(t, err)
 
 		start := time.Now()
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature1,
+			taskIndex,
+			taskResponse,
+			blsSigOp1,
+			testOperator1.OperatorId,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskSignature2,
+			taskIndex,
+			taskResponse,
+			blsSigOp2,
+			testOperator2.OperatorId,
 		)
 		require.Nil(t, err)
 
@@ -1500,10 +1611,12 @@ func TestBlsAgg(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
-		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = handler.ProcessNewSignature(
+		err = blsAggServ.ProcessNewSignature(
 			ctx,
-			taskSignature3,
+			taskIndex,
+			taskResponse,
+			blsSigOp3,
+			testOperator3.OperatorId,
 		)
 		require.Equal(t, context.DeadlineExceeded, err)
 
@@ -1522,7 +1635,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-aggResponsesC
+		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1605,7 +1718,6 @@ func TestIntegrationBlsAgg(t *testing.T) {
 			logger,
 		)
 		blsAggServ := NewBlsAggregatorService(avsRegistryService, hashFunction, logger)
-		handler, aggResponsesC := blsAggServ.Start()
 
 		// register operator
 		quorumNumbers := testData.Input.QuorumNumbers
@@ -1631,29 +1743,24 @@ func TestIntegrationBlsAgg(t *testing.T) {
 		quorumThresholdPercentages := testData.Input.QuorumThresholdPercentages
 
 		// initialize the task
-		metadata := NewTaskMetadata(
+		err = blsAggServ.InitializeNewTask(
 			taskIndex,
-			uint32(curBlockNum),
+			uint32(referenceBlockNumber),
 			quorumNumbers,
 			quorumThresholdPercentages,
 			tasksTimeToExpiry,
 		)
-		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		// compute the signature and send it to the aggregation service
 		taskResponseDigest, err := hashFunction(taskResponse)
 		require.Nil(t, err)
 		blsSig := blsKeyPair.SignMessage(taskResponseDigest)
-		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, operatorId)
-		err = handler.ProcessNewSignature(
-			context.Background(),
-			taskSignature,
-		)
+		err = blsAggServ.ProcessNewSignature(context.Background(), taskIndex, taskResponse, blsSig, operatorId)
 		require.Nil(t, err)
 
 		// wait for the response from the aggregation service and check the signature
-		blsAggServiceResp := <-aggResponsesC
+		blsAggServiceResp := <-blsAggServ.aggregatedResponsesC
 
 		avsServiceManager, err := avssm.NewContractMockAvsServiceManager(contractAddrs.ServiceManager, ethHttpClient)
 		require.NoError(t, err)

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -80,7 +80,7 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -101,7 +101,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersApkG2:        testOperator1.BlsKeypair.GetPubKeyG2(),
 			SignersAggSigG1:     testOperator1.BlsKeypair.SignMessage(taskResponseDigest),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -140,7 +140,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -184,7 +184,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -216,7 +216,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -254,7 +254,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -281,7 +281,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		// initialize 2 concurrent tasks
 		task1Index := types.TaskIndex(1)
@@ -367,8 +367,8 @@ func TestBlsAgg(t *testing.T) {
 		}
 
 		// we don't know which of task1 or task2 responses will be received first
-		gotAggregationServiceResponseTaskFirstReceived := receiver.ReceiveAggregatedResponse()
-		gotAggregationServiceResponseTaskSecondReceived := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponseTaskFirstReceived := <-aggResponsesC
+		gotAggregationServiceResponseTaskSecondReceived := <-aggResponsesC
 
 		if gotAggregationServiceResponseTaskFirstReceived.TaskIndex == task1Index {
 			require.EqualValues(t, wantAggregationServiceResponseTask1, gotAggregationServiceResponseTaskFirstReceived)
@@ -405,7 +405,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		logger.Info("Initializing new task", "taskIndex", taskIndex)
 		timeToExpire := 10 * time.Second
@@ -463,7 +463,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 
 	})
@@ -482,7 +482,7 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err := handler.InitializeNewTask(metadata)
@@ -490,7 +490,7 @@ func TestBlsAgg(t *testing.T) {
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -522,7 +522,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -545,7 +545,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersApkG2:    testOperator1.BlsKeypair.GetPubKeyG2(),
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -577,7 +577,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -591,7 +591,7 @@ func TestBlsAgg(t *testing.T) {
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -624,7 +624,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -658,7 +658,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -698,7 +698,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, receiver := blsAggServ.Start()
+			handler, aggResponsesC := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -744,7 +744,7 @@ func TestBlsAgg(t *testing.T) {
 				SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 					Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 			}
-			gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+			gotAggregationServiceResponse := <-aggResponsesC
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		},
 	)
@@ -785,7 +785,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, receiver := blsAggServ.Start()
+			handler, aggResponsesC := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -814,7 +814,7 @@ func TestBlsAgg(t *testing.T) {
 			wantAggregationServiceResponse := BlsAggregationServiceResponse{
 				Err: TaskExpiredErrorFn(taskIndex),
 			}
-			gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+			gotAggregationServiceResponse := <-aggResponsesC
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -838,7 +838,7 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -854,7 +854,7 @@ func TestBlsAgg(t *testing.T) {
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -888,7 +888,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, receiver := blsAggServ.Start()
+			handler, aggResponsesC := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -910,7 +910,7 @@ func TestBlsAgg(t *testing.T) {
 			wantAggregationServiceResponse := BlsAggregationServiceResponse{
 				Err: TaskExpiredErrorFn(taskIndex),
 			}
-			gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+			gotAggregationServiceResponse := <-aggResponsesC
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -970,7 +970,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, receiver := blsAggServ.Start()
+			handler, aggResponsesC := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -1017,7 +1017,7 @@ func TestBlsAgg(t *testing.T) {
 				SignersApkG2:        testOperator1.BlsKeypair.GetPubKeyG2(),
 				SignersAggSigG1:     testOperator1.BlsKeypair.SignMessage(taskResponseDigest1),
 			}
-			gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+			gotAggregationServiceResponse := <-aggResponsesC
 			require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -1047,7 +1047,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err := handler.InitializeNewTask(metadata)
@@ -1075,7 +1075,7 @@ func TestBlsAgg(t *testing.T) {
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -1161,7 +1161,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		start := time.Now()
 		metadata := NewTaskMetadata(
@@ -1214,7 +1214,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1264,7 +1264,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		start := time.Now()
 		metadata := NewTaskMetadata(
@@ -1319,7 +1319,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1362,7 +1362,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(
 			taskIndex,
@@ -1419,7 +1419,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1464,7 +1464,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(
 			taskIndex,
@@ -1522,7 +1522,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponse := <-aggResponsesC
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1605,7 +1605,7 @@ func TestIntegrationBlsAgg(t *testing.T) {
 			logger,
 		)
 		blsAggServ := NewBlsAggregatorService(avsRegistryService, hashFunction, logger)
-		handler, receiver := blsAggServ.Start()
+		handler, aggResponsesC := blsAggServ.Start()
 
 		// register operator
 		quorumNumbers := testData.Input.QuorumNumbers
@@ -1653,7 +1653,7 @@ func TestIntegrationBlsAgg(t *testing.T) {
 		require.Nil(t, err)
 
 		// wait for the response from the aggregation service and check the signature
-		blsAggServiceResp := receiver.ReceiveAggregatedResponse()
+		blsAggServiceResp := <-aggResponsesC
 
 		avsServiceManager, err := avssm.NewContractMockAvsServiceManager(contractAddrs.ServiceManager, ethHttpClient)
 		require.NoError(t, err)

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -80,12 +80,14 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature,
 		)
@@ -100,7 +102,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersApkG2:        testOperator1.BlsKeypair.GetPubKeyG2(),
 			SignersAggSigG1:     testOperator1.BlsKeypair.SignMessage(taskResponseDigest),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -139,27 +141,29 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
 		require.Nil(t, err)
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature3,
 		)
@@ -182,7 +186,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -214,20 +218,22 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
@@ -251,7 +257,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -278,6 +284,8 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		// initialize 2 concurrent tasks
 		task1Index := types.TaskIndex(1)
@@ -285,40 +293,40 @@ func TestBlsAgg(t *testing.T) {
 		task1ResponseDigest, err := hashFunction(task1Response)
 		require.Nil(t, err)
 		metadata1 := NewTaskMetadata(task1Index, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata1)
+		err = handler.InitializeNewTask(metadata1)
 		require.Nil(t, err)
 		task2Index := types.TaskIndex(2)
 		task2Response := mockTaskResponse{234}
 		task2ResponseDigest, err := hashFunction(task2Response)
 		require.Nil(t, err)
 		metadata2 := NewTaskMetadata(task2Index, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata2)
+		err = handler.InitializeNewTask(metadata2)
 		require.Nil(t, err)
 
 		blsSigTask1Op1 := testOperator1.BlsKeypair.SignMessage(task1ResponseDigest)
 		taskSignature1Op1 := NewTaskSignature(task1Index, task1Response, blsSigTask1Op1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1Op1,
 		)
 		require.Nil(t, err)
 		blsSigTask2Op1 := testOperator1.BlsKeypair.SignMessage(task2ResponseDigest)
 		taskSignature2Op1 := NewTaskSignature(task2Index, task2Response, blsSigTask2Op1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2Op1,
 		)
 		require.Nil(t, err)
 		blsSigTask1Op2 := testOperator2.BlsKeypair.SignMessage(task1ResponseDigest)
 		taskSignature1Op2 := NewTaskSignature(task1Index, task1Response, blsSigTask1Op2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1Op2,
 		)
 		require.Nil(t, err)
 		blsSigTask2Op2 := testOperator2.BlsKeypair.SignMessage(task2ResponseDigest)
 		taskSignature2Op2 := NewTaskSignature(task2Index, task2Response, blsSigTask2Op2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2Op2,
 		)
@@ -363,8 +371,8 @@ func TestBlsAgg(t *testing.T) {
 		}
 
 		// we don't know which of task1 or task2 responses will be received first
-		gotAggregationServiceResponseTaskFirstReceived := <-blsAggServ.aggregatedResponsesC
-		gotAggregationServiceResponseTaskSecondReceived := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponseTaskFirstReceived := receiver.ReceiveAggregatedResponse()
+		gotAggregationServiceResponseTaskSecondReceived := receiver.ReceiveAggregatedResponse()
 
 		if gotAggregationServiceResponseTaskFirstReceived.TaskIndex == task1Index {
 			require.EqualValues(t, wantAggregationServiceResponseTask1, gotAggregationServiceResponseTaskFirstReceived)
@@ -401,11 +409,13 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		logger.Info("Initializing new task", "taskIndex", taskIndex)
 		timeToExpire := 10 * time.Second
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, timeToExpire)
-		err := blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.NoError(t, err)
 
 		taskResponseDigest, err := hashFunction(taskResponse)
@@ -414,7 +424,7 @@ func TestBlsAgg(t *testing.T) {
 		logger.Info("Processing first signature", "operatorId", testOperator1.OperatorId)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
@@ -423,7 +433,7 @@ func TestBlsAgg(t *testing.T) {
 		logger.Info("Processing second signature (Operator 1 double sign)", "operatorId", testOperator1.OperatorId)
 		blsSigOp1Dup := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1Dup := NewTaskSignature(taskIndex, taskResponse, blsSigOp1Dup, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1Dup,
 		)
@@ -438,7 +448,7 @@ func TestBlsAgg(t *testing.T) {
 		logger.Info("Processing second signature", "operatorId", testOperator2.OperatorId)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
@@ -458,7 +468,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 
 	})
@@ -477,14 +487,16 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err := blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -516,12 +528,14 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature,
 		)
@@ -538,7 +552,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersApkG2:    testOperator1.BlsKeypair.GetPubKeyG2(),
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -570,12 +584,14 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature,
 		)
@@ -583,7 +599,7 @@ func TestBlsAgg(t *testing.T) {
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -616,20 +632,22 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
@@ -649,12 +667,11 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
-	t.Run(
-		"2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 50% - verified",
+	t.Run("2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 50% - verified",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -690,6 +707,8 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+			handler, receiver, err := blsAggServ.Start()
+			require.NoError(t, err)
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -698,18 +717,18 @@ func TestBlsAgg(t *testing.T) {
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = blsAggServ.InitializeNewTask(metadata)
+			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 			taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-			err = blsAggServ.ProcessNewSignature(
+			err = handler.ProcessNewSignature(
 				context.Background(),
 				taskSignature1,
 			)
 			require.Nil(t, err)
 			blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 			taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-			err = blsAggServ.ProcessNewSignature(
+			err = handler.ProcessNewSignature(
 				context.Background(),
 				taskSignature2,
 			)
@@ -735,13 +754,12 @@ func TestBlsAgg(t *testing.T) {
 				SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 					Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 			}
-			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+			gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		},
 	)
 
-	t.Run(
-		"2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 60% - task expired",
+	t.Run("2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 60% - task expired",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -777,6 +795,8 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+			handler, receiver, err := blsAggServ.Start()
+			require.NoError(t, err)
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -785,18 +805,18 @@ func TestBlsAgg(t *testing.T) {
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = blsAggServ.InitializeNewTask(metadata)
+			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 			taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-			err = blsAggServ.ProcessNewSignature(
+			err = handler.ProcessNewSignature(
 				context.Background(),
 				taskSignature1,
 			)
 			require.Nil(t, err)
 			blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 			taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-			err = blsAggServ.ProcessNewSignature(
+			err = handler.ProcessNewSignature(
 				context.Background(),
 				taskSignature2,
 			)
@@ -805,7 +825,7 @@ func TestBlsAgg(t *testing.T) {
 			wantAggregationServiceResponse := BlsAggregationServiceResponse{
 				Err: TaskExpiredErrorFn(taskIndex),
 			}
-			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+			gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -829,13 +849,15 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature,
 		)
@@ -844,13 +866,12 @@ func TestBlsAgg(t *testing.T) {
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
-	t.Run(
-		"2 quorums 2 operators, 1 operator which just stake one quorum; 1 signatures - task expired",
+	t.Run("2 quorums 2 operators, 1 operator which just stake one quorum; 1 signatures - task expired",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -879,6 +900,8 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+			handler, receiver, err := blsAggServ.Start()
+			require.NoError(t, err)
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -887,11 +910,11 @@ func TestBlsAgg(t *testing.T) {
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = blsAggServ.InitializeNewTask(metadata)
+			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 			taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-			err = blsAggServ.ProcessNewSignature(
+			err = handler.ProcessNewSignature(
 				context.Background(),
 				taskSignature,
 			)
@@ -900,7 +923,7 @@ func TestBlsAgg(t *testing.T) {
 			wantAggregationServiceResponse := BlsAggregationServiceResponse{
 				Err: TaskExpiredErrorFn(taskIndex),
 			}
-			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+			gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -922,9 +945,11 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, _, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature,
 		)
@@ -933,8 +958,7 @@ func TestBlsAgg(t *testing.T) {
 
 	// this is an edge case as typically we would send new tasks and listen for task responses in a for select loop
 	// but this test makes sure the context deadline exceeded can get us out of a deadlock
-	t.Run(
-		"send new signedTaskDigest before listen on responseChan - context timeout cancels the request to prevent deadlock",
+	t.Run("send new signedTaskDigest before listen on responseChan - context timeout cancels the request to prevent deadlock",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId:     types.OperatorId{1},
@@ -959,6 +983,8 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+			handler, receiver, err := blsAggServ.Start()
+			require.NoError(t, err)
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -967,14 +993,14 @@ func TestBlsAgg(t *testing.T) {
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err := blsAggServ.InitializeNewTask(metadata)
+			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			taskResponse1 := mockTaskResponse{1}
 			taskResponseDigest1, err := hashFunction(taskResponse1)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest1)
 			taskSignature1 := NewTaskSignature(taskIndex, taskResponse1, blsSigOp1, testOperator1.OperatorId)
-			err = blsAggServ.ProcessNewSignature(
+			err = handler.ProcessNewSignature(
 				context.Background(),
 				taskSignature1,
 			)
@@ -987,7 +1013,7 @@ func TestBlsAgg(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 			taskSignature2 := NewTaskSignature(taskIndex, taskResponse2, blsSigOp2, testOperator2.OperatorId)
-			err = blsAggServ.ProcessNewSignature(
+			err = handler.ProcessNewSignature(
 				ctx,
 				taskSignature2,
 			)
@@ -1005,7 +1031,7 @@ func TestBlsAgg(t *testing.T) {
 				SignersApkG2:        testOperator1.BlsKeypair.GetPubKeyG2(),
 				SignersAggSigG1:     testOperator1.BlsKeypair.SignMessage(taskResponseDigest1),
 			}
-			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+			gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 			require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -1035,16 +1061,18 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err := blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		taskResponse1 := mockTaskResponse{1}
 		taskResponseDigest1, err := hashFunction(taskResponse1)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest1)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse1, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
@@ -1054,7 +1082,7 @@ func TestBlsAgg(t *testing.T) {
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest2)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse2, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
@@ -1062,13 +1090,12 @@ func TestBlsAgg(t *testing.T) {
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
-	t.Run(
-		"1 quorum 1 operator 1 invalid signature (TaskResponseDigest does not match TaskResponse)",
+	t.Run("1 quorum 1 operator 1 invalid signature (TaskResponseDigest does not match TaskResponse)",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId:     types.OperatorId{1},
@@ -1092,6 +1119,8 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+			handler, _, err := blsAggServ.Start()
+			require.NoError(t, err)
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -1100,14 +1129,14 @@ func TestBlsAgg(t *testing.T) {
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = blsAggServ.InitializeNewTask(metadata)
+			err = handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
-			err = blsAggServ.ProcessNewSignature(
+			err = handler.ProcessNewSignature(
 				context.Background(),
 				taskSignature,
 			)
-			require.EqualError(t, err, "Signature verification failed. Incorrect Signature.")
+			require.EqualError(t, err, "signature verification failed. incorrect signature")
 		},
 	)
 
@@ -1148,6 +1177,8 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		start := time.Now()
 		metadata := NewTaskMetadata(
@@ -1157,19 +1188,19 @@ func TestBlsAgg(t *testing.T) {
 			quorumThresholdPercentages,
 			tasksTimeToExpiry,
 		).WithWindowDuration(windowDuration)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
@@ -1177,7 +1208,7 @@ func TestBlsAgg(t *testing.T) {
 		require.Nil(t, err)
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature3,
 		)
@@ -1200,7 +1231,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1250,6 +1281,8 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		start := time.Now()
 		metadata := NewTaskMetadata(
@@ -1259,19 +1292,19 @@ func TestBlsAgg(t *testing.T) {
 			quorumThresholdPercentages,
 			timeToExpiry,
 		).WithWindowDuration(windowDuration)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
@@ -1281,7 +1314,7 @@ func TestBlsAgg(t *testing.T) {
 
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature3,
 		)
@@ -1304,7 +1337,7 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1347,6 +1380,8 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(
 			taskIndex,
@@ -1355,21 +1390,21 @@ func TestBlsAgg(t *testing.T) {
 			quorumThresholdPercentages,
 			tasksTimeToExpiry,
 		).WithWindowDuration(windowDuration)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		start := time.Now()
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
@@ -1382,7 +1417,7 @@ func TestBlsAgg(t *testing.T) {
 		defer cancel()
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			ctx,
 			taskSignature3,
 		)
@@ -1403,7 +1438,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1448,6 +1483,8 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		metadata := NewTaskMetadata(
 			taskIndex,
@@ -1456,21 +1493,21 @@ func TestBlsAgg(t *testing.T) {
 			quorumThresholdPercentages,
 			tasksTimeToExpiry,
 		).WithWindowDuration(windowDuration)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		start := time.Now()
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature2,
 		)
@@ -1484,7 +1521,7 @@ func TestBlsAgg(t *testing.T) {
 		defer cancel()
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
 		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			ctx,
 			taskSignature3,
 		)
@@ -1505,7 +1542,7 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		gotAggregationServiceResponse := receiver.ReceiveAggregatedResponse()
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1588,6 +1625,8 @@ func TestIntegrationBlsAgg(t *testing.T) {
 			logger,
 		)
 		blsAggServ := NewBlsAggregatorService(avsRegistryService, hashFunction, logger)
+		handler, receiver, err := blsAggServ.Start()
+		require.NoError(t, err)
 
 		// register operator
 		quorumNumbers := testData.Input.QuorumNumbers
@@ -1620,7 +1659,7 @@ func TestIntegrationBlsAgg(t *testing.T) {
 			quorumThresholdPercentages,
 			tasksTimeToExpiry,
 		)
-		err = blsAggServ.InitializeNewTask(metadata)
+		err = handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		// compute the signature and send it to the aggregation service
@@ -1628,14 +1667,14 @@ func TestIntegrationBlsAgg(t *testing.T) {
 		require.Nil(t, err)
 		blsSig := blsKeyPair.SignMessage(taskResponseDigest)
 		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, operatorId)
-		err = blsAggServ.ProcessNewSignature(
+		err = handler.ProcessNewSignature(
 			context.Background(),
 			taskSignature,
 		)
 		require.Nil(t, err)
 
 		// wait for the response from the aggregation service and check the signature
-		blsAggServiceResp := <-blsAggServ.aggregatedResponsesC
+		blsAggServiceResp := receiver.ReceiveAggregatedResponse()
 
 		avsServiceManager, err := avssm.NewContractMockAvsServiceManager(contractAddrs.ServiceManager, ethHttpClient)
 		require.NoError(t, err)

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients"
 	"github.com/Layr-Labs/eigensdk-go/chainio/utils"
+	avssm "github.com/Layr-Labs/eigensdk-go/contracts/bindings/MockAvsServiceManager"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/services/avsregistry"
@@ -23,8 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
-
-	avssm "github.com/Layr-Labs/eigensdk-go/contracts/bindings/MockAvsServiceManager"
 )
 
 // TestBlsAgg is a suite of test that tests the main aggregation logic of the aggregation service
@@ -81,20 +80,13 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
+		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSig,
-			testOperator1.OperatorId,
+			taskSignature,
 		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
@@ -107,7 +99,8 @@ func TestBlsAgg(t *testing.T) {
 			SignersApkG2:        testOperator1.BlsKeypair.GetPubKeyG2(),
 			SignersAggSigG1:     testOperator1.BlsKeypair.SignMessage(taskResponseDigest),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -115,19 +108,19 @@ func TestBlsAgg(t *testing.T) {
 	t.Run("1 quorum 3 operator 3 correct signatures", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x1"),
 			Socket:         "localhost:8080",
 		}
 		testOperator2 := types.TestOperator{
 			OperatorId:     types.OperatorId{2},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 			Socket:         "localhost:8081",
 		}
 		testOperator3 := types.TestOperator{
 			OperatorId:     types.OperatorId{3},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(300), 1: big.NewInt(100)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(300)},
 			BlsKeypair:     newBlsKeyPairPanics("0x3"),
 			Socket:         "localhost:8082",
 		}
@@ -147,39 +140,28 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		require.Nil(t, err)
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp3,
-			testOperator3.OperatorId,
+			taskSignature3,
 		)
 		require.Nil(t, err)
 
@@ -200,7 +182,8 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
@@ -233,30 +216,21 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		require.Nil(t, err)
 
@@ -278,7 +252,8 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -311,61 +286,43 @@ func TestBlsAgg(t *testing.T) {
 		task1Response := mockTaskResponse{123}
 		task1ResponseDigest, err := hashFunction(task1Response)
 		require.Nil(t, err)
-		err = blsAggServ.InitializeNewTask(
-			task1Index,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata1 := NewTaskMetadata(task1Index, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata1)
 		require.Nil(t, err)
 		task2Index := types.TaskIndex(2)
 		task2Response := mockTaskResponse{234}
 		task2ResponseDigest, err := hashFunction(task2Response)
 		require.Nil(t, err)
-		err = blsAggServ.InitializeNewTask(
-			task2Index,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata2 := NewTaskMetadata(task2Index, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata2)
 		require.Nil(t, err)
 
 		blsSigTask1Op1 := testOperator1.BlsKeypair.SignMessage(task1ResponseDigest)
+		taskSignature1Op1 := NewTaskSignature(task1Index, task1Response, blsSigTask1Op1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			task1Index,
-			task1Response,
-			blsSigTask1Op1,
-			testOperator1.OperatorId,
+			taskSignature1Op1,
 		)
 		require.Nil(t, err)
 		blsSigTask2Op1 := testOperator1.BlsKeypair.SignMessage(task2ResponseDigest)
+		taskSignature2Op1 := NewTaskSignature(task2Index, task2Response, blsSigTask2Op1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			task2Index,
-			task2Response,
-			blsSigTask2Op1,
-			testOperator1.OperatorId,
+			taskSignature2Op1,
 		)
 		require.Nil(t, err)
 		blsSigTask1Op2 := testOperator2.BlsKeypair.SignMessage(task1ResponseDigest)
+		taskSignature1Op2 := NewTaskSignature(task1Index, task1Response, blsSigTask1Op2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			task1Index,
-			task1Response,
-			blsSigTask1Op2,
-			testOperator2.OperatorId,
+			taskSignature1Op2,
 		)
 		require.Nil(t, err)
 		blsSigTask2Op2 := testOperator2.BlsKeypair.SignMessage(task2ResponseDigest)
+		taskSignature2Op2 := NewTaskSignature(task2Index, task2Response, blsSigTask2Op2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			task2Index,
-			task2Response,
-			blsSigTask2Op2,
-			testOperator2.OperatorId,
+			taskSignature2Op2,
 		)
 		require.Nil(t, err)
 
@@ -408,8 +365,10 @@ func TestBlsAgg(t *testing.T) {
 		}
 
 		// we don't know which of task1 or task2 responses will be received first
-		gotAggregationServiceResponseTaskFirstReceived := <-blsAggServ.aggregatedResponsesC
-		gotAggregationServiceResponseTaskSecondReceived := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponseTaskFirstReceived := <-responseChannel
+		responseChannel = blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponseTaskSecondReceived := <-responseChannel
 
 		if gotAggregationServiceResponseTaskFirstReceived.TaskIndex == task1Index {
 			require.EqualValues(t, wantAggregationServiceResponseTask1, gotAggregationServiceResponseTaskFirstReceived)
@@ -448,13 +407,9 @@ func TestBlsAgg(t *testing.T) {
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
 		logger.Info("Initializing new task", "taskIndex", taskIndex)
-		err := blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			10*time.Second, // Longer expiry time for testing
-		)
+		timeToExpire := 10 * time.Second
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, timeToExpire)
+		err := blsAggServ.InitializeNewTask(metadata)
 		require.NoError(t, err)
 
 		taskResponseDigest, err := hashFunction(taskResponse)
@@ -462,23 +417,19 @@ func TestBlsAgg(t *testing.T) {
 
 		logger.Info("Processing first signature", "operatorId", testOperator1.OperatorId)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.NoError(t, err)
 
 		logger.Info("Processing second signature (Operator 1 double sign)", "operatorId", testOperator1.OperatorId)
 		blsSigOp1Dup := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1Dup := NewTaskSignature(taskIndex, taskResponse, blsSigOp1Dup, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1Dup,
-			testOperator1.OperatorId,
+			taskSignature1Dup,
 		)
 
 		if err != nil {
@@ -490,12 +441,10 @@ func TestBlsAgg(t *testing.T) {
 
 		logger.Info("Processing second signature", "operatorId", testOperator2.OperatorId)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		require.NoError(t, err)
 
@@ -513,7 +462,8 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 
 	})
@@ -533,31 +483,27 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err := blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err := blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
 	t.Run("1 quorum 2 operator 1 correct signature quorumThreshold 50% - verified", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x1"),
 			Socket:         "localhost:8080",
 		}
 		testOperator2 := types.TestOperator{
 			OperatorId:     types.OperatorId{2},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 			Socket:         "localhost:8081",
 		}
@@ -577,20 +523,13 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
+		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSig,
-			testOperator1.OperatorId,
+			taskSignature,
 		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
@@ -605,20 +544,21 @@ func TestBlsAgg(t *testing.T) {
 			SignersApkG2:    testOperator1.BlsKeypair.GetPubKeyG2(),
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
 	t.Run("1 quorum 2 operator 1 correct signature quorumThreshold 60% - task expired", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x1"),
 			Socket:         "localhost:8080",
 		}
 		testOperator2 := types.TestOperator{
 			OperatorId:     types.OperatorId{2},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 			Socket:         "localhost:8081",
 		}
@@ -638,26 +578,20 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
+		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSig,
-			testOperator1.OperatorId,
+			taskSignature,
 		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
@@ -691,30 +625,21 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		require.Nil(t, err)
 
@@ -732,12 +657,12 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 	})
 
-	t.Run(
-		"2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 50% - verified",
+	t.Run("2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 50% - verified",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -774,30 +699,27 @@ func TestBlsAgg(t *testing.T) {
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-			err = blsAggServ.InitializeNewTask(
+			metadata := NewTaskMetadata(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
+			err = blsAggServ.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+			taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskIndex,
-				taskResponse,
-				blsSigOp1,
-				testOperator1.OperatorId,
+				taskSignature1,
 			)
 			require.Nil(t, err)
 			blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+			taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskIndex,
-				taskResponse,
-				blsSigOp2,
-				testOperator2.OperatorId,
+				taskSignature2,
 			)
 			require.Nil(t, err)
 
@@ -821,13 +743,13 @@ func TestBlsAgg(t *testing.T) {
 				SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 					Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 			}
-			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+			responseChannel := blsAggServ.GetResponseChannel()
+			gotAggregationServiceResponse := <-responseChannel
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		},
 	)
 
-	t.Run(
-		"2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 60% - task expired",
+	t.Run("2 quorums 3 operators which just stake one quorum; 2 correct signature quorumThreshold 60% - task expired",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -864,37 +786,35 @@ func TestBlsAgg(t *testing.T) {
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-			err = blsAggServ.InitializeNewTask(
+			metadata := NewTaskMetadata(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
+			err = blsAggServ.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+			taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskIndex,
-				taskResponse,
-				blsSigOp1,
-				testOperator1.OperatorId,
+				taskSignature1,
 			)
 			require.Nil(t, err)
 			blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+			taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskIndex,
-				taskResponse,
-				blsSigOp2,
-				testOperator2.OperatorId,
+				taskSignature2,
 			)
 			require.Nil(t, err)
 
 			wantAggregationServiceResponse := BlsAggregationServiceResponse{
 				Err: TaskExpiredErrorFn(taskIndex),
 			}
-			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+			responseChannel := blsAggServ.GetResponseChannel()
+			gotAggregationServiceResponse := <-responseChannel
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -919,34 +839,27 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature,
 		)
 		require.Nil(t, err)
 
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
-	t.Run(
-		"2 quorums 2 operators, 1 operator which just stake one quorum; 1 signatures - task expired",
+	t.Run("2 quorums 2 operators, 1 operator which just stake one quorum; 1 signatures - task expired",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId: types.OperatorId{1},
@@ -976,28 +889,28 @@ func TestBlsAgg(t *testing.T) {
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-			err = blsAggServ.InitializeNewTask(
+			metadata := NewTaskMetadata(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
+			err = blsAggServ.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+			taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskIndex,
-				taskResponse,
-				blsSigOp1,
-				testOperator1.OperatorId,
+				taskSignature,
 			)
 			require.Nil(t, err)
 
 			wantAggregationServiceResponse := BlsAggregationServiceResponse{
 				Err: TaskExpiredErrorFn(taskIndex),
 			}
-			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+			responseChannel := blsAggServ.GetResponseChannel()
+			gotAggregationServiceResponse := <-responseChannel
 			require.EqualValues(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -1020,33 +933,27 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
+		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSig,
-			testOperator1.OperatorId,
+			taskSignature,
 		)
 		require.Equal(t, TaskNotFoundErrorFn(taskIndex), err)
 	})
 
 	// this is an edge case as typically we would send new tasks and listen for task responses in a for select loop
 	// but this test makes sure the context deadline exceeded can get us out of a deadlock
-	t.Run(
-		"send new signedTaskDigest before listen on responseChan - context timeout cancels the request to prevent deadlock",
+	t.Run("send new signedTaskDigest before listen on responseChan - context timeout cancels the request to prevent deadlock",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId:     types.OperatorId{1},
-				StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+				StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 				BlsKeypair:     newBlsKeyPairPanics("0x1"),
 				Socket:         "localhost:8080",
 			}
-			testOperator2 := types.TestOperator{
-				OperatorId:     types.OperatorId{2},
-				StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
-				BlsKeypair:     newBlsKeyPairPanics("0x2"),
-				Socket:         "localhost:8081",
-			}
+			testOperator2OperatorId := types.OperatorId{2}
+			testOperator2BlsKeypair := newBlsKeyPairPanics("0x2")
+
 			blockNum := uint32(1)
 			taskIndex := types.TaskIndex(0)
 			quorumNumbers := types.QuorumNums{0}
@@ -1059,34 +966,37 @@ func TestBlsAgg(t *testing.T) {
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-			err := blsAggServ.InitializeNewTask(
+			metadata := NewTaskMetadata(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
+			err := blsAggServ.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			taskResponse1 := mockTaskResponse{1}
 			taskResponseDigest1, err := hashFunction(taskResponse1)
 			require.Nil(t, err)
 			blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest1)
+			taskSignature1 := NewTaskSignature(taskIndex, taskResponse1, blsSigOp1, testOperator1.OperatorId)
 			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskIndex,
-				taskResponse1,
-				blsSigOp1,
-				testOperator1.OperatorId,
+				taskSignature1,
 			)
 			require.Nil(t, err)
 
 			taskResponse2 := mockTaskResponse{2}
 			taskResponseDigest2, err := hashFunction(taskResponse2)
 			require.Nil(t, err)
-			blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest2)
+			blsSigOp2 := testOperator2BlsKeypair.SignMessage(taskResponseDigest2)
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			err = blsAggServ.ProcessNewSignature(ctx, taskIndex, taskResponse2, blsSigOp2, testOperator2.OperatorId)
+			taskSignature2 := NewTaskSignature(taskIndex, taskResponse2, blsSigOp2, testOperator2OperatorId)
+			err = blsAggServ.ProcessNewSignature(
+				ctx,
+				taskSignature2,
+			)
 			// this should timeout because the task goroutine is blocked on the response channel (since we only listen
 			// for it below)
 			require.Equal(t, context.DeadlineExceeded, err)
@@ -1101,7 +1011,8 @@ func TestBlsAgg(t *testing.T) {
 				SignersApkG2:        testOperator1.BlsKeypair.GetPubKeyG2(),
 				SignersAggSigG1:     testOperator1.BlsKeypair.SignMessage(taskResponseDigest1),
 			}
-			gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+			responseChannel := blsAggServ.GetResponseChannel()
+			gotAggregationServiceResponse := <-responseChannel
 			require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 			require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		},
@@ -1132,48 +1043,39 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err := blsAggServ.InitializeNewTask(
-			taskIndex,
-			blockNum,
-			quorumNumbers,
-			quorumThresholdPercentages,
-			tasksTimeToExpiry,
-		)
+		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
+		err := blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		taskResponse1 := mockTaskResponse{1}
 		taskResponseDigest1, err := hashFunction(taskResponse1)
 		require.Nil(t, err)
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest1)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse1, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse1,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.Nil(t, err)
 		taskResponse2 := mockTaskResponse{2}
 		taskResponseDigest2, err := hashFunction(taskResponse2)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest2)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse2, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse2,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 	})
 
-	t.Run(
-		"1 quorum 1 operator 1 invalid signature (TaskResponseDigest does not match TaskResponse)",
+	t.Run("1 quorum 1 operator 1 invalid signature (TaskResponseDigest does not match TaskResponse)",
 		func(t *testing.T) {
 			testOperator1 := types.TestOperator{
 				OperatorId:     types.OperatorId{1},
@@ -1198,22 +1100,21 @@ func TestBlsAgg(t *testing.T) {
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-			err = blsAggServ.InitializeNewTask(
+			metadata := NewTaskMetadata(
 				taskIndex,
 				blockNum,
 				quorumNumbers,
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
+			err = blsAggServ.InitializeNewTask(metadata)
 			require.Nil(t, err)
+			taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
 			err = blsAggServ.ProcessNewSignature(
 				context.Background(),
-				taskIndex,
-				taskResponse,
-				blsSig,
-				testOperator1.OperatorId,
+				taskSignature,
 			)
-			require.EqualError(t, err, "Signature verification failed. Incorrect Signature.")
+			require.EqualError(t, err, "signature verification failed. incorrect signature")
 		},
 	)
 
@@ -1256,42 +1157,36 @@ func TestBlsAgg(t *testing.T) {
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
 		start := time.Now()
-		err = blsAggServ.InitializeNewTaskWithWindow(
+		metadata := NewTaskMetadata(
 			taskIndex,
 			blockNum,
 			quorumNumbers,
 			quorumThresholdPercentages,
-			timeToExpiry,
-			windowDuration,
-		)
+			tasksTimeToExpiry,
+		).WithWindowDuration(windowDuration)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		// quorum has already been reached, but window should still be open
 		require.Nil(t, err)
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp3,
-			testOperator3.OperatorId,
+			taskSignature3,
 		)
 		require.Nil(t, err)
 
@@ -1312,7 +1207,8 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1328,19 +1224,19 @@ func TestBlsAgg(t *testing.T) {
 	t.Run("if quorum has been reached and the task expires during window, the response is sent", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x1"),
 			Socket:         "localhost:8080",
 		}
 		testOperator2 := types.TestOperator{
 			OperatorId:     types.OperatorId{2},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 			Socket:         "localhost:8081",
 		}
 		testOperator3 := types.TestOperator{
 			OperatorId:     types.OperatorId{3},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(100)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x3"),
 			Socket:         "localhost:8082",
 		}
@@ -1364,44 +1260,38 @@ func TestBlsAgg(t *testing.T) {
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
 		start := time.Now()
-		err = blsAggServ.InitializeNewTaskWithWindow(
+		metadata := NewTaskMetadata(
 			taskIndex,
 			blockNum,
 			quorumNumbers,
 			quorumThresholdPercentages,
 			timeToExpiry,
-			windowDuration,
-		)
+		).WithWindowDuration(windowDuration)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		require.Nil(t, err)
 
 		// quorum has already been reached, window will be open and receiving signature until the task expires
 
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp3,
-			testOperator3.OperatorId,
+			taskSignature3,
 		)
 		require.Nil(t, err)
 
@@ -1422,7 +1312,8 @@ func TestBlsAgg(t *testing.T) {
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)).
 				Add(testOperator3.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1434,17 +1325,17 @@ func TestBlsAgg(t *testing.T) {
 	t.Run("if window duration is zero, no signatures are aggregated after reaching quorum", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x1"),
 		}
 		testOperator2 := types.TestOperator{
 			OperatorId:     types.OperatorId{2},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 		}
 		testOperator3 := types.TestOperator{
 			OperatorId:     types.OperatorId{3},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(100)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x3"),
 		}
 		blockNum := uint32(1)
@@ -1466,34 +1357,30 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTaskWithWindow(
+		metadata := NewTaskMetadata(
 			taskIndex,
 			blockNum,
 			quorumNumbers,
 			quorumThresholdPercentages,
-			timeToExpiry,
-			windowDuration,
-		)
+			tasksTimeToExpiry,
+		).WithWindowDuration(windowDuration)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		start := time.Now()
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		require.Nil(t, err)
 
@@ -1503,12 +1390,10 @@ func TestBlsAgg(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			ctx,
-			taskIndex,
-			taskResponse,
-			blsSigOp3,
-			testOperator3.OperatorId,
+			taskSignature3,
 		)
 		require.Equal(t, context.DeadlineExceeded, err)
 
@@ -1527,7 +1412,8 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1538,19 +1424,19 @@ func TestBlsAgg(t *testing.T) {
 	t.Run("no signatures are aggregated after window", func(t *testing.T) {
 		testOperator1 := types.TestOperator{
 			OperatorId:     types.OperatorId{1},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x1"),
 			Socket:         "localhost:8080",
 		}
 		testOperator2 := types.TestOperator{
 			OperatorId:     types.OperatorId{2},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(200)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x2"),
 			Socket:         "localhost:8081",
 		}
 		testOperator3 := types.TestOperator{
 			OperatorId:     types.OperatorId{3},
-			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100), 1: big.NewInt(100)},
+			StakePerQuorum: map[types.QuorumNum]types.StakeAmount{0: big.NewInt(100)},
 			BlsKeypair:     newBlsKeyPairPanics("0x3"),
 			Socket:         "localhost:8082",
 		}
@@ -1573,34 +1459,30 @@ func TestBlsAgg(t *testing.T) {
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
 
-		err = blsAggServ.InitializeNewTaskWithWindow(
+		metadata := NewTaskMetadata(
 			taskIndex,
 			blockNum,
 			quorumNumbers,
 			quorumThresholdPercentages,
-			timeToExpiry,
-			windowDuration,
-		)
+			tasksTimeToExpiry,
+		).WithWindowDuration(windowDuration)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		start := time.Now()
 
 		blsSigOp1 := testOperator1.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature1 := NewTaskSignature(taskIndex, taskResponse, blsSigOp1, testOperator1.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp1,
-			testOperator1.OperatorId,
+			taskSignature1,
 		)
 		require.Nil(t, err)
 		blsSigOp2 := testOperator2.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature2 := NewTaskSignature(taskIndex, taskResponse, blsSigOp2, testOperator2.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			context.Background(),
-			taskIndex,
-			taskResponse,
-			blsSigOp2,
-			testOperator2.OperatorId,
+			taskSignature2,
 		)
 		require.Nil(t, err)
 
@@ -1611,12 +1493,10 @@ func TestBlsAgg(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		blsSigOp3 := testOperator3.BlsKeypair.SignMessage(taskResponseDigest)
+		taskSignature3 := NewTaskSignature(taskIndex, taskResponse, blsSigOp3, testOperator3.OperatorId)
 		err = blsAggServ.ProcessNewSignature(
 			ctx,
-			taskIndex,
-			taskResponse,
-			blsSigOp3,
-			testOperator3.OperatorId,
+			taskSignature3,
 		)
 		require.Equal(t, context.DeadlineExceeded, err)
 
@@ -1635,7 +1515,8 @@ func TestBlsAgg(t *testing.T) {
 			SignersAggSigG1: testOperator1.BlsKeypair.SignMessage(taskResponseDigest).
 				Add(testOperator2.BlsKeypair.SignMessage(taskResponseDigest)),
 		}
-		gotAggregationServiceResponse := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		gotAggregationServiceResponse := <-responseChannel
 		require.Equal(t, wantAggregationServiceResponse, gotAggregationServiceResponse)
 		require.EqualValues(t, taskIndex, gotAggregationServiceResponse.TaskIndex)
 		elapsed := time.Since(start)
@@ -1667,6 +1548,7 @@ func TestIntegrationBlsAgg(t *testing.T) {
 	anvilWsEndpoint, err := anvilC.Endpoint(context.Background(), "ws")
 	require.NoError(t, err)
 	contractAddrs := testutils.GetContractAddressesFromContractRegistry(anvilHttpEndpoint)
+
 	t.Run("1 quorums 1 operator", func(t *testing.T) {
 		// read input from JSON if available, otherwise use default values
 		var defaultInput = struct {
@@ -1693,7 +1575,7 @@ func TestIntegrationBlsAgg(t *testing.T) {
 		logger := logging.NewTextSLogger(os.Stdout, &logging.SLoggerOptions{Level: slog.LevelDebug})
 		avsClients, err := clients.BuildAll(clients.BuildAllConfig{
 			EthHttpUrl:                 anvilHttpEndpoint,
-			EthWsUrl:                   anvilWsEndpoint, // not used so doesn't matter that we pass an http url
+			EthWsUrl:                   anvilWsEndpoint,
 			RegistryCoordinatorAddr:    contractAddrs.RegistryCoordinator.String(),
 			OperatorStateRetrieverAddr: contractAddrs.OperatorStateRetriever.String(),
 			AvsName:                    "avs",
@@ -1743,24 +1625,30 @@ func TestIntegrationBlsAgg(t *testing.T) {
 		quorumThresholdPercentages := testData.Input.QuorumThresholdPercentages
 
 		// initialize the task
-		err = blsAggServ.InitializeNewTask(
+		metadata := NewTaskMetadata(
 			taskIndex,
-			uint32(referenceBlockNumber),
+			uint32(curBlockNum),
 			quorumNumbers,
 			quorumThresholdPercentages,
 			tasksTimeToExpiry,
 		)
+		err = blsAggServ.InitializeNewTask(metadata)
 		require.Nil(t, err)
 
 		// compute the signature and send it to the aggregation service
 		taskResponseDigest, err := hashFunction(taskResponse)
 		require.Nil(t, err)
 		blsSig := blsKeyPair.SignMessage(taskResponseDigest)
-		err = blsAggServ.ProcessNewSignature(context.Background(), taskIndex, taskResponse, blsSig, operatorId)
+		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, operatorId)
+		err = blsAggServ.ProcessNewSignature(
+			context.Background(),
+			taskSignature,
+		)
 		require.Nil(t, err)
 
 		// wait for the response from the aggregation service and check the signature
-		blsAggServiceResp := <-blsAggServ.aggregatedResponsesC
+		responseChannel := blsAggServ.GetResponseChannel()
+		blsAggServiceResp := <-responseChannel
 
 		avsServiceManager, err := avssm.NewContractMockAvsServiceManager(contractAddrs.ServiceManager, ethHttpClient)
 		require.NoError(t, err)

--- a/services/bls_aggregation/blsagg_test.go
+++ b/services/bls_aggregation/blsagg_test.go
@@ -80,8 +80,7 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -141,8 +140,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -218,8 +216,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -284,8 +281,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		// initialize 2 concurrent tasks
 		task1Index := types.TaskIndex(1)
@@ -409,13 +405,12 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		logger.Info("Initializing new task", "taskIndex", taskIndex)
 		timeToExpire := 10 * time.Second
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, timeToExpire)
-		err = handler.InitializeNewTask(metadata)
+		err := handler.InitializeNewTask(metadata)
 		require.NoError(t, err)
 
 		taskResponseDigest, err := hashFunction(taskResponse)
@@ -487,11 +482,10 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err := handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		wantAggregationServiceResponse := BlsAggregationServiceResponse{
 			Err: TaskExpiredErrorFn(taskIndex),
@@ -528,8 +522,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -584,8 +577,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -632,8 +624,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -707,8 +698,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, receiver, err := blsAggServ.Start()
-			require.NoError(t, err)
+			handler, receiver := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -795,8 +785,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, receiver, err := blsAggServ.Start()
-			require.NoError(t, err)
+			handler, receiver := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -849,8 +838,7 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
 		err = handler.InitializeNewTask(metadata)
@@ -900,8 +888,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, receiver, err := blsAggServ.Start()
-			require.NoError(t, err)
+			handler, receiver := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -945,8 +932,7 @@ func TestBlsAgg(t *testing.T) {
 		fakeAvsRegistryService := avsregistry.NewFakeAvsRegistryService(blockNum, []types.TestOperator{testOperator1})
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, _, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, _ := blsAggServ.Start()
 
 		taskSignature := NewTaskSignature(taskIndex, taskResponse, blsSig, testOperator1.OperatorId)
 		err = handler.ProcessNewSignature(
@@ -984,8 +970,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, receiver, err := blsAggServ.Start()
-			require.NoError(t, err)
+			handler, receiver := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -994,7 +979,7 @@ func TestBlsAgg(t *testing.T) {
 				quorumThresholdPercentages,
 				tasksTimeToExpiry,
 			)
-			err = handler.InitializeNewTask(metadata)
+			err := handler.InitializeNewTask(metadata)
 			require.Nil(t, err)
 			taskResponse1 := mockTaskResponse{1}
 			taskResponseDigest1, err := hashFunction(taskResponse1)
@@ -1062,11 +1047,10 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(taskIndex, blockNum, quorumNumbers, quorumThresholdPercentages, tasksTimeToExpiry)
-		err = handler.InitializeNewTask(metadata)
+		err := handler.InitializeNewTask(metadata)
 		require.Nil(t, err)
 		taskResponse1 := mockTaskResponse{1}
 		taskResponseDigest1, err := hashFunction(taskResponse1)
@@ -1120,8 +1104,7 @@ func TestBlsAgg(t *testing.T) {
 			)
 			logger := testutils.GetTestLogger()
 			blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-			handler, _, err := blsAggServ.Start()
-			require.NoError(t, err)
+			handler, _ := blsAggServ.Start()
 
 			metadata := NewTaskMetadata(
 				taskIndex,
@@ -1178,8 +1161,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		start := time.Now()
 		metadata := NewTaskMetadata(
@@ -1282,8 +1264,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		start := time.Now()
 		metadata := NewTaskMetadata(
@@ -1381,8 +1362,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(
 			taskIndex,
@@ -1484,8 +1464,7 @@ func TestBlsAgg(t *testing.T) {
 		)
 		logger := testutils.GetTestLogger()
 		blsAggServ := NewBlsAggregatorService(fakeAvsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		metadata := NewTaskMetadata(
 			taskIndex,
@@ -1626,8 +1605,7 @@ func TestIntegrationBlsAgg(t *testing.T) {
 			logger,
 		)
 		blsAggServ := NewBlsAggregatorService(avsRegistryService, hashFunction, logger)
-		handler, receiver, err := blsAggServ.Start()
-		require.NoError(t, err)
+		handler, receiver := blsAggServ.Start()
 
 		// register operator
 		quorumNumbers := testData.Input.QuorumNumbers

--- a/types/avs.go
+++ b/types/avs.go
@@ -16,7 +16,7 @@ type SignedTaskResponseDigest struct {
 	TaskResponse                TaskResponse
 	BlsSignature                *bls.Signature
 	OperatorId                  OperatorId
-	SignatureVerificationErrorC chan error `json:"-"` // removed from json because channels are not marshallable
+	SignatureVerificationErrorC chan<- error `json:"-"` // removed from json because channels are not marshallable
 }
 
 func (strd SignedTaskResponseDigest) LogValue() slog.Value {


### PR DESCRIPTION
### What Changed?
This PR changes the bls aggregation service interface to simplify the user experience. The user now interacts with the service handler, receiving the aggregated responses via the Aggregate Receiver, instead of accessing to the service directly.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it