### PR TITLE
chore(v2): rename task generator to spammer

### DIFF
--- a/examples/aggregator/aggregator_use_example.go
+++ b/examples/aggregator/aggregator_use_example.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/bindings/taskManager"
-	taskgeneratorexample "github.com/Layr-Labs/eigensdk-go/examples/task-generator"
+	taskspammerexample "github.com/Layr-Labs/eigensdk-go/examples/task-spammer"
 	blsagg "github.com/Layr-Labs/eigensdk-go/services/bls_aggregation"
 	sdktypes "github.com/Layr-Labs/eigensdk-go/types"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	txMgr, err := taskgeneratorexample.GetTxManager(logger, ethHttpClient, testutils.ANVIL_FIRST_PRIVATE_KEY)
+	txMgr, err := taskspammerexample.GetTxManager(logger, ethHttpClient, testutils.ANVIL_FIRST_PRIVATE_KEY)
 	if err != nil {
 		return
 	}

--- a/examples/challenger/challenger_use_example.go
+++ b/examples/challenger/challenger_use_example.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/bindings/taskManager"
-	taskgeneratorexample "github.com/Layr-Labs/eigensdk-go/examples/task-generator"
+	taskspammerexample "github.com/Layr-Labs/eigensdk-go/examples/task-spammer"
 )
 
 func main() {
@@ -44,7 +44,7 @@ func main() {
 		EthClient:      ethHttpClient,
 	}
 
-	txMgr, err := taskgeneratorexample.GetTxManager(logger, ethHttpClient, testutils.ANVIL_FIRST_PRIVATE_KEY)
+	txMgr, err := taskspammerexample.GetTxManager(logger, ethHttpClient, testutils.ANVIL_FIRST_PRIVATE_KEY)
 	if err != nil {
 		return
 	}

--- a/examples/task-spammer/task_spammer_use_example.go
+++ b/examples/task-spammer/task_spammer_use_example.go
@@ -1,4 +1,4 @@
-package taskgeneratorexample
+package taskspammerexample
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/bindings/taskManager"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/signerv2"
-	taskgenerator "github.com/Layr-Labs/eigensdk-go/task-generator"
+	taskspammer "github.com/Layr-Labs/eigensdk-go/task-spammer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -23,8 +23,8 @@ func main() {
 		return
 	}
 
-	// This pk should be related to the address passed to TaskManager as task_generator_addr when initialized
-	taskgeneratorPk := "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+	// This pk should be related to the address passed to TaskManager as task_spammer_addr when initialized
+	taskSpammerPk := "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
 
 	ethHttpUrl := "http://localhost:8545"
 	ethHttpClient, err := ethclient.Dial(ethHttpUrl)
@@ -32,7 +32,7 @@ func main() {
 		return
 	}
 
-	txMgr, err := GetTxManager(logger, ethHttpClient, taskgeneratorPk)
+	txMgr, err := GetTxManager(logger, ethHttpClient, taskSpammerPk)
 	if err != nil {
 		return
 	}
@@ -48,14 +48,14 @@ func main() {
 		return
 	}
 
-	taskGeneratorConfig := taskgenerator.Config{
+	taskSpammerConfig := taskspammer.Config{
 		Logger:           logger,
 		TimeBetweenTasks: 10 * time.Second,
 
 		QuorumThresholdPercentage: 100,
 		QuorumNumbers:             []uint8{0},
 	}
-	taskGen, err := taskgenerator.NewTaskGenerator(contractTaskManager, txMgr, taskGeneratorConfig)
+	taskGen, err := taskspammer.NewTaskSpammer(contractTaskManager, txMgr, taskSpammerConfig)
 	if err != nil {
 		return
 	}
@@ -69,8 +69,8 @@ func main() {
 }
 
 // TODO: this should be in the SDK
-func GetTxManager(logger logging.Logger, ethHttpClient *ethclient.Client, taskgeneratorPk string) (*txmgr.SimpleTxManager, error) {
-	ecdsaPrivateKey, err := crypto.HexToECDSA(taskgeneratorPk)
+func GetTxManager(logger logging.Logger, ethHttpClient *ethclient.Client, taskSpammerPk string) (*txmgr.SimpleTxManager, error) {
+	ecdsaPrivateKey, err := crypto.HexToECDSA(taskSpammerPk)
 	if err != nil {
 		return nil, err
 	}

--- a/task-spammer/config.go
+++ b/task-spammer/config.go
@@ -1,4 +1,4 @@
-package taskgenerator
+package taskspammer
 
 import (
 	"time"
@@ -6,9 +6,9 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/logging"
 )
 
-// Task generator configuration struct.
+// Task spammer configuration struct.
 //
-// Contains optional parameters for the task generator.
+// Contains optional parameters for the task spammer.
 // TODO: have default values
 type Config struct {
 	Logger           logging.Logger

--- a/task-spammer/task_spammer.go
+++ b/task-spammer/task_spammer.go
@@ -1,4 +1,4 @@
-package taskgenerator
+package taskspammer
 
 import (
 	"context"
@@ -16,29 +16,29 @@ type TaskManager[Input any] interface {
 	CreateNewTask(opts *bind.TransactOpts, input Input, quorumThresholdPercentage uint32, quorumNumbers []byte) (*gethtypes.Transaction, error)
 }
 
-type TaskGenerator[Input any] struct {
+type TaskSpammer[Input any] struct {
 	taskManager TaskManager[Input]
 	txMgr       txmgr.TxManager
 	config      Config
 }
 
-func NewTaskGenerator[Input any](taskManager TaskManager[Input], txMgr txmgr.TxManager, config Config) (*TaskGenerator[Input], error) {
+func NewTaskSpammer[Input any](taskManager TaskManager[Input], txMgr txmgr.TxManager, config Config) (*TaskSpammer[Input], error) {
 	// TODO: validate config
-	return &TaskGenerator[Input]{
+	return &TaskSpammer[Input]{
 		taskManager,
 		txMgr,
 		config,
 	}, nil
 }
 
-func (taskGen *TaskGenerator[Input]) Start(ctx context.Context, inputGen iter.Seq[Input]) error {
+func (taskGen *TaskSpammer[Input]) Start(ctx context.Context, inputGen iter.Seq[Input]) error {
 	logger := taskGen.config.Logger
 
-	logger.Info("Starting Task Generator.")
+	logger.Info("Starting Task Spammer.")
 
 	ticker := time.NewTicker(taskGen.config.TimeBetweenTasks)
 	defer ticker.Stop()
-	logger.Infof("Task Generator set to send new task every %v seconds...", taskGen.config.TimeBetweenTasks)
+	logger.Infof("Task Spammer set to send new task every %v seconds...", taskGen.config.TimeBetweenTasks)
 
 	taskIndex := int64(0)
 
@@ -48,15 +48,15 @@ func (taskGen *TaskGenerator[Input]) Start(ctx context.Context, inputGen iter.Se
 	for {
 		// Submit new task
 		taskIndex++
-		logger.Infof("Task Generator sending new task, task index: %v", taskIndex)
+		logger.Infof("Task Spammer sending new task, task index: %v", taskIndex)
 		value, ok := nextInput()
 		if !ok {
-			logger.Info("Task Generator finished sending tasks")
+			logger.Info("Task Spammer finished sending tasks")
 			return nil
 		}
 		err := taskGen.CreateNewTask(ctx, value)
 		if err != nil {
-			logger.Error("Task Generator failed to send new task", "err", err)
+			logger.Error("Task Spammer failed to send new task", "err", err)
 			return err
 		}
 
@@ -69,7 +69,7 @@ func (taskGen *TaskGenerator[Input]) Start(ctx context.Context, inputGen iter.Se
 	}
 }
 
-func (taskGen *TaskGenerator[Input]) CreateNewTask(
+func (taskGen *TaskSpammer[Input]) CreateNewTask(
 	ctx context.Context,
 	input Input,
 ) error {


### PR DESCRIPTION
### What Changed?
This PR renames all task generator occurrences to task spammer, including examples.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it