### PR TITLE
docs: fix "Modules" section in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 
 ### Documentation 📚
 
+* Fixed broken link in documentation and updated "Modules" section in [#641](https://github.com/Layr-Labs/eigensdk-go/pull/641)
+
 ### Other Changes
 
 * added rewards utilities integration test by @maximopalopoli in [#608](https://github.com/Layr-Labs/eigensdk-go/pull/608)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ We support following modules right now.
 > **_NOTE:_** All modules are in active development and interfaces might change.
 
 * [Logging](./logging)
-* [Signer](./signer)
+* [ECDSA Signer](./signerv2)
+* [BLS Signer](./signer)
 * [ChainIO](./chainio)
 * [Services](./services)
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ go get github.com/Layr-Labs/eigensdk-go
 ```
 
 ## Modules
-We support following modules right now. 
-> **_NOTE:_** All modules are in active development and interfaces might change. 
-* [Logging](./logging/README.md)
-* [Signer](./signer/README.md)
-* [ChainIO](./chainio/README.md)
-* [Services](./services/README.md)
+We support following modules right now.
+> **_NOTE:_** All modules are in active development and interfaces might change.
+
+* [Logging](./logging)
+* [Signer](./signer)
+* [ChainIO](./chainio)
+* [Services](./services)
 
 ## Development
 Clone the repo


### PR DESCRIPTION
Supersedes #612

### What Changed?

This PR renames the "Signer" item to "ECDSA Signer" to differentiate from the new "BLS Signer" item. Additionally, it fixes the broken link in the "Modules" section to point to `signerv2`.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it