### PR TITLE
docs: add links to target in examples docs

### DIFF
--- a/examples/awesome-vault-service/README.md
+++ b/examples/awesome-vault-service/README.md
@@ -47,7 +47,7 @@ For response validation, there should be an additional check to verify that the 
 
 To create the sequence that passes input values to the task spammer, we use the sequence generator in the task manager main (in `examples/awesome-vault-service/task-spammer/main.go`), that creates a sequence that on each iteration advances on 1 and gives as input a fixed key-pair defined from the iteration number.
 
-### Binaries
+### Moving parts
 
 The system flow is composed of 4 binaries:
 

--- a/examples/awesome-vault-service/README.md
+++ b/examples/awesome-vault-service/README.md
@@ -89,3 +89,12 @@ To start the cycle, start the task spammer:
 ``` bash
 make start-task-spammer
 ```
+
+## Link to implementations
+
+To see the specific implementation on each member of this example, you can see:
+
+- [Aggregator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/aggregator/main.go)
+- [Challenger implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/challenger/main.go)
+- [Operator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/operator/main.go)
+- [Task Spammer implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/task-spammer/main.go)

--- a/examples/awesome-vault-service/README.md
+++ b/examples/awesome-vault-service/README.md
@@ -51,10 +51,10 @@ To create the sequence that passes input values to the task spammer, we use the 
 
 The system flow is composed of 4 binaries:
 
-- Aggregator: Aggregates responses from operators and sends the aggregated responses to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/aggregator/main.go)
-- Challenger: If the aggregated responses are incorrect, raises a challenge to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/challenger/main.go)
-- Operator: Responds to tasks and sends them to the aggregator. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/operator/main.go)
-- Task Spammer: Creates new tasks and sends them to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/task-spammer/main.go)
+- [Aggregator](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/aggregator/main.go): Aggregates responses from operators and sends the aggregated responses to the task manager contract.
+- [Challenger](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/challenger/main.go): If the aggregated responses are incorrect, raises a challenge to the task manager contract.
+- [Operator](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/operator/main.go): Responds to tasks and sends them to the aggregator.
+- [Task Spammer](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/task-spammer/main.go): Creates new tasks and sends them to the task manager contract.
 
 ## How to run
 

--- a/examples/awesome-vault-service/README.md
+++ b/examples/awesome-vault-service/README.md
@@ -47,6 +47,15 @@ For response validation, there should be an additional check to verify that the 
 
 To create the sequence that passes input values to the task spammer, we use the sequence generator in the task manager main (in `examples/awesome-vault-service/task-spammer/main.go`), that creates a sequence that on each iteration advances on 1 and gives as input a fixed key-pair defined from the iteration number.
 
+### Binaries
+
+The system flow is composed of 4 binaries:
+
+- Aggregator: Aggregates responses from operators and sends the aggregated responses to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/aggregator/main.go)
+- Challenger: If the aggregated responses are incorrect, raises a challenge to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/challenger/main.go)
+- Operator: Responds to tasks and sends them to the aggregator. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/operator/main.go)
+- Task Spammer: Creates new tasks and sends them to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/task-spammer/main.go)
+
 ## How to run
 
 This simple session illustrates the basic flow of the AVS:
@@ -89,12 +98,3 @@ To start the cycle, start the task spammer:
 ``` bash
 make start-task-spammer
 ```
-
-## Link to implementations
-
-To see the specific implementation on each member of this example, you can see:
-
-- [Aggregator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/aggregator/main.go)
-- [Challenger implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/challenger/main.go)
-- [Operator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/operator/main.go)
-- [Task Spammer implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/awesome-vault-service/task-spammer/main.go)

--- a/examples/incredible-dot-product/README.md
+++ b/examples/incredible-dot-product/README.md
@@ -43,6 +43,15 @@ In the specific case of the dot product, the function receives an input with two
 
 To create the sequence that passes input values to the task spammer, we use the sequence generator in the task manager main (in `examples/incredible-dot-product/task-spammer/main.go`), which creates a sequence that on each iteration advances on 1 and gives as input a fixed pair of vectors defined from the iteration number.
 
+### Binaries
+
+The system flow is composed of 4 binaries:
+
+- Aggregator: Aggregates responses from operators and sends the aggregated responses to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/aggregator/main.go)
+- Challenger: If the aggregated responses are incorrect, raises a challenge to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/challenger/main.go)
+- Operator: Responds to tasks and sends them to the aggregator. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/operator/main.go)
+- Task Spammer: Creates new tasks and sends them to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/task-spammer/main.go)
+
 ## How to run
 
 This simple session illustrates the basic flow of the AVS:
@@ -85,12 +94,3 @@ To start the cycle, start the task spammer:
 ``` bash
 make start-task-spammer
 ```
-
-## Link to implementations
-
-To see the specific implementation on each member of this example, you can see:
-
-- [Aggregator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/aggregator/main.go)
-- [Challenger implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/challenger/main.go)
-- [Operator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/operator/main.go)
-- [Task Spammer implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/task-spammer/main.go)

--- a/examples/incredible-dot-product/README.md
+++ b/examples/incredible-dot-product/README.md
@@ -47,10 +47,10 @@ To create the sequence that passes input values to the task spammer, we use the 
 
 The system flow is composed of 4 binaries:
 
-- Aggregator: Aggregates responses from operators and sends the aggregated responses to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/aggregator/main.go)
-- Challenger: If the aggregated responses are incorrect, raises a challenge to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/challenger/main.go)
-- Operator: Responds to tasks and sends them to the aggregator. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/operator/main.go)
-- Task Spammer: Creates new tasks and sends them to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/task-spammer/main.go)
+- [Aggregator](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/aggregator/main.go): Aggregates responses from operators and sends the aggregated responses to the task manager contract.
+- [Challenger](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/challenger/main.go): If the aggregated responses are incorrect, raises a challenge to the task manager contract.
+- [Operator](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/operator/main.go): Responds to tasks and sends them to the aggregator.
+- [Task Spammer](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/task-spammer/main.go): Creates new tasks and sends them to the task manager contract.
 
 ## How to run
 

--- a/examples/incredible-dot-product/README.md
+++ b/examples/incredible-dot-product/README.md
@@ -85,3 +85,12 @@ To start the cycle, start the task spammer:
 ``` bash
 make start-task-spammer
 ```
+
+## Link to implementations
+
+To see the specific implementation on each member of this example, you can see:
+
+- [Aggregator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/aggregator/main.go)
+- [Challenger implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/challenger/main.go)
+- [Operator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/operator/main.go)
+- [Task Spammer implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-dot-product/task-spammer/main.go)

--- a/examples/incredible-dot-product/README.md
+++ b/examples/incredible-dot-product/README.md
@@ -43,7 +43,7 @@ In the specific case of the dot product, the function receives an input with two
 
 To create the sequence that passes input values to the task spammer, we use the sequence generator in the task manager main (in `examples/incredible-dot-product/task-spammer/main.go`), which creates a sequence that on each iteration advances on 1 and gives as input a fixed pair of vectors defined from the iteration number.
 
-### Binaries
+### Moving parts
 
 The system flow is composed of 4 binaries:
 

--- a/examples/incredible-squaring/README.md
+++ b/examples/incredible-squaring/README.md
@@ -42,10 +42,10 @@ To create the sequence that passes input values to the task spammer, we use the 
 
 The system flow is composed of 4 binaries:
 
-- Aggregator: Aggregates responses from operators and sends the aggregated responses to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/aggregator/main.go)
-- Challenger: If the aggregated responses are incorrect, raises a challenge to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/challenger/main.go)
-- Operator: Responds to tasks and sends them to the aggregator. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/operator/main.go)
-- Task Spammer: Creates new tasks and sends them to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/task-spammer/main.go)
+- [Aggregator](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/aggregator/main.go): Aggregates responses from operators and sends the aggregated responses to the task manager contract.
+- [Challenger](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/challenger/main.go): If the aggregated responses are incorrect, raises a challenge to the task manager contract.
+- [Operator](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/operator/main.go): Responds to tasks and sends them to the aggregator.
+- [Task Spammer](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/task-spammer/main.go): Creates new tasks and sends them to the task manager contract.
 
 ## How to run
 

--- a/examples/incredible-squaring/README.md
+++ b/examples/incredible-squaring/README.md
@@ -38,7 +38,7 @@ In the specific case of squaring, the function receives an input of an uint256, 
 
 To create the sequence that passes input values to the task spammer, we use the sequence generator in the task manager main (in `examples/incredible-squaring/task-spammer/main.go`) which creates a sequence that advances on 1 and gives the iteration number as input on each iteration.
 
-### Binaries
+### Moving parts
 
 The system flow is composed of 4 binaries:
 

--- a/examples/incredible-squaring/README.md
+++ b/examples/incredible-squaring/README.md
@@ -38,6 +38,15 @@ In the specific case of squaring, the function receives an input of an uint256, 
 
 To create the sequence that passes input values to the task spammer, we use the sequence generator in the task manager main (in `examples/incredible-squaring/task-spammer/main.go`) which creates a sequence that advances on 1 and gives the iteration number as input on each iteration.
 
+### Binaries
+
+The system flow is composed of 4 binaries:
+
+- Aggregator: Aggregates responses from operators and sends the aggregated responses to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/aggregator/main.go)
+- Challenger: If the aggregated responses are incorrect, raises a challenge to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/challenger/main.go)
+- Operator: Responds to tasks and sends them to the aggregator. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/operator/main.go)
+- Task Spammer: Creates new tasks and sends them to the task manager contract. [Link to use example](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/task-spammer/main.go)
+
 ## How to run
 
 This simple session illustrates the basic flow of the AVS:
@@ -80,12 +89,3 @@ To start the cycle, start the task spammer:
 ``` bash
 make start-task-spammer
 ```
-
-## Link to implementations
-
-To see the specific implementation on each member of this example, you can see:
-
-- [Aggregator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/aggregator/main.go)
-- [Challenger implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/challenger/main.go)
-- [Operator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/operator/main.go)
-- [Task Spammer implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/task-spammer/main.go)

--- a/examples/incredible-squaring/README.md
+++ b/examples/incredible-squaring/README.md
@@ -80,3 +80,12 @@ To start the cycle, start the task spammer:
 ``` bash
 make start-task-spammer
 ```
+
+## Link to implementations
+
+To see the specific implementation on each member of this example, you can see:
+
+- [Aggregator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/aggregator/main.go)
+- [Challenger implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/challenger/main.go)
+- [Operator implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/operator/main.go)
+- [Task Spammer implementation](https://github.com/Layr-Labs/eigensdk-go/blob/v2-dev-2/examples/incredible-squaring/task-spammer/main.go)


### PR DESCRIPTION
### What Changed?
This PR adds a section with links to the specific example implementations in each AVS example's readme.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it