### PR TITLE
fix: update broken link ConfigsReadWriter.sol

### DIFF
--- a/contracts/script/parsers/ConfigsReadWriter.sol
+++ b/contracts/script/parsers/ConfigsReadWriter.sol
@@ -8,7 +8,7 @@ import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 
 contract ConfigsReadWriter is Script {
-    // Forge scripts best practice: https://book.getfoundry.sh/tutorials/best-practices#scripts
+    // Forge scripts best practice: https://book.getfoundry.sh/guides/best-practices#scripts
     // inputFileName should not contain the .json extension, we add it automatically
     function readInput(string memory inputFileName) internal view returns (string memory) {
         string memory inputDir = string.concat(vm.projectRoot(), "/script/input/");


### PR DESCRIPTION
I fixes a broken link in the `ConfigsReadWriter.sol` contract. The outdated link to Foundry's best practices for scripts has been updated to the correct URL.
### What Changed?
<!-- Describe the changes made in this pull request -->
- Updated the link from:  
  `https://book.getfoundry.sh/tutorials/best-practices#scripts`  
  to:  
  `https://book.getfoundry.sh/guides/best-practices#scripts`.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it