### PR TITLE
docs(v2): `operator`

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -22,7 +22,7 @@ The Operator functions through the following flow:
    - Creates a `SignedTaskResponse` containing the result, signature, and operator ID
 
 4. **Response Submission**:
-   - Sends the signed response to an Aggregator service through a RPC request.
+   - Sends the signed response to an Aggregator service through an RPC request.
 
 ## How to Set Up an Operator
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -75,7 +75,7 @@ The Operator functions through the following flow:
         }
       ```
 
-4. **Response Calculator**: To abstract your computation into the operator, we provide a `ResponseCalculator` interface with a standar `functionResponseCalculator` struct. This struct implements the interface and a helper method for turning your function into `functionResponseCalculator`:
+4. **Response Calculator**: To abstract your computation into the operator, we provide a `ResponseCalculator` interface with a standard `functionResponseCalculator` struct. This struct implements the interface and a helper method for turning your function into `functionResponseCalculator`:
    - `NewFunctionResponseCalculator`: Create a response calculator from your computation function.
 
       ```go

--- a/operator/README.md
+++ b/operator/README.md
@@ -1,0 +1,115 @@
+# Operator
+
+## What is an Operator
+
+Operators are off-chain nodes that perform, sign, and submit verifiable computations for Autonomous Verifiable Services (AVSs) using Ethereum restaking for security. They first register on EigenLayer’s core contracts, then opt-in to provide a range of services to AVSs. Operators listen for new task events, execute the supplied computation logic, cryptographically sign the results with `BLS/ECDSA` keys, and finally send the proofs to an aggregator for final consolidation.
+
+## How the Logic Works
+
+The Operator functions through the following flow:
+
+1. **Task Subscription**:
+   - The operator subscribes to specific event signatures emitted by task processors
+   - Uses WebSocket connection to listen to blockchain events
+   - Filters only for the specific task type it's designed to handle
+
+2. **Task Processing**:
+   - When a new task is detected, it extracts the task index and input data
+   - Applies a computation function to the input data. This computation function is provided when creating the operator.
+
+3. **Response Signing**:
+   - Signs the computed result using the operator's BLS Key Pair.
+   - Creates a `SignedTaskResponse` containing the result, signature, and operator ID
+
+4. **Response Submission**:
+   - Sends the signed response to an Aggregator service through a RPC request.
+
+## How to Set Up an Operator
+
+1. **Task Manager ABI**: Get the ABI of the task manager from your bindings.
+   
+   ```go
+      taskManagerAbi, err := cstaskmanager.ContractIncredibleSquaringTaskManagerMetaData.GetAbi()
+   ```
+
+2. **Create the operator configuration**: Create a `operator.Config` struct
+    - By default, the operator will try to register itself to EigenLayer using the values of `operator.RegistrationConfig` struct. If you don't want to register the operator, do not set the `RegistrationCfg` field.
+    - Config fields:
+      - `OperatorAddress`: The address of the operator
+      - `OperatorStateRetrieverAddress`: The address of the operator state retriever
+      - `ServiceManagerAddress`: The address of the service manager
+      - `AVSRegistryCoordinatorAddress`: The address of the AVS registry coordinator
+      - `EthRpcUrl`: The URL of the Ethereum RPC
+      - `EthWsUrl`: The URL of the Ethereum WebSocket
+      - `BlsPrivateKeyStorePath`: The path to the BLS private key store
+      - `AggregatorServerIpPortAddress`: The IP and port of the aggregator
+      - `Logger`: The logger
+      - `TaskManagerAbi`: The ABI of the task manager
+      - `RegistrationCfg`: The registration configuration
+
+      ```go
+          operatorConfig := operator.Config{
+            OperatorAddress:               "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            OperatorStateRetrieverAddress: "0x4c5859f0f772848b2d91f1d83e2fe57935348029",
+            ServiceManagerAddress:         "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154",
+            AVSRegistryCoordinatorAddress: "0x7bc06c482dead17c0e297afbc32f6e63d3846650",
+            EthRpcUrl:                     "http://localhost:8545",
+            EthWsUrl:                      "ws://localhost:8545",
+            BlsPrivateKeyStorePath:        "keys/test.bls.key.json",
+            AggregatorServerIpPortAddress: "localhost:8090",
+            Logger:                        logger,
+            TaskManagerAbi:                taskManagerAbi,
+            RegistrationCfg:               registrationConfig,
+          }
+      ```
+
+3. **Processing Logic**: Implement the computation function that processes task inputs and produces outputs
+   - This function will be called when the operator receives a `"NewTaskCreated"` event.
+
+      ```go
+        func square(taskIndex uint32, numberToSquare *big.Int) (*big.Int, error) {
+          numberSquared := big.NewInt(0).Exp(numberToSquare, big.NewInt(2), nil)
+
+          return numberSquared, nil
+        }
+      ```
+
+4. **Response Calculator**: To abstract your computation into the operator, we provide a `ResponseCalculator` interface with a standar `functionResponseCalculator` struct. This struct implements the interface and a helper method for turning your function into `functionResponseCalculator`:
+   - `NewFunctionResponseCalculator`: Create a response calculator from your computation function.
+
+      ```go
+          calculator := operator.NewFunctionResponseCalculator(square)
+      ```
+
+   - In case you need to save state in the operator, you can use your own struct implementing the `ResponseCalculator` interface.
+
+5. **Failing Response Calculator**: If you want to test what happens when the operator responds incorrectly to a task and see how slashing works, you can wrap your logic with `NewFailingResponseCalculator` method to inject failures and a given failure rate. **Use this for testing purposes only.**
+    
+    ```go
+        logic, err := operator.NewFailingResponseCalculator(calculator, 50, big.NewInt(0))
+    ```
+
+6. **Run the operator**: Initialize the `Operator` with the configuration and the processing logic. Then start the operator.
+
+    ```go
+        operator, err := operator.NewOperatorFromConfig(operatorConfig, logic, nil)
+        if err != nil {
+          logger.Errorf("Failed to create operator from config: %v", err)
+          return
+        }
+
+        err = operator.Start(context.Background())
+        if err != nil {
+          logger.Errorf("Error while running operator: %v", err)
+          return
+        }
+    ```
+
+## Examples
+
+Here are some examples of operators that are already implemented:
+
+- [Incredible Squaring](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-1/examples/incredible-squaring/operator/main.go)
+- [Incredible Dot Product](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-1/examples/incredible-dot-product/operator/main.go)
+- [Awesome Vault Service](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-1/examples/awesome-vault-service/operator/main.go)
+

--- a/operator/README.md
+++ b/operator/README.md
@@ -33,7 +33,8 @@ The Operator functions through the following flow:
    ```
 
 2. **Create the operator configuration**: Create a `operator.Config` struct
-    - By default, the operator will try to register itself to EigenLayer using the values of `operator.RegistrationConfig` struct. If you don't want to register the operator, do not set the `RegistrationCfg` field.
+    - By default, the operator attempts to register itself to EigenLayer using the values provided in the `operator.RegistrationConfig` struct. To skip automatic registration, leave the `RegistrationCfg` field unset, but make sure the operator is already registered to EigenLayer.
+
     - Config fields:
       - `OperatorAddress`: The address of the operator
       - `OperatorStateRetrieverAddress`: The address of the operator state retriever
@@ -63,7 +64,7 @@ The Operator functions through the following flow:
           }
       ```
 
-3. **Processing Logic**: Implement the computation function that processes task inputs and produces outputs
+1. **Processing Logic**: Implement the computation function that processes task inputs and produces outputs
    - This function will be called when the operator receives a `"NewTaskCreated"` event.
 
       ```go
@@ -74,7 +75,7 @@ The Operator functions through the following flow:
         }
       ```
 
-4. **Response Calculator**: To abstract your computation into the operator, we provide a `ResponseCalculator` interface with a standar `functionResponseCalculator` struct. This struct implements the interface and a helper method for turning your function into `functionResponseCalculator`:
+2. **Response Calculator**: To abstract your computation into the operator, we provide a `ResponseCalculator` interface with a standar `functionResponseCalculator` struct. This struct implements the interface and a helper method for turning your function into `functionResponseCalculator`:
    - `NewFunctionResponseCalculator`: Create a response calculator from your computation function.
 
       ```go
@@ -83,13 +84,13 @@ The Operator functions through the following flow:
 
    - In case you need to save state in the operator, you can use your own struct implementing the `ResponseCalculator` interface.
 
-5. **Failing Response Calculator**: If you want to test what happens when the operator responds incorrectly to a task and see how slashing works, you can wrap your logic with `NewFailingResponseCalculator` method to inject failures and a given failure rate. **Use this for testing purposes only.**
+3. **Failing Response Calculator**: If you want to test what happens when the operator responds incorrectly to a task and see how slashing works, you can wrap your logic with `NewFailingResponseCalculator` method to inject failures and a given failure rate. **Use this for testing purposes only.**
     
     ```go
         logic, err := operator.NewFailingResponseCalculator(calculator, 50, big.NewInt(0))
     ```
 
-6. **Run the operator**: Initialize the `Operator` with the configuration and the processing logic. Then start the operator.
+4. **Run the operator**: Initialize the `Operator` with the configuration and the processing logic. Then start the operator.
 
     ```go
         operator, err := operator.NewOperatorFromConfig(operatorConfig, logic, nil)

--- a/operator/README.md
+++ b/operator/README.md
@@ -33,8 +33,6 @@ The Operator functions through the following flow:
    ```
 
 2. **Create the operator configuration**: Create a `operator.Config` struct
-    - By default, the operator attempts to register itself to EigenLayer using the values provided in the `operator.RegistrationConfig` struct. To skip automatic registration, leave the `RegistrationCfg` field unset, but make sure the operator is already registered to EigenLayer.
-
     - Config fields:
       - `OperatorAddress`: The address of the operator
       - `OperatorStateRetrieverAddress`: The address of the operator state retriever

--- a/operator/README.md
+++ b/operator/README.md
@@ -46,7 +46,7 @@ The Operator functions through the following flow:
       - `AggregatorServerIpPortAddress`: The IP and port of the aggregator
       - `Logger`: The logger
       - `TaskManagerAbi`: The ABI of the task manager
-      - `RegistrationCfg`: The registration configuration
+      - `RegistrationCfg`: The registration configuration. If `RegistrationCfg.RegisterOnStartup` is `true`, the operator attempts to register itself to EigenLayer using the values provided here. To skip automatic registration, leave this field unset (or set `RegistrationCfg.RegisterOnStartup` to `false`), but note that this requires the operator to be already registered to EigenLayer.
 
       ```go
           operatorConfig := operator.Config{

--- a/operator/README.md
+++ b/operator/README.md
@@ -64,7 +64,7 @@ The Operator functions through the following flow:
           }
       ```
 
-1. **Processing Logic**: Implement the computation function that processes task inputs and produces outputs
+3. **Processing Logic**: Implement the computation function that processes task inputs and produces outputs
    - This function will be called when the operator receives a `"NewTaskCreated"` event.
 
       ```go
@@ -75,7 +75,7 @@ The Operator functions through the following flow:
         }
       ```
 
-2. **Response Calculator**: To abstract your computation into the operator, we provide a `ResponseCalculator` interface with a standar `functionResponseCalculator` struct. This struct implements the interface and a helper method for turning your function into `functionResponseCalculator`:
+4. **Response Calculator**: To abstract your computation into the operator, we provide a `ResponseCalculator` interface with a standar `functionResponseCalculator` struct. This struct implements the interface and a helper method for turning your function into `functionResponseCalculator`:
    - `NewFunctionResponseCalculator`: Create a response calculator from your computation function.
 
       ```go
@@ -84,13 +84,13 @@ The Operator functions through the following flow:
 
    - In case you need to save state in the operator, you can use your own struct implementing the `ResponseCalculator` interface.
 
-3. **Failing Response Calculator**: If you want to test what happens when the operator responds incorrectly to a task and see how slashing works, you can wrap your logic with `NewFailingResponseCalculator` method to inject failures and a given failure rate. **Use this for testing purposes only.**
+5. **Failing Response Calculator**: If you want to test what happens when the operator responds incorrectly to a task and see how slashing works, you can wrap your logic with `NewFailingResponseCalculator` method to inject failures and a given failure rate. **Use this for testing purposes only.**
     
     ```go
         logic, err := operator.NewFailingResponseCalculator(calculator, 50, big.NewInt(0))
     ```
 
-4. **Run the operator**: Initialize the `Operator` with the configuration and the processing logic. Then start the operator.
+6. **Run the operator**: Initialize the `Operator` with the configuration and the processing logic. Then start the operator.
 
     ```go
         operator, err := operator.NewOperatorFromConfig(operatorConfig, logic, nil)


### PR DESCRIPTION
### What Changed?
This PR adds a README to the operator package.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it