### PR TITLE
chore: fix error comparison with `errors.Is`

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -106,7 +106,7 @@ func ReadPublicURL(url string) ([]byte, error) {
 		// since MaxBytesError has pointer receiver. Not sure what is the correct
 		// way to do this.
 		maxByteErr := http.MaxBytesError{}
-		if err.Error() == maxByteErr.Error() {
+		if errors.Is(err, &http.MaxBytesError{}) {
 			return nil, ErrResponseTooLarge
 		}
 		return nil, err


### PR DESCRIPTION
### What Changed?

I noticed that comparing errors using `err.Error() == maxByteErr.Error()` could be unreliable, as the error message text might change in future Go versions. Replaced the comparison with `errors.Is` to correctly check the error type, ensuring stability across Go updates.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it