### PR TITLE
fix: double send in open window for expired timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 ### Other Changes
 
 * added rewards utilities integration test by @maximopalopoli in [#608](https://github.com/Layr-Labs/eigensdk-go/pull/608)
+* fixed expired timer handling in bls aggregation service in [#616](https://github.com/Layr-Labs/eigensdk-go/pull/616)
 
 ## [0.3.0] - 2025-03-19
 

--- a/services/bls_aggregation/blsagg.go
+++ b/services/bls_aggregation/blsagg.go
@@ -621,11 +621,11 @@ func (a *BlsAggregatorBuilder) singleTaskAggregatorGoroutineFunc(
 					quorumApksG1,
 					aggregatedResponsesC,
 				)
-			}
-
-			aggregatedResponsesC <- BlsAggregationServiceResponse{
-				Err:       TaskExpiredErrorFn(metadata.taskIndex),
-				TaskIndex: metadata.taskIndex,
+			} else {
+				aggregatedResponsesC <- BlsAggregationServiceResponse{
+					Err:       TaskExpiredErrorFn(metadata.taskIndex),
+					TaskIndex: metadata.taskIndex,
+				}
 			}
 			return
 		case <-windowTimer.C:


### PR DESCRIPTION
### What Changed?
This PR fixes a bug that happens when the time expires in the BLS aggregation service, and the open_window variable is set as true. In that case, a message would be sent to the aggregated responses channel sending the response, but after that would be also sent a message error due to the code inside the if not having a return clause. This PR fixes it by making the code below that if (the one sending the error) the else code preventing it from being executed.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it