### PR TITLE
fix: propagate DontUseAllocationManager flag between builders configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 
 * Fixed BLS aggregation for multiple quorums by @TomasArrachea in [#394](https://github.com/Layr-Labs/eigensdk-go/pull/394)
 * fix: change requested pr url in changelog's workflow by @maximopalopoli in [#575](https://github.com/Layr-Labs/eigensdk-go/pull/575)
+* fix: propagate DontUseAllocationManager flag between builders configs by @maximopalopoli in [#581](https://github.com/Layr-Labs/eigensdk-go/pull/581)
 
 ### Breaking changes
 

--- a/chainio/clients/avsregistry/builder.go
+++ b/chainio/clients/avsregistry/builder.go
@@ -94,6 +94,7 @@ func BuildClients(
 		elcontracts.Config{
 			DelegationManagerAddress: avsBindings.DelegationManagerAddr,
 			AvsDirectoryAddress:      avsBindings.AvsDirectoryAddr,
+			DontUseAllocationManager: config.DontUseAllocationManager,
 		},
 		client,
 		logger,

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -93,6 +93,7 @@ func NewWriterFromConfig(
 	elReader, err := elcontracts.NewReaderFromConfig(elcontracts.Config{
 		DelegationManagerAddress: bindings.DelegationManagerAddr,
 		AvsDirectoryAddress:      bindings.AvsDirectoryAddr,
+		DontUseAllocationManager: cfg.DontUseAllocationManager,
 	}, client, logger)
 	if err != nil {
 		return nil, err

--- a/chainio/clients/builder.go
+++ b/chainio/clients/builder.go
@@ -187,6 +187,7 @@ func BuildAll(
 	avsCfg := avsregistry.Config{
 		RegistryCoordinatorAddress:    gethcommon.HexToAddress(config.RegistryCoordinatorAddr),
 		OperatorStateRetrieverAddress: gethcommon.HexToAddress(config.OperatorStateRetrieverAddr),
+		DontUseAllocationManager:      config.DontUseAllocationManager,
 	}
 	if config.ServiceManagerAddress != "" {
 		avsCfg.ServiceManagerAddress = gethcommon.HexToAddress(config.ServiceManagerAddress)
@@ -207,6 +208,7 @@ func BuildAll(
 	elcontractsCfg := elcontracts.Config{
 		DelegationManagerAddress: avsRegistryContractBindings.DelegationManagerAddr,
 		AvsDirectoryAddress:      avsRegistryContractBindings.AvsDirectoryAddr,
+		DontUseAllocationManager: config.DontUseAllocationManager,
 	}
 	if config.RewardsCoordinatorAddress != "" {
 		elcontractsCfg.RewardsCoordinatorAddress = gethcommon.HexToAddress(config.RewardsCoordinatorAddress)


### PR DESCRIPTION
### What Changed?
The flag `DontUseAllocationManager` in config variables does not propagate between builders. This means that if a user of SDK sets this attribute as true in the config passed to `BuildClients` function, then this flag is dismissed when creating new config files for creation of avsregistry and elcontracts readers and writers. This PRs changes this by setting those attributes with the value setted on config parameter.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it