### PR TITLE
fix: avoid building all clients on aggregator

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 
-	sdkclients "github.com/Layr-Labs/eigensdk-go/chainio/clients"
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	avsregistryservice "github.com/Layr-Labs/eigensdk-go/services/avsregistry"
 	blsagg "github.com/Layr-Labs/eigensdk-go/services/bls_aggregation"
 	oprsinfoserv "github.com/Layr-Labs/eigensdk-go/services/operatorsinfo"
@@ -54,26 +54,35 @@ func NewAggregator[Input any, Output any](
 	taskProcessor taskprocessor.TaskProcessor[Input, Output],
 	taskManagerAbi *abi.ABI,
 ) (*Aggregator[Input, Output], error) {
-	chainioConfig := sdkclients.BuildAllConfig{
-		EthHttpUrl:                 c.EthHttpUrl,
-		EthWsUrl:                   c.EthWsUrl,
-		RegistryCoordinatorAddr:    c.RegistryCoordinatorAddress.String(),
-		OperatorStateRetrieverAddr: c.OperatorStateRetrieverAddress.String(),
-		AvsName:                    "Aggregator",
-		PromMetricsIpPortAddress:   ":9090",
-		DontUseAllocationManager:   true,
+	avsRegistryConfig := avsregistry.Config{
+		RegistryCoordinatorAddress:    c.RegistryCoordinatorAddress,
+		OperatorStateRetrieverAddress: c.OperatorStateRetrieverAddress,
 	}
 
-	clients, err := sdkclients.BuildAll(chainioConfig, c.EcdsaPrivateKey, logger)
+	wsClient, err := ethclient.Dial(c.EthWsUrl)
 	if err != nil {
-		logger.Errorf("Cannot create sdk clients. Err: %w", err)
-		return nil, err
+		logger.Fatal("error connecting to web socket", "err", err)
+	}
+
+	avsRegistrySubscriber, err := avsregistry.NewSubscriberFromConfig(avsRegistryConfig, wsClient, logger)
+	if err != nil {
+		logger.Fatal("Failed to create avs registry subscriber", "err", err)
+	}
+
+	httpClient, err := ethclient.Dial(c.EthHttpUrl)
+	if err != nil {
+		logger.Fatal("error connecting to http client", "err", err)
+	}
+
+	avsRegistryReader, err := avsregistry.NewReaderFromConfig(avsRegistryConfig, httpClient, logger)
+	if err != nil {
+		logger.Fatal("Failed to create avs registry reader", "err", err)
 	}
 
 	operatorPubkeysService := oprsinfoserv.NewOperatorsInfoServiceInMemory(
 		context.Background(),
-		clients.AvsRegistryChainSubscriber,
-		clients.AvsRegistryChainReader,
+		avsRegistrySubscriber,
+		avsRegistryReader,
 		nil,
 		oprsinfoserv.Opts{},
 		logger,
@@ -88,13 +97,8 @@ func NewAggregator[Input any, Output any](
 		return taskProcessor.ProcessTaskResponse(taskResponse)
 	}
 
-	avsRegistryService := avsregistryservice.NewAvsRegistryServiceChainCaller(clients.AvsRegistryChainReader, operatorPubkeysService, logger)
+	avsRegistryService := avsregistryservice.NewAvsRegistryServiceChainCaller(avsRegistryReader, operatorPubkeysService, logger)
 	blsAggregationService := blsagg.NewBlsAggregatorService(avsRegistryService, taskResponseHashFn, logger)
-
-	client, err := ethclient.Dial(c.EthWsUrl)
-	if err != nil {
-		logger.Fatal("error connecting to web socket", "err", err)
-	}
 
 	newTaskCreatedEventHash := taskManagerAbi.Events["NewTaskCreated"].ID
 	query := ethereum.FilterQuery{
@@ -103,7 +107,7 @@ func NewAggregator[Input any, Output any](
 	}
 
 	newTaskCreatedLogs := make(chan types.Log)
-	_, err = client.SubscribeFilterLogs(context.Background(), query, newTaskCreatedLogs)
+	_, err = wsClient.SubscribeFilterLogs(context.Background(), query, newTaskCreatedLogs)
 	if err != nil {
 		logger.Fatal("error subscribing to newTaskCreated events", "err", err)
 	}

--- a/aggregator/config.go
+++ b/aggregator/config.go
@@ -20,7 +20,6 @@ type Config struct {
 	// These addresses are used to initialize the avs registry chain reader and subscriber
 	RegistryCoordinatorAddress    common.Address `toml:"registry_coordinator_address"`
 	OperatorStateRetrieverAddress common.Address `toml:"operator_state_retriever_address"`
-	ServiceManagerAddress         common.Address `toml:"service_manager_address"`
 
 	// The private key to use when signing transactions
 	// TODO: This field can't be parsed from config files, we should add some way to parse it.

--- a/aggregator/config.go
+++ b/aggregator/config.go
@@ -1,8 +1,6 @@
 package aggregator
 
 import (
-	"crypto/ecdsa"
-
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -20,9 +18,4 @@ type Config struct {
 	// These addresses are used to initialize the avs registry chain reader and subscriber
 	RegistryCoordinatorAddress    common.Address `toml:"registry_coordinator_address"`
 	OperatorStateRetrieverAddress common.Address `toml:"operator_state_retriever_address"`
-
-	// The private key to use when signing transactions
-	// TODO: This field can't be parsed from config files, we should add some way to parse it.
-	// Maybe we should implement a wrapper using https://pkg.go.dev/encoding#TextUnmarshaler.
-	EcdsaPrivateKey *ecdsa.PrivateKey
 }

--- a/examples/awesome-vault-service/aggregator/main.go
+++ b/examples/awesome-vault-service/aggregator/main.go
@@ -79,7 +79,6 @@ func main() {
 	}
 
 	aggConfig := config.Config
-	aggConfig.EcdsaPrivateKey = ecdsaPrivateKey
 
 	taskManagerAddr := gethcommon.HexToAddress(config.TaskManagerAddress)
 	taskResponder, err := taskmanager.NewTaskManagerFromAbi[examplecommon.TaskInput, [32]byte](taskManagerAddr, taskManagerAbi, txMgr, ethClient)

--- a/examples/incredible-dot-product/aggregator/main.go
+++ b/examples/incredible-dot-product/aggregator/main.go
@@ -79,7 +79,6 @@ func main() {
 	}
 
 	aggConfig := config.Config
-	aggConfig.EcdsaPrivateKey = ecdsaPrivateKey
 
 	taskManagerAddr := gethcommon.HexToAddress(config.TaskManagerAddress)
 	taskResponder, err := taskmanager.NewTaskManagerFromAbi[examplecommon.DotProductInput, *big.Int](taskManagerAddr, taskManagerAbi, txMgr, ethClient)

--- a/examples/incredible-squaring/aggregator/main.go
+++ b/examples/incredible-squaring/aggregator/main.go
@@ -49,10 +49,8 @@ func main() {
 	cfg := aggregator.Config{
 		RegistryCoordinatorAddress:    common.HexToAddress("0x7bc06c482dead17c0e297afbc32f6e63d3846650"),
 		OperatorStateRetrieverAddress: common.HexToAddress("0x4c5859f0f772848b2d91f1d83e2fe57935348029"),
-		ServiceManagerAddress:         common.HexToAddress("0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"),
 		EthHttpUrl:                    ethHttpUrl,
 		EthWsUrl:                      "ws://localhost:8545",
-		EcdsaPrivateKey:               ecdsaPrivateKey,
 		AggregatorServerIpPortAddr:    "localhost:8090",
 	}
 


### PR DESCRIPTION
### What Changed?
This PR replaces the call to `clients.BuildAll` with separate calls to the builders of the AVS Registry Reader and Subscriber. This is done to avoid passing the ECDSA key inside the config.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it