### PR TITLE
feat(v2): add function to create a `SimpleTxManager` from a private key

### DIFF
--- a/chainio/txmgr/simple.go
+++ b/chainio/txmgr/simple.go
@@ -75,7 +75,7 @@ func NewSimpleTxManagerFromPrivateKey(
 	}
 
 	signerV2, senderAddr, err := signerv2.SignerFromConfig(signerv2.Config{PrivateKey: privateKey}, chainid)
-	// This should never happen
+	// This can only happen if privateKey is nil
 	if err != nil {
 		return nil, utils.WrapError("could not create signer", err)
 	}

--- a/chainio/txmgr/simple.go
+++ b/chainio/txmgr/simple.go
@@ -2,18 +2,21 @@ package txmgr
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"errors"
 	"math/big"
 	"time"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/Layr-Labs/eigensdk-go/signerv2"
 	"github.com/Layr-Labs/eigensdk-go/utils"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -41,7 +44,7 @@ type SimpleTxManager struct {
 
 var _ TxManager = (*SimpleTxManager)(nil)
 
-// NewSimpleTxManager creates a new simpleTxManager which can be used
+// Creates a new simpleTxManager which can be used
 // to send a transaction to smart contracts on the Ethereum node
 func NewSimpleTxManager(
 	wallet wallet.Wallet,
@@ -56,6 +59,32 @@ func NewSimpleTxManager(
 		sender:             sender,
 		gasLimitMultiplier: FallbackGasLimitMultiplier,
 	}
+}
+
+// Creates a new simpleTxManager from an ECDSA private key
+func NewSimpleTxManagerFromPrivateKey(
+	logger logging.Logger,
+	ethClient *ethclient.Client,
+	privateKey *ecdsa.PrivateKey,
+) (*SimpleTxManager, error) {
+	rpcCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	chainid, err := ethClient.ChainID(rpcCtx)
+	if err != nil {
+		return nil, utils.WrapError("cannot get chain id for signer", err)
+	}
+
+	signerV2, senderAddr, err := signerv2.SignerFromConfig(signerv2.Config{PrivateKey: privateKey}, chainid)
+	// This should never happen
+	if err != nil {
+		return nil, utils.WrapError("could not create signer", err)
+	}
+
+	pkWallet, err := wallet.NewPrivateKeyWallet(ethClient, signerV2, senderAddr, logger)
+	if err != nil {
+		return nil, utils.WrapError("could not create wallet", err)
+	}
+	return NewSimpleTxManager(pkWallet, ethClient, logger, senderAddr), nil
 }
 
 func (m *SimpleTxManager) WithGasLimitMultiplier(multiplier float64) *SimpleTxManager {

--- a/examples/aggregator/aggregator_use_example.go
+++ b/examples/aggregator/aggregator_use_example.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/Layr-Labs/eigensdk-go/aggregator"
+	"github.com/Layr-Labs/eigensdk-go/chainio/txmgr"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	taskprocessor "github.com/Layr-Labs/eigensdk-go/task-processor"
 	"github.com/Layr-Labs/eigensdk-go/testutils"
@@ -13,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/bindings/taskManager"
-	taskspammerexample "github.com/Layr-Labs/eigensdk-go/examples/task-spammer"
 )
 
 func main() {
@@ -29,14 +29,15 @@ func main() {
 		return
 	}
 
-	txMgr, err := taskspammerexample.GetTxManager(logger, ethHttpClient, testutils.ANVIL_FIRST_PRIVATE_KEY)
-	if err != nil {
-		return
-	}
-
 	ecdsaPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
 	if err != nil {
 		logger.Errorf("Cannot parse ecdsa private key", "err", err)
+		return
+	}
+
+	txMgr, err := txmgr.NewSimpleTxManagerFromPrivateKey(logger, ethHttpClient, ecdsaPrivateKey)
+	if err != nil {
+		logger.Errorf("Failed to create transaction manager", "err", err)
 		return
 	}
 

--- a/examples/challenger/challenger_use_example.go
+++ b/examples/challenger/challenger_use_example.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/bindings/taskManager"
-	taskspammerexample "github.com/Layr-Labs/eigensdk-go/examples/task-spammer"
 )
 
 func main() {
@@ -44,8 +44,15 @@ func main() {
 		EthClient:      ethHttpClient,
 	}
 
-	txMgr, err := taskspammerexample.GetTxManager(logger, ethHttpClient, testutils.ANVIL_FIRST_PRIVATE_KEY)
+	ecdsaPrivateKey, err := crypto.HexToECDSA(testutils.ANVIL_FIRST_PRIVATE_KEY)
 	if err != nil {
+		logger.Errorf("Cannot parse ecdsa private key", "err", err)
+		return
+	}
+
+	txMgr, err := txmgr.NewSimpleTxManagerFromPrivateKey(logger, ethHttpClient, ecdsaPrivateKey)
+	if err != nil {
+		logger.Errorf("Failed to create transaction manager", "err", err)
 		return
 	}
 

--- a/examples/task-spammer/task_spammer_use_example.go
+++ b/examples/task-spammer/task_spammer_use_example.go
@@ -6,11 +6,9 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
 	"github.com/Layr-Labs/eigensdk-go/chainio/txmgr"
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/bindings/taskManager"
 	"github.com/Layr-Labs/eigensdk-go/logging"
-	"github.com/Layr-Labs/eigensdk-go/signerv2"
 	taskspammer "github.com/Layr-Labs/eigensdk-go/task-spammer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -32,7 +30,12 @@ func main() {
 		return
 	}
 
-	txMgr, err := GetTxManager(logger, ethHttpClient, taskSpammerPk)
+	ecdsaPrivateKey, err := crypto.HexToECDSA(taskSpammerPk)
+	if err != nil {
+		return
+	}
+
+	txMgr, err := txmgr.NewSimpleTxManagerFromPrivateKey(logger, ethHttpClient, ecdsaPrivateKey)
 	if err != nil {
 		return
 	}
@@ -84,33 +87,4 @@ func NewNumberToSquareSequence() iter.Seq[*big.Int] {
 			acc.Add(acc, delta)
 		}
 	}
-}
-
-// TODO: this should be in the SDK
-func GetTxManager(logger logging.Logger, ethHttpClient *ethclient.Client, taskSpammerPk string) (*txmgr.SimpleTxManager, error) {
-	ecdsaPrivateKey, err := crypto.HexToECDSA(taskSpammerPk)
-	if err != nil {
-		return nil, err
-	}
-
-	rpcCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	chainid, err := ethHttpClient.ChainID(rpcCtx)
-	if err != nil {
-		logger.Error("Cannot get chain id", "err", err)
-		return nil, err
-	}
-
-	signerV2, senderAddr, err := signerv2.SignerFromConfig(signerv2.Config{PrivateKey: ecdsaPrivateKey}, chainid)
-	if err != nil {
-		return nil, err
-	}
-
-	pkWallet, err := wallet.NewPrivateKeyWallet(ethHttpClient, signerV2, senderAddr, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	txMgr := txmgr.NewSimpleTxManager(pkWallet, ethHttpClient, logger, senderAddr)
-	return txMgr, nil
 }


### PR DESCRIPTION
### What Changed?

This PR adds a function `NewSimpleTxManagerFromPrivateKey` to create a `TxManager` from an ECDSA private key. This removes some boilerplate when trying to create a `TxManager` for other functions of the SDK.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it