### PR TITLE
fix: use getAllocatedStake to get stake regardless of slashability status

### DIFF
--- a/chainio/clients/elcontracts/reader.go
+++ b/chainio/clients/elcontracts/reader.go
@@ -994,18 +994,11 @@ func (r *ChainReader) GetSlashableShares(
 		return nil, errors.New("AllocationManager contract not provided")
 	}
 
-	currentBlock, err := r.ethClient.BlockNumber(ctx)
-	// This call should not fail since it's a getter
-	if err != nil {
-		return nil, err
-	}
-
-	slashableShares, err := r.allocationManager.GetMinimumSlashableStake(
+	slashableShares, err := r.allocationManager.GetAllocatedStake(
 		&bind.CallOpts{Context: ctx},
 		operatorSet,
 		[]gethcommon.Address{operatorAddress},
 		strategies,
-		uint32(currentBlock),
 	)
 	// This call should not fail since it's a getter
 	if err != nil {


### PR DESCRIPTION
We currently use the `getMinimumSlashableStake` function. This method has been updated recently to not return any stake if the operator is not slashable for the operatorSet. Therefore we need to update this to use the `getAllocatedStake` function to get the stake allocated by an operator to an operatorSet regardless of the operator's slashability status.

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it