### PR TITLE
feat(v2): add config option to make operator randomly fail

### DIFF
--- a/operator/config.go
+++ b/operator/config.go
@@ -21,6 +21,10 @@ type OperatorConfig struct {
 
 	RegisterOnStartup bool
 
+	// Percentage chance of randomly failing a task
+	// This is used for testing purposes and defaults to not failing any tasks
+	FailingPercentage uint
+
 	Logger         logging.Logger
 	TaskManagerAbi *abi.ABI
 }

--- a/operator/config.go
+++ b/operator/config.go
@@ -21,10 +21,14 @@ type OperatorConfig struct {
 
 	RegisterOnStartup bool
 
-	// Percentage chance of randomly failing a task
-	// This is used for testing purposes and defaults to not failing any tasks
-	FailingPercentage uint
-
 	Logger         logging.Logger
 	TaskManagerAbi *abi.ABI
+
+	// Testing options for the operator.
+	// These shouldn't be used in production.
+	Testing struct {
+		// Percentage chance of randomly failing a task
+		// This is used for testing purposes and defaults to not failing any tasks
+		FailingPercentage uint
+	}
 }

--- a/operator/config.go
+++ b/operator/config.go
@@ -30,5 +30,8 @@ type OperatorConfig struct {
 		// Percentage chance of randomly failing a task
 		// This is used for testing purposes and defaults to not failing any tasks
 		FailingPercentage uint
+		// Seed used to generate operator failures
+		// Defaults to the current time
+		FailingSeed uint64
 	}
 }

--- a/operator/config.go
+++ b/operator/config.go
@@ -26,7 +26,7 @@ type OperatorConfig struct {
 
 	// Testing options for the operator.
 	// These shouldn't be used in production.
-	Testing struct {
+	TestingOpts struct {
 		// Percentage chance of randomly failing a task
 		// This is used for testing purposes and defaults to not failing any tasks
 		FailingPercentage uint

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -164,8 +164,8 @@ func NewOperatorFromConfig[Input any, Output any](
 		taskResponseHashFn = getDefaultHashFunction[Output](taskResponseType)
 	}
 
-	if c.Testing.FailingPercentage != 0 {
-		failPercentage := c.Testing.FailingPercentage
+	if c.TestingOpts.FailingPercentage != 0 {
+		failPercentage := c.TestingOpts.FailingPercentage
 		if failPercentage > 100 {
 			return nil, fmt.Errorf("failing percentage must be between 0 and 100")
 		}

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"math/rand/v2"
 	"os"
 
 	"github.com/ethereum/go-ethereum"
@@ -79,8 +80,8 @@ func getDefaultHashFunction[Output any](taskResponseType abi.Type) TaskResponseH
 
 func NewOperatorFromConfig[Input any, Output any](
 	c OperatorConfig,
-	ResponseCalculationFn ResponseCalculationFunction[Input, Output],
-	TaskResponseHashFn TaskResponseHashFunction[Output],
+	responseCalculationFn ResponseCalculationFunction[Input, Output],
+	taskResponseHashFn TaskResponseHashFunction[Output],
 ) (*Operator[Input, Output], error) {
 	avs_config := avsregistry.Config{
 		RegistryCoordinatorAddress:    common.HexToAddress(c.AVSRegistryCoordinatorAddress),
@@ -153,14 +154,33 @@ func NewOperatorFromConfig[Input any, Output any](
 		c.Logger.Fatal("error subscribing to newTaskCreated events", "err", err)
 	}
 
-	if TaskResponseHashFn == nil {
+	if taskResponseHashFn == nil {
 		taskResponseType, err := extractTypeFromAbi(c.TaskManagerAbi)
 		if err != nil {
 			c.Logger.Error("Failed to get task response type in default abi.", "err", err)
 			return nil, err
 		}
 
-		TaskResponseHashFn = getDefaultHashFunction[Output](taskResponseType)
+		taskResponseHashFn = getDefaultHashFunction[Output](taskResponseType)
+	}
+
+	if c.FailingPercentage != 0 {
+		if c.FailingPercentage > 100 {
+			return nil, fmt.Errorf("failing percentage must be between 0 and 100")
+		}
+		computeOutput := responseCalculationFn
+		// TODO: allow users to set the seed
+		rng := rand.New(rand.NewChaCha8([32]byte{}))
+
+		// TODO: allow users to specify the failed values
+		responseCalculationFn = func(taskIndex uint32, input Input) (Output, error) {
+			randomNumber := rng.UintN(100)
+			if randomNumber < c.FailingPercentage {
+				var emptyOutput Output
+				return emptyOutput, nil
+			}
+			return computeOutput(taskIndex, input)
+		}
 	}
 
 	operator := &Operator[Input, Output]{
@@ -170,8 +190,8 @@ func NewOperatorFromConfig[Input any, Output any](
 		operatorId:            operatorId,
 		newTaskCreatedLogs:    newTaskCreatedLogs,
 		taskManagerAbi:        c.TaskManagerAbi,
-		responseCalculationFn: ResponseCalculationFn,
-		taskResponseHashFn:    TaskResponseHashFn,
+		responseCalculationFn: responseCalculationFn,
+		taskResponseHashFn:    taskResponseHashFn,
 	}
 
 	c.Logger.Info("Operator info",

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"math/rand/v2"
 	"os"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -169,12 +170,18 @@ func NewOperatorFromConfig[Input any, Output any](
 		if failPercentage > 100 {
 			return nil, fmt.Errorf("failing percentage must be between 0 and 100")
 		}
-		c.Logger.Warn("FailingPercentage option was set. This operator will randomly fail tasks.")
 		computeOutput := responseCalculationFn
-		// TODO: allow users to set the seed
-		rng := rand.New(rand.NewChaCha8([32]byte{}))
 
-		// TODO: allow users to specify the failed values
+		failSeed := c.TestingOpts.FailingSeed
+		if failSeed == 0 {
+			// If the seed is not set, we use the current time as the seed
+			failSeed = uint64(time.Now().UnixNano())
+		}
+		rng := rand.New(rand.NewPCG(42, failSeed))
+
+		c.Logger.Warn("FailingPercentage option was set. This operator will randomly fail tasks.")
+		c.Logger.Info("Using seed:", failSeed)
+
 		responseCalculationFn = func(taskIndex uint32, input Input) (Output, error) {
 			randomNumber := rng.UintN(100)
 			if randomNumber < failPercentage {

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -164,10 +164,12 @@ func NewOperatorFromConfig[Input any, Output any](
 		taskResponseHashFn = getDefaultHashFunction[Output](taskResponseType)
 	}
 
-	if c.FailingPercentage != 0 {
-		if c.FailingPercentage > 100 {
+	if c.Testing.FailingPercentage != 0 {
+		failPercentage := c.Testing.FailingPercentage
+		if failPercentage > 100 {
 			return nil, fmt.Errorf("failing percentage must be between 0 and 100")
 		}
+		c.Logger.Warn("FailingPercentage option was set. This operator will randomly fail tasks.")
 		computeOutput := responseCalculationFn
 		// TODO: allow users to set the seed
 		rng := rand.New(rand.NewChaCha8([32]byte{}))
@@ -175,7 +177,7 @@ func NewOperatorFromConfig[Input any, Output any](
 		// TODO: allow users to specify the failed values
 		responseCalculationFn = func(taskIndex uint32, input Input) (Output, error) {
 			randomNumber := rng.UintN(100)
-			if randomNumber < c.FailingPercentage {
+			if randomNumber < failPercentage {
 				var emptyOutput Output
 				return emptyOutput, nil
 			}


### PR DESCRIPTION
### What Changed?

This PR adds the `FailingPercentage` config option, to allow users to make the operator randomly fail.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it