### PR TITLE
docs: add v2 modules to the root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ We support following modules right now.
 * [BLS Signer](./signer)
 * [ChainIO](./chainio)
 * [Services](./services)
+* [Aggregator](./aggregator)
+* [Challenger](./challenger)
+* [Operator](./operator)
+* [Task Manager](./task-manager)
+* [Task Spammer](./task-spammer)
 
 ## AVS use examples
 


### PR DESCRIPTION
### What Changed?
This PR adds the v2 new modules to the README file at the root of repository.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it