### PR TITLE
feat: add missing option to BuildAllConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 
 ### Added 🎉
 
+* Added field `DontUseAllocationManager` to `BuildAllConfig` in [#580](https://github.com/Layr-Labs/eigensdk-go/pull/580)
+
 ### Changed
 
 * Fixed BLS aggregation for multiple quorums by @TomasArrachea in [#394](https://github.com/Layr-Labs/eigensdk-go/pull/394)

--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -34,6 +34,11 @@ type BuildAllConfig struct {
 
 	/// The address of the ServiceManager contract.
 	ServiceManagerAddress string
+
+	/// Setting this to true will disable the fetching of the AllocationManager address.
+	/// This is useful for older deployments, which don't have the contract deployed.
+	// TODO: remove this once mainnet is updated with the new contracts
+	DontUseAllocationManager bool
 }
 
 // ReadClients is a struct that holds only the read clients for interacting with the AVS and EL contracts.


### PR DESCRIPTION
Fixes # .

### What Changed?

This PR adds a missing field to the `BuildAllConfig` that was previously added to the 2 other `Config` structs.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it