### PR TITLE
docs: add create response calculator section

### DIFF
--- a/aggregator/README.md
+++ b/aggregator/README.md
@@ -77,13 +77,13 @@ This flow ensures tasks are initialized, signatures collected, and the final res
             )
         ```
 
-    4. Create the `IndexingTaskProcessor` with the `TaskResponder` created below:
+    4. Create the `IndexingTaskProcessor` with the `TaskResponder` created above:
 
         ```go
             taskProcessor, err := taskprocessor.NewIndexingTaskProcessor(logger, taskResponder)
         ```
 
-3. **Run the aggregator**: Instantiate an `Aggregator` with the config, a logger, the task processor created below and the task manager contract ABI, and then start it:
+3. **Run the aggregator**: Instantiate an `Aggregator` with the config, a logger, the task processor created above and the task manager contract ABI, and then start it:
 
     ``` go
         agg, err := aggregator.NewAggregator(cfg, logger, taskProcessor, taskManagerAbi)

--- a/operator/README.md
+++ b/operator/README.md
@@ -119,13 +119,13 @@ To create your Response Calculator you have to declare a struct that satisfies t
 ``` go
    type ResponseCalculator[Input any, Output any] interface {
       ComputeResponse(taskIndex uint32, input Input) (Output, error)
-   }
+ }
 ```
 
-The `ResponseCalculator` interface has the `ComputeResponse` method, that computes the response of a task given its index and input, returning the response, or an error if the computation fails.
+The `ResponseCalculator` interface has the `ComputeResponse` method, which computes the response of a task given its index and input, returning the output, or an error if the computation fails.
 
-If you don't need to save a state between the operator responses, then you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package, that receives a function that computes the result from an input returning an output (or an error if fails) and returns a `ResponseCalculator` that on every call to the `ComputeResponse` method will call the received function.
+If you don't need to save a state between the operator responses you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package, that receives a function that computes the result from an input returning an output (or an error if fails) and returns a `ResponseCalculator` that on every call to the `ComputeResponse` method will call the received function.
 
-If you need to save a state between the operator responses, then you will have to implement your own Response calculator following the interface shown above.
+If you need to save a state between the operator responses, then you should implement your Response calculator following the above interface.
 
-As a suggestion, you should place the calculation logic at the `ComputeResponse` method, and initialize on the new calculator type builder the necessary things for calculating the response.
+As a suggestion, you should place the calculation logic in the `ComputeResponse` method and initialize the necessary things for calculating the response on the new response calculator builder.

--- a/operator/README.md
+++ b/operator/README.md
@@ -119,7 +119,7 @@ To create your Response Calculator you have to declare a struct that satisfies t
 ``` go
    type ResponseCalculator[Input any, Output any] interface {
       ComputeResponse(taskIndex uint32, input Input) (Output, error)
- }
+   }
 ```
 
 The `ResponseCalculator` interface has the `ComputeResponse` method, which computes the response of a task given its index and input, returning the output, or an error if the computation fails.

--- a/operator/README.md
+++ b/operator/README.md
@@ -124,7 +124,7 @@ To create your Response Calculator you have to declare a struct that satisfies t
 
 The `ResponseCalculator` interface has the `ComputeResponse` method, which computes the response of a task given its index and input, returning the output, or an error if the computation fails.
 
-If you don't need to save a state between the operator responses you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package, that receives a function that computes the result from an input returning an output (or an error if fails) and returns a `ResponseCalculator` that on every call to the `ComputeResponse` method will call the received function.
+We recommend implementing your own reponse calculator if you need to save state between responses. If you don't need to save a state between the operator responses you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package, that receives a function that computes the result from an input returning an output (or an error if fails) and returns a `ResponseCalculator` that on every call to the `ComputeResponse` method will call the received function.
 
 If you need to save a state between the operator responses, then you should implement your Response calculator following the above interface.
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -124,8 +124,6 @@ To create your Response Calculator you have to declare a struct that satisfies t
 
 The `ResponseCalculator` interface has the `ComputeResponse` method, which computes the response of a task given its index and input, returning the output, or an error if the computation fails.
 
-We recommend implementing your own reponse calculator if you need to save state between responses. If you don't need to save a state between the operator responses you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package, that receives a function that computes the result from an input returning an output (or an error if fails) and returns a `ResponseCalculator` that on every call to the `ComputeResponse` method will call the received function.
+We recommend implementing your own reponse calculator if you need to save state between responses. If you need to save a state between the operator responses, then you should implement your Response calculator following the above interface. As a suggestion, you should place the calculation logic in the `ComputeResponse` method and initialize the necessary things for calculating the response on the new response calculator builder.
 
-If you need to save a state between the operator responses, then you should implement your Response calculator following the above interface.
-
-As a suggestion, you should place the calculation logic in the `ComputeResponse` method and initialize the necessary things for calculating the response on the new response calculator builder.
+If you don't need to save a state between the operator responses you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package, that receives a function that computes the result from an input returning an output (or an error if fails) and returns a `ResponseCalculator` that on every call to the `ComputeResponse` method will call the received function.

--- a/operator/README.md
+++ b/operator/README.md
@@ -27,7 +27,7 @@ The Operator functions through the following flow:
 ## How to Set Up an Operator
 
 1. **Task Manager ABI**: Get the ABI of the task manager from your bindings.
-   
+
    ```go
       taskManagerAbi, err := cstaskmanager.ContractIncredibleSquaringTaskManagerMetaData.GetAbi()
    ```
@@ -83,7 +83,7 @@ The Operator functions through the following flow:
    - In case you need to save state in the operator, you can use your own struct implementing the `ResponseCalculator` interface.
 
 5. **Failing Response Calculator**: If you want to test what happens when the operator responds incorrectly to a task and see how slashing works, you can wrap your logic with `NewFailingResponseCalculator` method to inject failures and a given failure rate. **Use this for testing purposes only.**
-    
+
     ```go
         logic, err := operator.NewFailingResponseCalculator(calculator, 50, big.NewInt(0))
     ```
@@ -112,3 +112,20 @@ Here are some examples of operators that are already implemented:
 - [Incredible Dot Product](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-1/examples/incredible-dot-product/operator/main.go)
 - [Awesome Vault Service](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-1/examples/awesome-vault-service/operator/main.go)
 
+## How to create your Response Calculator
+
+To create your Response Calculator you have to declare a struct that satisfies the `ResponseCalculator` interface:
+
+``` go
+   type ResponseCalculator[Input any, Output any] interface {
+      ComputeResponse(taskIndex uint32, input Input) (Output, error)
+   }
+```
+
+The `ResponseCalculator` interface has the `ComputeResponse` method, that computes the response of a task given its index and input, returning the response, or an error if the computation fails.
+
+If you don't need to save a state between the operator responses, then you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package, that receives a function that computes the result from an input returning an output (or an error if fails) and returns a `ResponseCalculator` that on every call to the `ComputeResponse` method will call the received function.
+
+If you need to save a state between the operator responses, then you will have to implement your own Response calculator following the interface shown above.
+
+As a suggestion, you should place the calculation logic at the `ComputeResponse` method, and initialize on the new calculator type builder the necessary things for calculating the response.

--- a/operator/README.md
+++ b/operator/README.md
@@ -126,4 +126,4 @@ The `ResponseCalculator` interface has the `ComputeResponse` method, which compu
 
 We recommend implementing your own reponse calculator if you need to save state between responses. If you need to save a state between the operator responses, then you should implement your Response calculator following the above interface. As a suggestion, you should place the calculation logic in the `ComputeResponse` method and initialize the necessary things for calculating the response on the new response calculator builder.
 
-If you don't need to save a state between the operator responses you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package, that receives a function that computes the result from an input returning an output (or an error if fails) and returns a `ResponseCalculator` that on every call to the `ComputeResponse` method will call the received function.
+If you don't need to save a state between the operator responses you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package. You can find it on `operator/response_calculator.go`.

--- a/operator/README.md
+++ b/operator/README.md
@@ -124,6 +124,6 @@ To create your Response Calculator you have to declare a struct that satisfies t
 
 The `ResponseCalculator` interface has the `ComputeResponse` method, which computes the response of a task given its index and input, returning the output, or an error if the computation fails.
 
-We recommend implementing your own reponse calculator if you need to save state between responses. If you need to save a state between the operator responses, then you should implement your Response calculator following the above interface. As a suggestion, you should place the calculation logic in the `ComputeResponse` method and initialize the necessary things for calculating the response on the new response calculator builder.
+We recommend implementing your own `ReponseCalculator` if you need to save state between responses, for that you should implement your Response calculator following the above interface. The response calculation logic should go in the `ComputeResponse` method and you can set your initial state in a constructor.
 
 If you don't need to save a state between the operator responses you can use the `NewFunctionResponseCalculator` function, provided by the SDK in the operator package. You can find it on `operator/response_calculator.go`.

--- a/operator/response_calculator.go
+++ b/operator/response_calculator.go
@@ -16,7 +16,8 @@ type functionResponseCalculator[Input any, Output any] struct {
 	computeFn func(taskIndex uint32, input Input) (Output, error)
 }
 
-// Turns a function that receives a task index and an input value and returns an output value into a ResponseCalculator.
+// Receives a function that receives a task index and an input value and returns an output value and returns a
+// ResponseCalculator, that on each call to ComputeResponse method will call the function received on building.
 func NewFunctionResponseCalculator[Input any, Output any](
 	computeFn func(taskIndex uint32, input Input) (Output, error),
 ) ResponseCalculator[Input, Output] {

--- a/operator/response_calculator.go
+++ b/operator/response_calculator.go
@@ -16,8 +16,8 @@ type functionResponseCalculator[Input any, Output any] struct {
 	computeFn func(taskIndex uint32, input Input) (Output, error)
 }
 
-// Receives a function that receives a task index and an input value and returns an output value and returns a
-// ResponseCalculator, that on each call to ComputeResponse method will call the function received on building.
+// Turns a function that receives a task index and an input value and returns an output value into a ResponseCalculator.
+// On each call to ComputeResponse method, the created calculator will call the function received on building
 func NewFunctionResponseCalculator[Input any, Output any](
 	computeFn func(taskIndex uint32, input Input) (Output, error),
 ) ResponseCalculator[Input, Output] {


### PR DESCRIPTION
### What Changed?
This PR adds a section for creating the response calculator type.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it