### PR TITLE
feat(v2): run entities on goroutines and return an error channel on Start

### DIFF
--- a/aggregator/README.md
+++ b/aggregator/README.md
@@ -88,7 +88,7 @@ This flow ensures tasks are initialized, signatures collected, and the final res
     ``` go
         agg, err := aggregator.NewAggregator(cfg, logger, taskProcessor, taskManagerAbi)
 
-        err = agg.Start(context.Background())
+        err = <-agg.Start(context.Background())
     ```
 
 ## Examples

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -128,10 +128,7 @@ func (agg *Aggregator[Input, Output]) Start(ctx context.Context) <-chan error {
 	errChan := make(chan error)
 
 	go func() {
-		defer close(errChan)
-		if err := agg.run(ctx); err != nil {
-			errChan <- err
-		}
+		errChan <- agg.run(ctx)
 	}()
 
 	return errChan

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -122,14 +122,27 @@ func NewAggregator[Input any, Output any](
 	}, nil
 }
 
-// Starts running the Aggregator. This should be called only one time per Aggregator.
-//
-// The main loop of the Aggregator has 2 main events:
+// Runs the Aggregator in a separate goroutine. This should be called only one time per Aggregator.
+// Returns an error channel, that in case of an error in the run method will contain the received error.
+func (agg *Aggregator[Input, Output]) Start(ctx context.Context) <-chan error {
+	errChan := make(chan error)
+
+	go func() {
+		defer close(errChan)
+		if err := agg.run(ctx); err != nil {
+			errChan <- err
+		}
+	}()
+
+	return errChan
+}
+
+// The run method contains the main loop of the Aggregator, that has 2 main events:
 //   - Get a response from the BLS aggregation service: In this case the response is processed and sent to
 //     the Task Manager on-chain contract.
 //   - Receive a new task created event log: In this case the aggregator processes that event, and sends to
 //     the BLS aggregation service the new task created metadata.
-func (agg *Aggregator[Input, Output]) Start(ctx context.Context) error {
+func (agg *Aggregator[Input, Output]) run(ctx context.Context) error {
 	agg.logger.Info("Starting aggregator.")
 	agg.logger.Info("Starting aggregator rpc server.")
 	go agg.startServer(ctx)

--- a/challenger/README.md
+++ b/challenger/README.md
@@ -95,13 +95,13 @@ The Challenger operates through a well-defined workflow:
 4. **Challenger**: Create a `Challenger` from the `Config` and the `ChallengerProcessor`.
 
     ```go
-      challenger, _ := challenger.NewChallenger(cfg, indexingTaskProcessor)
+        challenger, _ := challenger.NewChallenger(cfg, indexingTaskProcessor)
     ```
 
 5. **Start the Challenger**: Start the challenger.
 
     ```go
-      challenger.Start(context.Background())
+        err = <-challenger.Start(context.Background())
     ```
 
 ## Examples

--- a/challenger/challenger.go
+++ b/challenger/challenger.go
@@ -110,6 +110,8 @@ func (c *Challenger[Input, Output]) run(ctx context.Context) error {
 
 	for {
 		select {
+		case <-ctx.Done():
+			return nil
 		case newTaskCreatedLog := <-c.newTaskCreatedChan:
 			c.logger.Info("New task created log received")
 			err := c.processNewTaskCreatedLog(newTaskCreatedLog)

--- a/challenger/challenger.go
+++ b/challenger/challenger.go
@@ -88,12 +88,24 @@ func NewChallenger[Input any, Output any](
 	}, nil
 }
 
-// Start method runs the main loop of the Challenger. This loop has 2 main events:
+// Runs the Challenger in a separate goroutine. This should be called only one time per Challenger.
+// Returns an error channel, that in case of an error in the run method will contain the received error.
+func (c *Challenger[Input, Output]) Start(ctx context.Context) <-chan error {
+	errChan := make(chan error)
+
+	go func() {
+		errChan <- c.run(ctx)
+	}()
+
+	return errChan
+}
+
+// The run method executes the main loop of the Challenger. This loop has 2 main events:
 //   - Receive a task responded event: In this case the challenger will process that event, saving the
 //     task index
 //   - Receive a new task created event log: In this case the challenger processes that event, and in case
 //     the response is wrong, a challenge will be raised
-func (c *Challenger[Input, Output]) Start(ctx context.Context) error {
+func (c *Challenger[Input, Output]) run(ctx context.Context) error {
 	c.logger.Info("Starting Challenger.")
 
 	for {

--- a/examples/awesome-vault-service/aggregator/main.go
+++ b/examples/awesome-vault-service/aggregator/main.go
@@ -119,7 +119,7 @@ func main() {
 		return
 	}
 
-	err = aggregator.Start(context.Background())
+	err = <-aggregator.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Failure while running aggregator: %w", err)
 		return

--- a/examples/awesome-vault-service/challenger/main.go
+++ b/examples/awesome-vault-service/challenger/main.go
@@ -103,7 +103,7 @@ func main() {
 	}
 
 	// 5. Start the challenger
-	err = challenger.Start(context.Background())
+	err = <-challenger.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Failure while running challenger: %w", err)
 		return

--- a/examples/awesome-vault-service/operator/main.go
+++ b/examples/awesome-vault-service/operator/main.go
@@ -87,7 +87,7 @@ func main() {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}
 
-	err = operator.Start(context.Background())
+	err = <-operator.Start(context.Background())
 	if err != nil {
 		logger.Fatalf("Failure while running operator: %w", err)
 	}

--- a/examples/awesome-vault-service/task-spammer/main.go
+++ b/examples/awesome-vault-service/task-spammer/main.go
@@ -90,7 +90,7 @@ func main() {
 	}
 
 	// 5. Run the created task spammer, passing the created sequence as parameter
-	err = taskSpammer.Start(context.Background())
+	err = <-taskSpammer.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Failure while running Task Spammer: %w", err)
 		return

--- a/examples/incredible-dot-product/aggregator/main.go
+++ b/examples/incredible-dot-product/aggregator/main.go
@@ -119,7 +119,7 @@ func main() {
 		return
 	}
 
-	err = aggregator.Start(context.Background())
+	err = <-aggregator.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Failure while running aggregator: %w", err)
 		return

--- a/examples/incredible-dot-product/challenger/main.go
+++ b/examples/incredible-dot-product/challenger/main.go
@@ -105,7 +105,7 @@ func main() {
 	}
 
 	// 6. Start the challenger
-	err = challenger.Start(context.Background())
+	err = <-challenger.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Failure while running challenger: %w", err)
 		return

--- a/examples/incredible-dot-product/operator/main.go
+++ b/examples/incredible-dot-product/operator/main.go
@@ -87,7 +87,7 @@ func main() {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}
 
-	err = operator.Start(context.Background())
+	err = <-operator.Start(context.Background())
 	if err != nil {
 		logger.Fatalf("Failure while running operator: %w", err)
 	}

--- a/examples/incredible-dot-product/task-spammer/main.go
+++ b/examples/incredible-dot-product/task-spammer/main.go
@@ -92,7 +92,7 @@ func main() {
 	}
 
 	// 5. Run the created task spammer, passing the created sequence as parameter
-	err = taskSpammer.Start(context.Background())
+	err = <-taskSpammer.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Failure while running Task Spammer: %w", err)
 		return

--- a/examples/incredible-squaring/aggregator/main.go
+++ b/examples/incredible-squaring/aggregator/main.go
@@ -101,7 +101,7 @@ func main() {
 		return
 	}
 
-	err = aggregator.Start(context.Background())
+	err = <-aggregator.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Failure while running aggregator: %w", err)
 		return

--- a/examples/incredible-squaring/challenger/main.go
+++ b/examples/incredible-squaring/challenger/main.go
@@ -104,7 +104,7 @@ func main() {
 	}
 
 	// 6. Start the challenger
-	err = challenger.Start(context.Background())
+	err = <-challenger.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Error while running challenger: %v", err)
 		return

--- a/examples/incredible-squaring/operator/main.go
+++ b/examples/incredible-squaring/operator/main.go
@@ -82,7 +82,7 @@ func main() {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}
 
-	err = operator.Start(context.Background())
+	err = <-operator.Start(context.Background())
 	if err != nil {
 		logger.Fatalf("Failure while running operator: %w", err)
 	}

--- a/examples/incredible-squaring/task-spammer/main.go
+++ b/examples/incredible-squaring/task-spammer/main.go
@@ -83,7 +83,7 @@ func main() {
 	}
 
 	// 5. Run the created task spammer, passing the created sequence as parameter
-	err = taskSpammer.Start(context.Background())
+	err = <-taskSpammer.Start(context.Background())
 	if err != nil {
 		return
 	}

--- a/operator/README.md
+++ b/operator/README.md
@@ -84,25 +84,25 @@ The Operator functions through the following flow:
 
 5. **Failing Response Calculator**: If you want to test what happens when the operator responds incorrectly to a task and see how slashing works, you can wrap your logic with `NewFailingResponseCalculator` method to inject failures and a given failure rate. **Use this for testing purposes only.**
 
-    ```go
-        logic, err := operator.NewFailingResponseCalculator(calculator, 50, big.NewInt(0))
-    ```
+   ```go
+      logic, err := operator.NewFailingResponseCalculator(calculator, 50, big.NewInt(0))
+   ```
 
 6. **Run the operator**: Initialize the `Operator` with the configuration and the processing logic. Then start the operator.
 
-    ```go
-        operator, err := operator.NewOperatorFromConfig(operatorConfig, logic, nil)
-        if err != nil {
-          logger.Errorf("Failed to create operator from config: %v", err)
-          return
-        }
+   ```go
+      operator, err := operator.NewOperatorFromConfig(operatorConfig, logic, nil)
+      if err != nil {
+         logger.Errorf("Failed to create operator from config: %v", err)
+         return
+      }
 
-        err = operator.Start(context.Background())
-        if err != nil {
-          logger.Errorf("Error while running operator: %v", err)
-          return
-        }
-    ```
+      err = <-operator.Start(context.Background())
+      if err != nil {
+         logger.Errorf("Error while running operator: %v", err)
+         return
+      }
+   ```
 
 ## Examples
 

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -178,9 +178,21 @@ func NewOperatorFromConfig[Input any, Output any](
 	return operator, nil
 }
 
-// The start function executes the main loop for the operator, that basically listens to new task created events
+// Runs the Operator in a separate goroutine. This should be called only one time per Operator.
+// Returns an error channel, that in case of an error in the run method will contain the received error.
+func (o *Operator[Input, Output]) Start(ctx context.Context) <-chan error {
+	errChan := make(chan error)
+
+	go func() {
+		errChan <- o.run(ctx)
+	}()
+
+	return errChan
+}
+
+// The run method executes the main loop for the operator, that basically listens to new task created events
 // and respond to those tasks, signs them and sends them to the aggregator via aggregator RPC client.
-func (o *Operator[Input, Output]) Start(ctx context.Context) error {
+func (o *Operator[Input, Output]) run(ctx context.Context) error {
 	o.logger.Info("Starting operator.")
 
 	for {

--- a/task-spammer/README.md
+++ b/task-spammer/README.md
@@ -71,7 +71,7 @@ The Task Spammer uses a builder pattern and follows this workflow:
 5. **Start the Task Spammer**: Call the `Start` method to start the task spammer
 
     ```go
-      taskSpammer.Start(context.Background())
+      err = <-taskSpammer.Start(context.Background())
     ```
 
 ## Examples

--- a/task-spammer/task_spammer.go
+++ b/task-spammer/task_spammer.go
@@ -29,23 +29,35 @@ func NewTaskSpammer[Input any](taskCreator taskmanager.TaskCreator[Input], confi
 	}, nil
 }
 
-// The start method contains the main loop of the task spammer, that creates new tasks every period of time, and
+// Runs the Task Spammer in a separate goroutine. This should be called only one time per Task Spammer.
+// Returns an error channel, that in case of an error in the run method will contain the received error.
+func (taskSpam *TaskSpammer[Input]) Start(ctx context.Context) <-chan error {
+	errChan := make(chan error)
+
+	go func() {
+		errChan <- taskSpam.run(ctx)
+	}()
+
+	return errChan
+}
+
+// The run method contains the main loop of the task spammer, that creates new tasks every period of time, and
 // sends them to the on-chain task manager contract. The input sent to the task manager contract on each iteration
 // depends on the inputGen received by parameter.
 // Note that the taskIndex value is not sent to the task manager contract, so it may differ (will differ if shut
 // down and raise another without reseting the anvil node), but it wont affect the workflow of the system.
-func (taskGen *TaskSpammer[Input]) Start(ctx context.Context) error {
-	logger := taskGen.config.Logger
+func (taskSpam *TaskSpammer[Input]) run(ctx context.Context) error {
+	logger := taskSpam.config.Logger
 
 	logger.Info("Starting Task Spammer.")
 
-	ticker := time.NewTicker(taskGen.config.TimeBetweenTasks)
+	ticker := time.NewTicker(taskSpam.config.TimeBetweenTasks)
 	defer ticker.Stop()
-	logger.Infof("Task Spammer set to send new task every %v seconds...", taskGen.config.TimeBetweenTasks)
+	logger.Infof("Task Spammer set to send new task every %v seconds...", taskSpam.config.TimeBetweenTasks)
 
 	taskIndex := int64(0)
 
-	nextInput, stop := iter.Pull(taskGen.inputGen)
+	nextInput, stop := iter.Pull(taskSpam.inputGen)
 	defer stop()
 
 	for {
@@ -57,7 +69,7 @@ func (taskGen *TaskSpammer[Input]) Start(ctx context.Context) error {
 			logger.Info("Task Spammer finished sending tasks")
 			return nil
 		}
-		err := taskGen.taskCreator.CreateNewTask(ctx, value, taskGen.config.QuorumThresholdPercentage, taskGen.config.QuorumNumbers)
+		err := taskSpam.taskCreator.CreateNewTask(ctx, value, taskSpam.config.QuorumThresholdPercentage, taskSpam.config.QuorumNumbers)
 		if err != nil {
 			logger.Error("Task Spammer failed to send new task", "err", err)
 			return err


### PR DESCRIPTION
### What Changed?
This PR enables the entities to run on separate Goroutines generated by the Start method, which now returns an error channel.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it