### PR TITLE
fix(v2): challenger response validation interpretation

### DIFF
--- a/challenger/challenger-processor/challenger_task_processor.go
+++ b/challenger/challenger-processor/challenger_task_processor.go
@@ -47,13 +47,13 @@ func (icp IndexingChallengerProcessor[Input, Output]) ProcessTaskResponded(taskI
 		return fmt.Errorf("could not find the task for the received task index")
 	}
 
-	shouldRaiseChallenge, err := icp.responseValidationFn(taskIndex, task.InputValue, taskResponse.TaskResponse.OutputValue)
+	isResponseCorrect, err := icp.responseValidationFn(taskIndex, task.InputValue, taskResponse.TaskResponse.OutputValue)
 	if err != nil {
 		icp.logger.Errorf("Failure while validating response. Err: %w", err)
 		return err
 	}
 
-	if shouldRaiseChallenge {
+	if !isResponseCorrect {
 		icp.logger.Infof("Response was not correct, input was %v and output was %v", task.InputValue, taskResponse.TaskResponse.OutputValue)
 
 		err = icp.challengerRaiser.RaiseChallenge(task, taskResponse.TaskResponse, taskResponse.TaskResponseMetadata, taskResponse.NonSigningOperatorPubKeys)
@@ -68,7 +68,7 @@ func (icp IndexingChallengerProcessor[Input, Output]) ProcessTaskResponded(taskI
 
 // Takes a ResponseCalculator and an Equal function.
 // Returns a function that receives a task input and output, calculates the expected
-// output using the ResponseCalculator and returns whether is different to the given output,
+// output using the ResponseCalculator and returns whether is equal to the given output,
 // using the given Equal function.
 func ResponseValidationFunctionFromResponseCalculator[Input any, Output any](
 	responseCalculator operator.ResponseCalculator[Input, Output],
@@ -79,6 +79,6 @@ func ResponseValidationFunctionFromResponseCalculator[Input any, Output any](
 		if err != nil {
 			return false, utils.WrapError("failed to compute response", err)
 		}
-		return !equalFn(computedResponse, output), nil
+		return equalFn(computedResponse, output), nil
 	}
 }

--- a/challenger/challenger-processor/challenger_task_processor.go
+++ b/challenger/challenger-processor/challenger_task_processor.go
@@ -68,7 +68,7 @@ func (icp IndexingChallengerProcessor[Input, Output]) ProcessTaskResponded(taskI
 
 // Takes a ResponseCalculator and an Equal function.
 // Returns a function that receives a task input and output, calculates the expected
-// output using the ResponseCalculator and returns whether is equal to the given output,
+// output using the ResponseCalculator and returns whether it is equal to the given output,
 // using the given Equal function.
 func ResponseValidationFunctionFromResponseCalculator[Input any, Output any](
 	responseCalculator operator.ResponseCalculator[Input, Output],


### PR DESCRIPTION
### What Changed?
This PR changes the challenger response validation function to return whether the response is correct, instead of returning whether the response is wrong, to match the Rust implementation.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it