### PR TITLE
fix: remove repeated params operator config

### DIFF
--- a/examples/awesome-vault-service/operator/main.go
+++ b/examples/awesome-vault-service/operator/main.go
@@ -34,20 +34,15 @@ func main() {
 	registrationConfig := operator.RegistrationConfig{
 		RegisterOnStartup: true,
 
-		OperatorAddr:            common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
-		AllocationManagerAddr:   common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
-		AvsAddress:              common.HexToAddress("0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"),
-		RegistryCoordinatorAddr: common.HexToAddress("0xfd471836031dc5108809d173a067e8486b9047a3"),
-		StrategyAddrs:           []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
+		AllocationManagerAddr: common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
+		AvsAddress:            common.HexToAddress("0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"),
+		StrategyAddrs:         []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
 
 		DelegationManagerAddress:    common.HexToAddress("0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"),
 		RewardsCoordinatorAddress:   common.HexToAddress("0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"),
 		PermissionControllerAddress: common.HexToAddress("0x59b670e9fa9d0a427751af201d676719a970857b"),
 
-		EthRpcUrl: "http://localhost:8545",
-
 		EcdsaKeyStorePath: "keys/test.ecdsa.key.json",
-		BlsKeyStorePath:   "keys/test.bls.key.json",
 
 		AmountToMint:          amount,
 		AllocatableMagnitudes: []uint64{1000000000000000},
@@ -61,7 +56,7 @@ func main() {
 
 		OperatorAddress: operatorAddr,
 
-		AVSRegistryCoordinatorAddress: "0xfd471836031dc5108809d173a067e8486b9047a3",
+		RegistryCoordinatorAddress: "0xfd471836031dc5108809d173a067e8486b9047a3",
 
 		EthWsUrl:                      "ws://localhost:8545",
 		EthRpcUrl:                     ethHttpUrl,

--- a/examples/incredible-dot-product/operator/main.go
+++ b/examples/incredible-dot-product/operator/main.go
@@ -34,20 +34,15 @@ func main() {
 	registrationConfig := operator.RegistrationConfig{
 		RegisterOnStartup: true,
 
-		OperatorAddr:            common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
-		AllocationManagerAddr:   common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
-		AvsAddress:              common.HexToAddress("0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"),
-		RegistryCoordinatorAddr: common.HexToAddress("0xfd471836031dc5108809d173a067e8486b9047a3"),
-		StrategyAddrs:           []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
+		AllocationManagerAddr: common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
+		AvsAddress:            common.HexToAddress("0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"),
+		StrategyAddrs:         []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
 
 		DelegationManagerAddress:    common.HexToAddress("0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"),
 		RewardsCoordinatorAddress:   common.HexToAddress("0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"),
 		PermissionControllerAddress: common.HexToAddress("0x59b670e9fa9d0a427751af201d676719a970857b"),
 
-		EthRpcUrl: "http://localhost:8545",
-
 		EcdsaKeyStorePath: "keys/test.ecdsa.key.json",
-		BlsKeyStorePath:   "keys/test.bls.key.json",
 
 		AmountToMint:          amount,
 		AllocatableMagnitudes: []uint64{1000000000000000},
@@ -61,7 +56,7 @@ func main() {
 
 		OperatorAddress: operatorAddr,
 
-		AVSRegistryCoordinatorAddress: "0xfd471836031dc5108809d173a067e8486b9047a3",
+		RegistryCoordinatorAddress: "0xfd471836031dc5108809d173a067e8486b9047a3",
 
 		EthWsUrl:                      "ws://localhost:8545",
 		EthRpcUrl:                     ethHttpUrl,

--- a/examples/incredible-squaring/operator/main.go
+++ b/examples/incredible-squaring/operator/main.go
@@ -30,20 +30,15 @@ func main() {
 	registrationConfig := operator.RegistrationConfig{
 		RegisterOnStartup: true,
 
-		OperatorAddr:            common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
-		AllocationManagerAddr:   common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
-		AvsAddress:              common.HexToAddress("0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"),
-		RegistryCoordinatorAddr: common.HexToAddress("0x7bc06c482dead17c0e297afbc32f6e63d3846650"),
-		StrategyAddrs:           []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
+		AllocationManagerAddr: common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
+		AvsAddress:            common.HexToAddress("0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"),
+		StrategyAddrs:         []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
 
 		DelegationManagerAddress:    common.HexToAddress("0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"),
 		RewardsCoordinatorAddress:   common.HexToAddress("0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"),
 		PermissionControllerAddress: common.HexToAddress("0x59b670e9fa9d0a427751af201d676719a970857b"),
 
-		EthRpcUrl: "http://localhost:8545",
-
 		EcdsaKeyStorePath: "keys/test.ecdsa.key.json",
-		BlsKeyStorePath:   "keys/test.bls.key.json",
 
 		AmountToMint:          amount,
 		AllocatableMagnitudes: []uint64{1000000000000000},
@@ -55,7 +50,7 @@ func main() {
 	// https://github.com/Layr-Labs/incredible-squaring-avs/blob/dev/config-files/operator.anvil.yaml
 	operatorConfig := operator.Config{
 		OperatorAddress:               "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-		AVSRegistryCoordinatorAddress: "0x7bc06c482dead17c0e297afbc32f6e63d3846650",
+		RegistryCoordinatorAddress:    "0x7bc06c482dead17c0e297afbc32f6e63d3846650",
 		EthRpcUrl:                     "http://localhost:8545",
 		EthWsUrl:                      "ws://localhost:8545",
 		BlsPrivateKeyStorePath:        "keys/test.bls.key.json",

--- a/operator/config.go
+++ b/operator/config.go
@@ -58,7 +58,7 @@ type RegistrationConfig struct {
 	RewardsCoordinatorAddress   common.Address
 	PermissionControllerAddress common.Address
 
-	// The path to the location of the ecdsa private keys on local storage
+	// The path to the location of the ecdsa private key on local storage
 	EcdsaKeyStorePath string
 
 	// The ammount to mint to the operator

--- a/operator/config.go
+++ b/operator/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	OperatorAddress string
 
 	// The registry coordinator address is used to create the AVS reader
-	AVSRegistryCoordinatorAddress string
+	RegistryCoordinatorAddress string
 
 	// Ethereum HTTP RPC URL to use for interacting with on-chain contracts
 	EthRpcUrl string
@@ -44,15 +44,11 @@ type RegistrationConfig struct {
 	// If set true, should register the operator on startup
 	RegisterOnStartup bool
 
-	// The address for the operator
-	OperatorAddr common.Address
-
 	// Used for setting the allogation delay to zero and initialize allocations
 	AllocationManagerAddr common.Address
 
 	// Used to register operator in operator sets and initialize allocations
-	AvsAddress              common.Address
-	RegistryCoordinatorAddr common.Address
+	AvsAddress common.Address
 
 	// Used to deposit into these strategies for operator and initialize allocations on these strategies
 	StrategyAddrs []common.Address
@@ -62,12 +58,8 @@ type RegistrationConfig struct {
 	RewardsCoordinatorAddress   common.Address
 	PermissionControllerAddress common.Address
 
-	// The url exposed by the anvil node to call the contract methods
-	EthRpcUrl string
-
-	// The path to the location of the bls and ecdsa private keys on local storage
+	// The path to the location of the ecdsa private keys on local storage
 	EcdsaKeyStorePath string
-	BlsKeyStorePath   string
 
 	// The ammount to mint to the operator
 	AmountToMint *big.Int

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -77,6 +77,16 @@ func NewOperatorFromConfig[Input any, Output any](
 		return nil, err
 	}
 
+	blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
+	if !ok {
+		c.Logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
+	}
+	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
+	if err != nil {
+		c.Logger.Errorf("Cannot parse bls private key", "err", err)
+		return nil, err
+	}
+
 	// Check if operator was registered, if its not registered and register on startup flag is not set, then will fail.
 	// If its not registered and should be registered on startup, make the registration.
 	operatorIsRegistered, err := avsReader.IsOperatorRegistered(&bind.CallOpts{}, common.HexToAddress(c.OperatorAddress))
@@ -92,7 +102,7 @@ func NewOperatorFromConfig[Input any, Output any](
 				avsConfig.RegistryCoordinatorAddress,
 				common.HexToAddress(c.OperatorAddress),
 				c.EthRpcUrl,
-				c.BlsPrivateKeyStorePath,
+				blsKeyPair,
 			)
 			if err != nil {
 				c.Logger.Errorf("Failure while registering operator on startup: %w", err)
@@ -117,16 +127,6 @@ func NewOperatorFromConfig[Input any, Output any](
 	aggregatorRpcClient, err := NewAggregatorRpcClient[Output](c.AggregatorServerIpPortAddress, c.Logger)
 	if err != nil {
 		c.Logger.Error("Cannot create AggregatorRpcClient. Is aggregator running?", "err", err)
-		return nil, err
-	}
-
-	blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
-	if !ok {
-		c.Logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
-	}
-	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
-	if err != nil {
-		c.Logger.Errorf("Cannot parse bls private key", "err", err)
 		return nil, err
 	}
 

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -101,7 +101,7 @@ func NewOperatorFromConfig[Input any, Output any](
 				c.Logger,
 				avsConfig.RegistryCoordinatorAddress,
 				common.HexToAddress(c.OperatorAddress),
-				c.EthRpcUrl,
+				ethHttpClient,
 				blsKeyPair,
 			)
 			if err != nil {

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -63,7 +63,7 @@ func NewOperatorFromConfig[Input any, Output any](
 	// when we use the AVS registry reader. If you want to do more things with avs registry reader,
 	// you should add those addresses to the operator config and assign them here.
 	avsConfig := avsregistry.Config{
-		RegistryCoordinatorAddress: common.HexToAddress(c.AVSRegistryCoordinatorAddress),
+		RegistryCoordinatorAddress: common.HexToAddress(c.RegistryCoordinatorAddress),
 	}
 
 	ethHttpClient, err := ethclient.Dial(c.EthRpcUrl)
@@ -86,7 +86,14 @@ func NewOperatorFromConfig[Input any, Output any](
 	}
 	if !operatorIsRegistered {
 		if c.RegistrationCfg.RegisterOnStartup {
-			err = RegisterOperatorOnStartup(c.RegistrationCfg, c.Logger)
+			err = RegisterOperatorOnStartup(
+				c.RegistrationCfg,
+				c.Logger,
+				avsConfig.RegistryCoordinatorAddress,
+				common.HexToAddress(c.OperatorAddress),
+				c.EthRpcUrl,
+				c.BlsPrivateKeyStorePath,
+			)
 			if err != nil {
 				c.Logger.Errorf("Failure while registering operator on startup: %w", err)
 				return nil, err

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -86,7 +86,7 @@ func NewOperatorFromConfig[Input any, Output any](
 	}
 	if !operatorIsRegistered {
 		if c.RegistrationCfg.RegisterOnStartup {
-			err = RegisterOperatorOnStartup(
+			err = registerOperatorOnStartup(
 				c.RegistrationCfg,
 				c.Logger,
 				avsConfig.RegistryCoordinatorAddress,

--- a/operator/registration.go
+++ b/operator/registration.go
@@ -33,8 +33,15 @@ import (
 //   - Register the operator in the received operator sets
 //   - Set the allocation delay as zero, to performs allocations immediatly
 //   - Initialize allocations for the operator sets
-func RegisterOperatorOnStartup(c RegistrationConfig, logger logging.Logger) error {
-	ethRpcClient, err := ethclient.Dial(c.EthRpcUrl)
+func RegisterOperatorOnStartup(
+	c RegistrationConfig,
+	logger logging.Logger,
+	registryCoordinatorAddr common.Address,
+	operatorAddress common.Address,
+	ethRpcUrl string,
+	blsKeyStorePath string,
+) error {
+	ethRpcClient, err := ethclient.Dial(ethRpcUrl)
 	if err != nil {
 		logger.Errorf("Cannot create http ethclient", "err", err)
 		return err
@@ -82,7 +89,7 @@ func RegisterOperatorOnStartup(c RegistrationConfig, logger logging.Logger) erro
 	txMgr := txmgr.NewSimpleTxManager(pkWallet, ethRpcClient, logger, senderAddr)
 
 	err = RegisterOperatorWithEigenlayer(
-		c.OperatorAddr,
+		operatorAddress,
 		elcontractsConfig,
 		ethRpcClient,
 		logger,
@@ -98,7 +105,7 @@ func RegisterOperatorOnStartup(c RegistrationConfig, logger logging.Logger) erro
 		ethRpcClient,
 		c.StrategyAddrs,
 		txMgr,
-		c.OperatorAddr,
+		operatorAddress,
 		c.AmountToMint,
 	)
 	if err != nil {
@@ -109,19 +116,19 @@ func RegisterOperatorOnStartup(c RegistrationConfig, logger logging.Logger) erro
 	if !ok {
 		logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
 	}
-	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsKeyStorePath, blsKeyPassword)
+	blsKeyPair, err := bls.ReadPrivateKeyFromFile(blsKeyStorePath, blsKeyPassword)
 	if err != nil {
 		logger.Errorf("Cannot parse bls private key", "err", err)
 		return err
 	}
 
 	err = RegisterForOperatorSets(
-		c.OperatorAddr,
+		operatorAddress,
 		logger,
 		elcontractsConfig,
 		ethRpcClient,
 		txMgr,
-		c.RegistryCoordinatorAddr,
+		registryCoordinatorAddr,
 		c.AvsAddress,
 		c.OperatorSetIds,
 		*blsKeyPair,
@@ -133,7 +140,7 @@ func RegisterOperatorOnStartup(c RegistrationConfig, logger logging.Logger) erro
 
 	err = SetAllocationDelay(
 		logger,
-		c.OperatorAddr,
+		operatorAddress,
 		ethRpcClient,
 		c.AllocationManagerAddr,
 		txMgr,
@@ -144,12 +151,12 @@ func RegisterOperatorOnStartup(c RegistrationConfig, logger logging.Logger) erro
 	}
 
 	err = modifyAllocations(
-		c.OperatorAddr,
+		operatorAddress,
 		c.AllocationManagerAddr,
 		c.AvsAddress,
 		c.StrategyAddrs,
 		c.AllocatableMagnitudes,
-		c.EthRpcUrl,
+		ethRpcUrl,
 		txMgr,
 		c.OperatorSetIds,
 		logger,

--- a/operator/registration.go
+++ b/operator/registration.go
@@ -33,7 +33,7 @@ import (
 //   - Register the operator in the received operator sets
 //   - Set the allocation delay as zero, to performs allocations immediatly
 //   - Initialize allocations for the operator sets
-func RegisterOperatorOnStartup(
+func registerOperatorOnStartup(
 	c RegistrationConfig,
 	logger logging.Logger,
 	registryCoordinatorAddr common.Address,

--- a/operator/registration.go
+++ b/operator/registration.go
@@ -39,7 +39,7 @@ func registerOperatorOnStartup(
 	registryCoordinatorAddr common.Address,
 	operatorAddress common.Address,
 	ethRpcUrl string,
-	blsKeyStorePath string,
+	blsKeyPair *bls.KeyPair,
 ) error {
 	ethRpcClient, err := ethclient.Dial(ethRpcUrl)
 	if err != nil {
@@ -110,16 +110,6 @@ func registerOperatorOnStartup(
 	)
 	if err != nil {
 		logger.Fatalf("Failed to deposit into strategy for operator on startup: %v", err.Error())
-	}
-
-	blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
-	if !ok {
-		logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
-	}
-	blsKeyPair, err := bls.ReadPrivateKeyFromFile(blsKeyStorePath, blsKeyPassword)
-	if err != nil {
-		logger.Errorf("Cannot parse bls private key", "err", err)
-		return err
 	}
 
 	err = RegisterForOperatorSets(

--- a/operator/registration.go
+++ b/operator/registration.go
@@ -38,15 +38,9 @@ func registerOperatorOnStartup(
 	logger logging.Logger,
 	registryCoordinatorAddr common.Address,
 	operatorAddress common.Address,
-	ethRpcUrl string,
+	ethRpcClient *ethclient.Client,
 	blsKeyPair *bls.KeyPair,
 ) error {
-	ethRpcClient, err := ethclient.Dial(ethRpcUrl)
-	if err != nil {
-		logger.Errorf("Cannot create http ethclient", "err", err)
-		return err
-	}
-
 	elcontractsConfig := elcontracts.Config{
 		DelegationManagerAddress:    c.DelegationManagerAddress,
 		RewardsCoordinatorAddress:   c.RewardsCoordinatorAddress,
@@ -146,7 +140,7 @@ func registerOperatorOnStartup(
 		c.AvsAddress,
 		c.StrategyAddrs,
 		c.AllocatableMagnitudes,
-		ethRpcUrl,
+		ethRpcClient,
 		txMgr,
 		c.OperatorSetIds,
 		logger,
@@ -341,14 +335,13 @@ func modifyAllocations(
 	avsAddress common.Address,
 	strategies []common.Address,
 	newMagnitudes []uint64,
-	httpUrl string,
+	ethRpcClient *ethclient.Client,
 	txMgr txmgr.TxManager,
 	operatorSetsIds []uint32,
 	logger logging.Logger,
 ) error {
 	txOpts, _ := txMgr.GetNoSendTxOpts()
 
-	ethRpcClient, _ := ethclient.Dial(httpUrl)
 	waitForReceipt := true
 	allocationManagerContract, _ := allocationmanager.NewContractAllocationManager(allocationManagerAddr, ethRpcClient)
 


### PR DESCRIPTION
### What Changed?
This PR removes the registration parameters that are already in the operator configuration.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it