### PR TITLE
refactor: change `SetAccountIdentifier` -> `SetAvs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,9 @@ Each version will have a separate `Breaking Changes` section as well. To describ
   * To query if an operator is registered to an M2 quorum you should now use `chainReader.IsOperatorRegisteredWithAvs`, which queries the `AVSDirectory`.
 * `egnaddrs` utility now works with slashing release middleware contracts and, in that case, the returned service manager will be the zero address, unless the `--service-manager` is specified.
 
+* Renamed `SetAccountIdentifier` to `SetAvs` [#597](https://github.com/Layr-Labs/eigensdk-go/pull/597)
+  * The underlying call was renamed in [the v1.1.1 eigenlayer-middleware release](https://github.com/Layr-Labs/eigenlayer-middleware/releases/tag/v1.1.1-testnet-slashing).
+
 ### Removed
 * Removed `IsOperatorSetQuorum` method of avsRegistry chain reader by @maximopalopoli in [#585](https://github.com/Layr-Labs/eigensdk-go/pull/585)
   * This function was removed in [the v1.1.1 eigenlayer-middleware release](https://github.com/Layr-Labs/eigenlayer-middleware/releases/tag/v1.1.1-testnet-slashing).

--- a/chainio/clients/avsregistry/writer.go
+++ b/chainio/clients/avsregistry/writer.go
@@ -793,26 +793,26 @@ func (w *ChainWriter) ModifyStrategyParams(
 	return receipt, nil
 }
 
-// Sets the accountIdentifier as the address received as parameter. Identifier should only be set once, since
+// Sets the avs as the address received as parameter. Identifier should only be set once, since
 // changing it could break existing operator sets. Returns the receipt of the transaction in case of success.
-func (w *ChainWriter) SetAccountIdentifier(
+func (w *ChainWriter) SetAvs(
 	ctx context.Context,
-	accountIdentifierAddress gethcommon.Address,
+	avsAddress gethcommon.Address,
 	waitForReceipt bool,
 ) (*gethtypes.Receipt, error) {
-	w.logger.Info("setting account identifier with address ", accountIdentifierAddress)
+	w.logger.Info("setting account identifier with address ", avsAddress)
 
 	noSendTxOpts, err := w.txMgr.GetNoSendTxOpts()
 	if err != nil {
 		return nil, err
 	}
-	tx, err := w.registryCoordinator.SetAVS(noSendTxOpts, accountIdentifierAddress)
+	tx, err := w.registryCoordinator.SetAVS(noSendTxOpts, avsAddress)
 	if err != nil {
 		return nil, err
 	}
 	receipt, err := w.txMgr.Send(ctx, tx, waitForReceipt)
 	if err != nil {
-		return nil, utils.WrapError("failed to send SetAccountIdentifier tx with err", err)
+		return nil, utils.WrapError("failed to send SetAvs tx with err", err)
 	}
 	return receipt, nil
 }

--- a/chainio/clients/avsregistry/writer_test.go
+++ b/chainio/clients/avsregistry/writer_test.go
@@ -665,7 +665,7 @@ func TestSetEjector(t *testing.T) {
 	assert.Equal(t, newEjector.String(), testutils.ANVIL_SECOND_ADDRESS)
 }
 
-func TestSetAccountIdentifier(t *testing.T) {
+func TestSetAvs(t *testing.T) {
 	// Test set up
 	clients, anvilHttpEndpoint := testclients.BuildTestClients(t)
 
@@ -673,7 +673,7 @@ func TestSetAccountIdentifier(t *testing.T) {
 
 	chainWriter := clients.AvsRegistryChainWriter
 
-	accountIdentifierAddress := gethcommon.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
+	avsAddress := gethcommon.HexToAddress(testutils.ANVIL_SECOND_ADDRESS)
 
 	ethHttpClient := clients.EthHttpClient
 
@@ -683,20 +683,20 @@ func TestSetAccountIdentifier(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// At first, accountIdentifier is service manager address
-	accountIdentifier, err := registryCoordinatorContract.Avs(&bind.CallOpts{})
+	// At first, avs is service manager address
+	avs, err := registryCoordinatorContract.Avs(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.Equal(t, accountIdentifier, contractAddrs.ServiceManager)
+	assert.Equal(t, avs, contractAddrs.ServiceManager)
 
-	// Set a new accountIdentifier
-	receipt, err := chainWriter.SetAccountIdentifier(context.Background(), accountIdentifierAddress, true)
+	// Set a new avs
+	receipt, err := chainWriter.SetAvs(context.Background(), avsAddress, true)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, gethtypes.ReceiptStatusSuccessful)
 
-	// After change, accountIdentifier is the value set
-	newAccountIdentifier, err := registryCoordinatorContract.Avs(&bind.CallOpts{})
+	// After change, avs is the value set
+	newavs, err := registryCoordinatorContract.Avs(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.Equal(t, newAccountIdentifier.String(), testutils.ANVIL_SECOND_ADDRESS)
+	assert.Equal(t, newavs.String(), testutils.ANVIL_SECOND_ADDRESS)
 }
 
 func TestRemoveStrategies(t *testing.T) {


### PR DESCRIPTION
Fixes # .

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it