### PR TITLE
feat(v2): simplify operator response calculation function

### DIFF
--- a/examples/operator/operator_use_example.go
+++ b/examples/operator/operator_use_example.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	sdkoperator "github.com/Layr-Labs/eigensdk-go/operator"
-	sdktypes "github.com/Layr-Labs/eigensdk-go/types"
 
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/bindings/taskManager"
 )
@@ -25,15 +24,10 @@ func main() {
 	}
 
 	// This function calculates the task response from a Task, in this case with the number to square
-	responseCalcFunction := func(task sdktypes.GenericInputTask[*big.Int], taskIndex uint32) (sdktypes.GenericOutputTaskResponse[*big.Int], error) {
-		numberSquared := big.NewInt(0).Exp(task.InputValue, big.NewInt(2), nil)
+	responseCalcFunction := func(taskIndex uint32, numberToSquare *big.Int) (*big.Int, error) {
+		numberSquared := big.NewInt(0).Exp(numberToSquare, big.NewInt(2), nil)
 
-		taskResponse := sdktypes.GenericOutputTaskResponse[*big.Int]{
-			ReferenceTaskIndex: taskIndex,
-			OutputValue:        numberSquared,
-		}
-
-		return taskResponse, nil
+		return numberSquared, nil
 	}
 
 	// The values from this config are extracted from an incredible squaring config file:

--- a/examples/operator/operator_use_example.go
+++ b/examples/operator/operator_use_example.go
@@ -23,13 +23,6 @@ func main() {
 		logger.Fatalf(err.Error())
 	}
 
-	// This function calculates the task response from a Task, in this case with the number to square
-	responseCalcFunction := func(taskIndex uint32, numberToSquare *big.Int) (*big.Int, error) {
-		numberSquared := big.NewInt(0).Exp(numberToSquare, big.NewInt(2), nil)
-
-		return numberSquared, nil
-	}
-
 	// The values from this config are extracted from an incredible squaring config file:
 	// https://github.com/Layr-Labs/incredible-squaring-avs/blob/dev/config-files/operator.anvil.yaml
 	operatorConfig := sdkoperator.OperatorConfig{
@@ -45,7 +38,7 @@ func main() {
 		TaskManagerAbi:                taskManagerAbi,
 	}
 
-	operator, err := sdkoperator.NewOperatorFromConfig(operatorConfig, responseCalcFunction, nil)
+	operator, err := sdkoperator.NewOperatorFromConfig(operatorConfig, square, nil)
 	if err != nil {
 		logger.Errorf("Failed to create operator from config: %v", err)
 		return
@@ -56,4 +49,11 @@ func main() {
 		logger.Errorf("Error while running operator: %v", err)
 		return
 	}
+}
+
+// This function computes the square of a number
+func square(taskIndex uint32, numberToSquare *big.Int) (*big.Int, error) {
+	numberSquared := big.NewInt(0).Exp(numberToSquare, big.NewInt(2), nil)
+
+	return numberSquared, nil
 }

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -34,7 +34,7 @@ type Operator[Input any, Output any] struct {
 	taskResponseHashFn    TaskResponseHashFunction[Output]
 }
 
-type ResponseCalculationFunction[Input any, Output any] func(task sdktypes.GenericInputTask[Input], taskIndex uint32) (sdktypes.GenericOutputTaskResponse[Output], error)
+type ResponseCalculationFunction[Input any, Output any] func(taskIndex uint32, input Input) (Output, error)
 
 type TaskResponseHashFunction[Output any] func(taskResponse sdktypes.GenericOutputTaskResponse[Output]) ([32]byte, error)
 
@@ -231,12 +231,15 @@ func (o *Operator[Input, Output]) processNewTaskCreatedLog(
 		"QuorumThresholdPercentage", newTaskCreatedLog.Task.QuorumThresholdPercentage,
 	)
 
-	taskResponse, err := o.responseCalculationFn(newTaskCreatedLog.Task, newTaskIndex)
+	output, err := o.responseCalculationFn(newTaskIndex, newTaskCreatedLog.Task.InputValue)
 	if err != nil {
 		return nil, fmt.Errorf("error calculating task response: %w", err)
 	}
-
-	return &taskResponse, nil
+	taskResponse := &sdktypes.GenericOutputTaskResponse[Output]{
+		ReferenceTaskIndex: newTaskIndex,
+		OutputValue:        output,
+	}
+	return taskResponse, nil
 }
 
 func (o *Operator[Input, Output]) signTaskResponse(


### PR DESCRIPTION
### What Changed?

This PR changes the signature of the operator response calculation function into `(taskIndex, input) -> (output, error)`, removing generic types from it. This means the operator won't be able to use the whole task to compute the output, but this is not something we expect them to do.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it