### PR TITLE
chore: fix function name reference in comment

### DIFF
--- a/metrics/eigenmetrics.go
+++ b/metrics/eigenmetrics.go
@@ -70,7 +70,7 @@ func (m *EigenMetrics) initMetrics() {
 	// them to be 0 on every json-rpc... but is that really necessary?
 }
 
-// AddEigenFeeEarnedTotal adds the fee earned to the total fee earned metric
+// AddFeeEarnedTotal adds the fee earned to the total fee earned metric
 func (m *EigenMetrics) AddFeeEarnedTotal(amount float64, token string) {
 	m.feeEarnedTotal.WithLabelValues(token).Add(amount)
 }


### PR DESCRIPTION
### What Changed?
Noticed a mismatch between the function name and its reference in the comment. The function is called `AddFeeEarnedTotal`, but the comment incorrectly referred to it as `AddEigenFeeEarnedTotal`.
Removed "Eigen" to keep it accurate.

### Reviewer Checklist
- [x] Code is well-documented
- [x] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [x] Code deprecates any old functionality before removing it