### PR TITLE
feat(v2): read config from toml on AVS use examples

### DIFF
--- a/examples/awesome-vault-service/challenger/main.go
+++ b/examples/awesome-vault-service/challenger/main.go
@@ -16,6 +16,14 @@ import (
 	avtaskmanager "github.com/Layr-Labs/eigensdk-go/examples/awesome-vault-service/contracts/bindings/AwesomeVaultTaskManager"
 )
 
+// This config contains the values needed to create and run the Challenger
+type Config struct {
+	TaskManagerAddress string `toml:"task_manager_address"`
+
+	EthHttpUrl string `toml:"eth_http_url"`
+	EthWsUrl   string `toml:"eth_ws_url"`
+}
+
 func main() {
 	// 0. Create the logger where all the logs will appear
 	logger, err := logging.NewZapLogger(logging.Production) // Change here if want to change logging level
@@ -26,6 +34,12 @@ func main() {
 
 	// 1. Create the config passed to the challenger
 
+	challengerConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/challenger_config.toml", challengerConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	// Get the ABI of the task manager contract's binding
 	taskManagerAbi, err := avtaskmanager.ContractAwesomeVaultTaskManagerMetaData.GetAbi()
 	if err != nil {
@@ -34,14 +48,14 @@ func main() {
 	}
 
 	// Create the ethereum client that will send the RPC messages to the node
-	ethClient, err := ethclient.Dial("http://localhost:8545")
+	ethClient, err := ethclient.Dial(challengerConfig.EthHttpUrl)
 	if err != nil {
 		logger.Errorf("Failed to dial ethclient: %w", err)
 		return
 	}
 
-	challengerConfig := challenger.Config{
-		EthWsUrl:       "ws://localhost:8545",
+	cfg := challenger.Config{
+		EthWsUrl:       challengerConfig.EthWsUrl,
 		Logger:         logger,
 		TaskManagerAbi: taskManagerAbi,
 		EthClient:      ethClient,
@@ -75,7 +89,7 @@ func main() {
 	// Note that in this step we define the input and output types that we are using on our AVS. In this case
 	// the TaskInput struct (a key-value pair) and 32 bytes.
 	challengeRaiser, err := taskmanager.NewTaskManagerFromAbi[examplecommon.TaskInput, [32]byte](
-		gethcommon.HexToAddress("0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"),
+		gethcommon.HexToAddress(challengerConfig.TaskManagerAddress),
 		taskManagerAbi,
 		txMgr,
 		ethClient,
@@ -94,7 +108,7 @@ func main() {
 
 	// 4. Create a Challenger from the Config and the ChallengerProcessor.
 	challenger, err := challenger.NewChallenger(
-		challengerConfig,
+		cfg,
 		challengerProcessor,
 	)
 	if err != nil {

--- a/examples/awesome-vault-service/common/common.go
+++ b/examples/awesome-vault-service/common/common.go
@@ -1,9 +1,12 @@
 package examplecommon
 
 import (
+	"os"
 	"slices"
 
 	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 type TaskInput struct {
@@ -39,4 +42,16 @@ func hashNodes(leftNode [32]byte, rightNode [32]byte) [32]byte {
 		leftNode, rightNode = rightNode, leftNode
 	}
 	return crypto.Keccak256Hash(leftNode[:], rightNode[:])
+}
+
+// This function reads the config from the .toml file at the path received as a parameter
+// and returns a config with those values
+func ReadTomlConfig(path string, config any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	err = toml.Unmarshal(data, config)
+	return err
 }

--- a/examples/awesome-vault-service/config/challenger_config.toml
+++ b/examples/awesome-vault-service/config/challenger_config.toml
@@ -1,0 +1,5 @@
+# Node URLs
+eth_http_url = "http://localhost:8545"
+eth_ws_url = "ws://localhost:8545"
+
+task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/examples/awesome-vault-service/config/operator_config.toml
+++ b/examples/awesome-vault-service/config/operator_config.toml
@@ -1,0 +1,27 @@
+operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+# This is the address of the contracts which are deployed in the anvil saved state
+# The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
+# TODO: automate updating these addresses when we deploy new contracts
+
+# Core deployment
+allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
+delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
+rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
+
+# Avs deployment
+service_manager_address = "0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"
+registry_coordinator_address = "0xfd471836031dc5108809d173a067e8486b9047a3"
+token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
+
+ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
+bls_private_key_store_path = "keys/test.bls.key.json"
+
+# Node URLs
+eth_http_url = "http://localhost:8545"
+eth_ws_url = "ws://localhost:8545"
+
+aggregator_server_ip_port = "localhost:8090"
+
+task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/examples/awesome-vault-service/config/task_spammer_config.toml
+++ b/examples/awesome-vault-service/config/task_spammer_config.toml
@@ -1,0 +1,4 @@
+# Node URLs
+eth_http_url = "http://localhost:8545"
+
+task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/examples/awesome-vault-service/operator/main.go
+++ b/examples/awesome-vault-service/operator/main.go
@@ -55,6 +55,9 @@ func main() {
 		return
 	}
 
+	// 2. Create the operator config, including the registration config. If you don't want to
+	// register your operator, you can leave the RegistrationCfg field of operator config empty
+
 	opConfig := &Config{}
 	err = examplecommon.ReadTomlConfig("config/operator_config.toml", opConfig)
 	if err != nil {
@@ -93,6 +96,9 @@ func main() {
 		TaskManagerAbi:                taskManagerAbi,
 		RegistrationCfg:               registrationConfig,
 	}
+
+	// 3. Implement the computation function that processes task inputs and produces outputs
+	// (we do this in examples/incredible-squaring/common/common.go)
 
 	// 4. Create the response calculator with the AVS calculation logic. Note that here we create a
 	// custom Response calculator, declared on examples/awesome-vault-service/common/response_calculator.go

--- a/examples/awesome-vault-service/operator/main.go
+++ b/examples/awesome-vault-service/operator/main.go
@@ -12,6 +12,32 @@ import (
 	taskmanager "github.com/Layr-Labs/eigensdk-go/examples/awesome-vault-service/contracts/bindings/AwesomeVaultTaskManager"
 )
 
+// TODO: add toml flags to the SDK operator config, removing most of this config attributes
+type Config struct {
+	OperatorAddress string `toml:"operator_address"`
+
+	// Core deployment addresses
+	AllocationManagerAddress    string `toml:"allocation_manager_address"`
+	DelegationManagerAddress    string `toml:"delegation_manager_address"`
+	RewardsCoordinatorAddress   string `toml:"rewards_coordinator_address"`
+	PermissionControllerAddress string `toml:"permission_controller_address"`
+
+	// Avs deployment addresses
+	ServiceManagerAddress      string `toml:"service_manager_address"`
+	RegistryCoordinatorAddress string `toml:"registry_coordinator_address"`
+	TokenStrategyAddr          string `toml:"token_strategy_addr"`
+
+	EcdsaPrivateKeyStorePath string `toml:"ecdsa_private_key_store_path"`
+	BlsPrivateKeyStorePath   string `toml:"bls_private_key_store_path"`
+
+	EthRpcUrl string `toml:"eth_http_url"`
+	EthWsUrl  string `toml:"eth_ws_url"`
+
+	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`
+
+	TaskManagerAddress string `toml:"task_manager_address"`
+}
+
 // This is the main function for the operator in the awesome vault service example. The steps followed are
 // also explained in the operator module readme, which can be found at operator/README.md
 func main() {
@@ -29,22 +55,26 @@ func main() {
 		return
 	}
 
-	// 2. Create the operator config, including the registration config. If you don't want to
-	// register your operator, you can leave the RegistrationCfg field of operator config empty
+	opConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/operator_config.toml", opConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	amount := new(big.Int)
 	amount.SetString("1000000000000000000000", 10)
 	registrationConfig := operator.RegistrationConfig{
 		RegisterOnStartup: true,
 
-		AllocationManagerAddr: common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
-		AvsAddress:            common.HexToAddress("0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"),
-		StrategyAddrs:         []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
+		AllocationManagerAddr: common.HexToAddress(opConfig.AllocationManagerAddress),
+		AvsAddress:            common.HexToAddress(opConfig.ServiceManagerAddress),
+		StrategyAddrs:         []common.Address{common.HexToAddress(opConfig.TokenStrategyAddr)},
 
-		DelegationManagerAddress:    common.HexToAddress("0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"),
-		RewardsCoordinatorAddress:   common.HexToAddress("0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"),
-		PermissionControllerAddress: common.HexToAddress("0x59b670e9fa9d0a427751af201d676719a970857b"),
+		DelegationManagerAddress:    common.HexToAddress(opConfig.DelegationManagerAddress),
+		RewardsCoordinatorAddress:   common.HexToAddress(opConfig.RewardsCoordinatorAddress),
+		PermissionControllerAddress: common.HexToAddress(opConfig.PermissionControllerAddress),
 
-		EcdsaKeyStorePath: "keys/test.ecdsa.key.json",
+		EcdsaKeyStorePath: opConfig.EcdsaPrivateKeyStorePath,
 
 		AmountToMint:          amount,
 		AllocatableMagnitudes: []uint64{1000000000000000},
@@ -53,20 +83,15 @@ func main() {
 	}
 
 	operatorConfig := operator.Config{
-		Logger:         logger,
-		TaskManagerAbi: taskManagerAbi,
-
-		OperatorAddress: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-
-		RegistryCoordinatorAddress: "0xfd471836031dc5108809d173a067e8486b9047a3",
-
-		EthWsUrl:                      "ws://localhost:8545",
-		EthRpcUrl:                     "http://localhost:8545",
-		AggregatorServerIpPortAddress: "localhost:8090",
-
-		BlsPrivateKeyStorePath: "keys/test.bls.key.json",
-
-		RegistrationCfg: registrationConfig,
+		OperatorAddress:               opConfig.OperatorAddress,
+		RegistryCoordinatorAddress:    opConfig.RegistryCoordinatorAddress,
+		EthRpcUrl:                     opConfig.EthRpcUrl,
+		EthWsUrl:                      opConfig.EthWsUrl,
+		BlsPrivateKeyStorePath:        opConfig.BlsPrivateKeyStorePath,
+		AggregatorServerIpPortAddress: opConfig.AggregatorServerIpPortAddress,
+		Logger:                        logger,
+		TaskManagerAbi:                taskManagerAbi,
+		RegistrationCfg:               registrationConfig,
 	}
 
 	// 4. Create the response calculator with the AVS calculation logic. Note that here we create a

--- a/examples/awesome-vault-service/task-spammer/main.go
+++ b/examples/awesome-vault-service/task-spammer/main.go
@@ -18,6 +18,12 @@ import (
 	avtaskmanager "github.com/Layr-Labs/eigensdk-go/examples/awesome-vault-service/contracts/bindings/AwesomeVaultTaskManager"
 )
 
+type Config struct {
+	TaskManagerAddress string `toml:"task_manager_address"`
+
+	EthHttpUrl string `toml:"eth_http_url"`
+}
+
 func main() {
 	// 0. Create the logger where all the logs will appear
 	logger, err := logging.NewZapLogger(logging.Production)
@@ -28,8 +34,14 @@ func main() {
 
 	// 1. Provide a struct that implements the `TaskManager` interface
 
+	tsConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/task_spammer_config.toml", tsConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	// i. Create the ethereum client that will send the RPC messages to the node
-	ethClient, err := ethclient.Dial("http://localhost:8545")
+	ethClient, err := ethclient.Dial(tsConfig.EthHttpUrl)
 	if err != nil {
 		logger.Errorf("Failed to dial ethclient: %w", err)
 		return
@@ -60,7 +72,7 @@ func main() {
 	// in task-manager/task_manager_wrapper.go
 	// Note that in this step we define the input and output types that we are using on our AVS. In this case
 	// the TaskInput struct (a key-value pair) and 32 bytes.
-	taskManagerAddr := common.HexToAddress("0x7bc06c482dead17c0e297afbc32f6e63d3846650")
+	taskManagerAddr := common.HexToAddress(tsConfig.TaskManagerAddress)
 	taskCreator, err := taskmanager.NewTaskManagerFromAbi[examplecommon.TaskInput, [32]byte](taskManagerAddr, taskManagerAbi, txMgr, ethClient)
 	if err != nil {
 		return

--- a/examples/incredible-dot-product/challenger/main.go
+++ b/examples/incredible-dot-product/challenger/main.go
@@ -101,14 +101,14 @@ func main() {
 		return
 	}
 
-	// 4. Create the Challenger Processor, with the challenger raiser created above.
+	// Create the Challenger Processor, with the challenger raiser created above.
 	challengerProcessor, err := challengerprocessor.NewIndexingChallengerProcessor(logger, dotProductValidation, challengeRaiser)
 	if err != nil {
 		logger.Errorf("Failed to create challenger processor: %v", err)
 		return
 	}
 
-	// 5. Create a Challenger from the Config and the ChallengerProcessor.
+	// 4. Create a Challenger from the Config and the ChallengerProcessor.
 	challenger, err := challenger.NewChallenger(
 		cfg,
 		challengerProcessor,
@@ -118,7 +118,7 @@ func main() {
 		return
 	}
 
-	// 6. Start the challenger
+	// 5. Start the challenger
 	err = <-challenger.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Failure while running challenger: %w", err)

--- a/examples/incredible-dot-product/challenger/main.go
+++ b/examples/incredible-dot-product/challenger/main.go
@@ -19,6 +19,14 @@ import (
 	idptaskmanager "github.com/Layr-Labs/eigensdk-go/examples/incredible-dot-product/contracts/bindings/IncredibleDotProductTaskManager"
 )
 
+// This config contains the values needed to create and run the Challenger
+type Config struct {
+	TaskManagerAddress string `toml:"task_manager_address"`
+
+	EthHttpUrl string `toml:"eth_http_url"`
+	EthWsUrl   string `toml:"eth_ws_url"`
+}
+
 func main() {
 	// 0. Create the logger where all the logs will appear
 	logger, err := logging.NewZapLogger(logging.Production) // Change here if want to change logging level
@@ -29,6 +37,12 @@ func main() {
 
 	// 1. Create the config passed to the challenger
 
+	challengerConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/challenger_config.toml", challengerConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	// Get the ABI of the task manager contract's binding
 	taskManagerAbi, err := idptaskmanager.ContractIncredibleDotProductTaskManagerMetaData.GetAbi()
 	if err != nil {
@@ -36,14 +50,14 @@ func main() {
 	}
 
 	// Create the ethereum client that will send the RPC messages to the node
-	ethClient, err := ethclient.Dial("http://localhost:8545")
+	ethClient, err := ethclient.Dial(challengerConfig.EthHttpUrl)
 	if err != nil {
 		logger.Errorf("Failed to dial ethclient: %w", err)
 		return
 	}
 
-	challengerConfig := challenger.Config{
-		EthWsUrl:       "ws://localhost:8545",
+	cfg := challenger.Config{
+		EthWsUrl:       challengerConfig.EthWsUrl,
 		Logger:         logger,
 		TaskManagerAbi: taskManagerAbi,
 		EthClient:      ethClient,
@@ -77,7 +91,7 @@ func main() {
 	// Note that in this step we define the input and output types that we are using on our AVS. In this case
 	// the DotProductInput struct (a pair of vectors) and a big int.
 	challengeRaiser, err := taskmanager.NewTaskManagerFromAbi[examplecommon.DotProductInput, *big.Int](
-		gethcommon.HexToAddress("0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"),
+		gethcommon.HexToAddress(challengerConfig.TaskManagerAddress),
 		taskManagerAbi,
 		txMgr,
 		ethClient,
@@ -96,7 +110,7 @@ func main() {
 
 	// 5. Create a Challenger from the Config and the ChallengerProcessor.
 	challenger, err := challenger.NewChallenger(
-		challengerConfig,
+		cfg,
 		challengerProcessor,
 	)
 	if err != nil {

--- a/examples/incredible-dot-product/common/common.go
+++ b/examples/incredible-dot-product/common/common.go
@@ -1,6 +1,11 @@
 package examplecommon
 
-import "math/big"
+import (
+	"math/big"
+	"os"
+
+	"github.com/pelletier/go-toml/v2"
+)
 
 type DotProductInput struct {
 	X []*big.Int
@@ -16,4 +21,16 @@ func DotProduct(taskIndex uint32, points DotProductInput) (*big.Int, error) {
 	}
 
 	return totalSum, nil
+}
+
+// This function reads the config from the .toml file at the path received as a parameter
+// and returns a config with those values
+func ReadTomlConfig(path string, config any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	err = toml.Unmarshal(data, config)
+	return err
 }

--- a/examples/incredible-dot-product/config/challenger_config.toml
+++ b/examples/incredible-dot-product/config/challenger_config.toml
@@ -1,0 +1,5 @@
+# Node URLs
+eth_http_url = "http://localhost:8545"
+eth_ws_url = "ws://localhost:8545"
+
+task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/examples/incredible-dot-product/config/operator_config.toml
+++ b/examples/incredible-dot-product/config/operator_config.toml
@@ -1,0 +1,27 @@
+operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+# This is the address of the contracts which are deployed in the anvil saved state
+# The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
+# TODO: automate updating these addresses when we deploy new contracts
+
+# Core deployment
+allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
+delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
+rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
+
+# Avs deployment
+service_manager_address = "0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"
+registry_coordinator_address = "0xfd471836031dc5108809d173a067e8486b9047a3"
+token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
+
+ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
+bls_private_key_store_path = "keys/test.bls.key.json"
+
+# Node URLs
+eth_http_url = "http://localhost:8545"
+eth_ws_url = "ws://localhost:8545"
+
+aggregator_server_ip_port = "localhost:8090"
+
+task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/examples/incredible-dot-product/config/task_spammer_config.toml
+++ b/examples/incredible-dot-product/config/task_spammer_config.toml
@@ -1,0 +1,4 @@
+# Node URLs
+eth_http_url = "http://localhost:8545"
+
+task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/examples/incredible-dot-product/operator/main.go
+++ b/examples/incredible-dot-product/operator/main.go
@@ -12,6 +12,32 @@ import (
 	taskmanager "github.com/Layr-Labs/eigensdk-go/examples/incredible-dot-product/contracts/bindings/IncredibleDotProductTaskManager"
 )
 
+// TODO: add toml flags to the SDK operator config, removing most of this config attributes
+type Config struct {
+	OperatorAddress string `toml:"operator_address"`
+
+	// Core deployment addresses
+	AllocationManagerAddress    string `toml:"allocation_manager_address"`
+	DelegationManagerAddress    string `toml:"delegation_manager_address"`
+	RewardsCoordinatorAddress   string `toml:"rewards_coordinator_address"`
+	PermissionControllerAddress string `toml:"permission_controller_address"`
+
+	// Avs deployment addresses
+	ServiceManagerAddress      string `toml:"service_manager_address"`
+	RegistryCoordinatorAddress string `toml:"registry_coordinator_address"`
+	TokenStrategyAddr          string `toml:"token_strategy_addr"`
+
+	EcdsaPrivateKeyStorePath string `toml:"ecdsa_private_key_store_path"`
+	BlsPrivateKeyStorePath   string `toml:"bls_private_key_store_path"`
+
+	EthRpcUrl string `toml:"eth_http_url"`
+	EthWsUrl  string `toml:"eth_ws_url"`
+
+	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`
+
+	TaskManagerAddress string `toml:"task_manager_address"`
+}
+
 // This is the main function for the operator in the incredible dot product example. The steps followed are
 // also explained in the operator module readme, which can be found at operator/README.md
 func main() {
@@ -31,20 +57,27 @@ func main() {
 
 	// 2. Create the operator config, including the registration config. If you don't want to
 	// register your operator, you can leave the RegistrationCfg field of operator config empty
+
+	opConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/operator_config.toml", opConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	amount := new(big.Int)
 	amount.SetString("1000000000000000000000", 10)
 	registrationConfig := operator.RegistrationConfig{
 		RegisterOnStartup: true,
 
-		AllocationManagerAddr: common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
-		AvsAddress:            common.HexToAddress("0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"),
-		StrategyAddrs:         []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
+		AllocationManagerAddr: common.HexToAddress(opConfig.AllocationManagerAddress),
+		AvsAddress:            common.HexToAddress(opConfig.ServiceManagerAddress),
+		StrategyAddrs:         []common.Address{common.HexToAddress(opConfig.TokenStrategyAddr)},
 
-		DelegationManagerAddress:    common.HexToAddress("0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"),
-		RewardsCoordinatorAddress:   common.HexToAddress("0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"),
-		PermissionControllerAddress: common.HexToAddress("0x59b670e9fa9d0a427751af201d676719a970857b"),
+		DelegationManagerAddress:    common.HexToAddress(opConfig.DelegationManagerAddress),
+		RewardsCoordinatorAddress:   common.HexToAddress(opConfig.RewardsCoordinatorAddress),
+		PermissionControllerAddress: common.HexToAddress(opConfig.PermissionControllerAddress),
 
-		EcdsaKeyStorePath: "keys/test.ecdsa.key.json",
+		EcdsaKeyStorePath: opConfig.EcdsaPrivateKeyStorePath,
 
 		AmountToMint:          amount,
 		AllocatableMagnitudes: []uint64{1000000000000000},
@@ -53,20 +86,15 @@ func main() {
 	}
 
 	operatorConfig := operator.Config{
-		Logger:         logger,
-		TaskManagerAbi: taskManagerAbi,
-
-		OperatorAddress: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-
-		RegistryCoordinatorAddress: "0xfd471836031dc5108809d173a067e8486b9047a3",
-
-		EthWsUrl:                      "ws://localhost:8545",
-		EthRpcUrl:                     "http://localhost:8545",
-		AggregatorServerIpPortAddress: "localhost:8090",
-
-		BlsPrivateKeyStorePath: "keys/test.bls.key.json",
-
-		RegistrationCfg: registrationConfig,
+		OperatorAddress:               opConfig.OperatorAddress,
+		RegistryCoordinatorAddress:    opConfig.RegistryCoordinatorAddress,
+		EthRpcUrl:                     opConfig.EthRpcUrl,
+		EthWsUrl:                      opConfig.EthWsUrl,
+		BlsPrivateKeyStorePath:        opConfig.BlsPrivateKeyStorePath,
+		AggregatorServerIpPortAddress: opConfig.AggregatorServerIpPortAddress,
+		Logger:                        logger,
+		TaskManagerAbi:                taskManagerAbi,
+		RegistrationCfg:               registrationConfig,
 	}
 
 	// 4. Create the response calculator with the AVS calculation logic. Note that here we create a

--- a/examples/incredible-dot-product/operator/main.go
+++ b/examples/incredible-dot-product/operator/main.go
@@ -97,6 +97,9 @@ func main() {
 		RegistrationCfg:               registrationConfig,
 	}
 
+	// 3. Implement the computation function that processes task inputs and produces outputs
+	// (we do this in examples/incredible-dot-product/common/common.go)
+
 	// 4. Create the response calculator with the AVS calculation logic. Note that here we create a
 	// Response calculator with the NewFunctionResponseCalculator from the operator package
 	responseCalculator := operator.NewFunctionResponseCalculator(examplecommon.DotProduct)

--- a/examples/incredible-dot-product/task-spammer/main.go
+++ b/examples/incredible-dot-product/task-spammer/main.go
@@ -18,6 +18,12 @@ import (
 	idptaskmanager "github.com/Layr-Labs/eigensdk-go/examples/incredible-dot-product/contracts/bindings/IncredibleDotProductTaskManager"
 )
 
+type Config struct {
+	TaskManagerAddress string `toml:"task_manager_address"`
+
+	EthHttpUrl string `toml:"eth_http_url"`
+}
+
 func main() {
 	// 0. Create the logger where all the logs will appear
 	logger, err := logging.NewZapLogger(logging.Production)
@@ -28,8 +34,14 @@ func main() {
 
 	// 1. Provide a struct that implements the `TaskManager` interface
 
+	tsConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/task_spammer_config.toml", tsConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	// i. Create the ethereum client that will send the RPC messages to the node
-	ethClient, err := ethclient.Dial("http://localhost:8545")
+	ethClient, err := ethclient.Dial(tsConfig.EthHttpUrl)
 	if err != nil {
 		logger.Errorf("Failed to dial ethclient: %w", err)
 		return
@@ -61,7 +73,7 @@ func main() {
 	// in task-manager/task_manager_wrapper.go
 	// Note that in this step we define the input and output types that we are using on our AVS. In this case
 	// the DotProductInput struct (a pair of vectors) and a big int.
-	taskManagerAddr := common.HexToAddress("0x7bc06c482dead17c0e297afbc32f6e63d3846650")
+	taskManagerAddr := common.HexToAddress(tsConfig.TaskManagerAddress)
 	taskCreator, err := taskmanager.NewTaskManagerFromAbi[examplecommon.DotProductInput, *big.Int](taskManagerAddr, taskManagerAbi, txMgr, ethClient)
 	if err != nil {
 		logger.Errorf("Failed to create Task Creator: %w", err)

--- a/examples/incredible-squaring/aggregator/main.go
+++ b/examples/incredible-squaring/aggregator/main.go
@@ -14,7 +14,16 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/incredible-squaring/bindings/taskManager"
+	examplecommon "github.com/Layr-Labs/eigensdk-go/examples/incredible-squaring/common"
 )
+
+// This config has the same attributes as the aggregator config and also includes the
+// deployed TaskManager contract address
+type Config struct {
+	aggregator.Config
+
+	TaskManagerAddress string `toml:"task_manager_address"`
+}
 
 // This is the main function for the aggregator in the incredible squaring example. The steps followed are
 // also explained in the aggregator module readme, which can be found at aggregator/README.md
@@ -26,21 +35,20 @@ func main() {
 		return
 	}
 
-	// 1. Create the aggregator configuration
-	ethHttpUrl := "http://localhost:8545"
-	cfg := aggregator.Config{
-		RegistryCoordinatorAddress:    common.HexToAddress("0x7bc06c482dead17c0e297afbc32f6e63d3846650"),
-		OperatorStateRetrieverAddress: common.HexToAddress("0x4c5859f0f772848b2d91f1d83e2fe57935348029"),
-		EthHttpUrl:                    ethHttpUrl,
-		EthWsUrl:                      "ws://localhost:8545",
-		AggregatorServerIpPortAddr:    "localhost:8090",
+	// 1. Create the aggregator configuration (in this case we read it from aggregator config file)
+	config := &Config{}
+	err = examplecommon.ReadTomlConfig("config/aggregator_config.toml", config)
+	if err != nil {
+		logger.Errorf("Failed to read config file: %w", err)
+		return
 	}
+	aggConfig := config.Config
 
 	// 2. Provide a Task Processor, first instantiating the things required for creating it
 
 	// i. Create the ethereum client that will send the RPC messages to the node, and the transaction
 	// manager, that will manage the transaction sending
-	ethClient, err := ethclient.Dial(ethHttpUrl)
+	ethClient, err := ethclient.Dial(aggConfig.EthHttpUrl)
 	if err != nil {
 		logger.Errorf("Failed to dial ethclient: %w", err)
 		return
@@ -95,7 +103,7 @@ func main() {
 
 	// 3. Build the aggregator, providing aggregator config, logger, task processor and the task manager ABI, and
 	// then start it.
-	aggregator, err := aggregator.NewAggregator(cfg, logger, taskProcessor, taskManagerAbi)
+	aggregator, err := aggregator.NewAggregator(aggConfig, logger, taskProcessor, taskManagerAbi)
 	if err != nil {
 		logger.Errorf("Failed to create aggregator: %w", err)
 		return

--- a/examples/incredible-squaring/challenger/main.go
+++ b/examples/incredible-squaring/challenger/main.go
@@ -100,14 +100,14 @@ func main() {
 		return
 	}
 
-	// 4. Create the Challenger Processor, with the challenger raiser created above.
+	// Create the Challenger Processor, with the challenger raiser created above.
 	indexingChallengerProcessor, err := challengerprocessor.NewIndexingChallengerProcessor(logger, squareValidation, challengeRaiser)
 	if err != nil {
 		logger.Errorf("Failed to create challenger logic from config: %v", err)
 		return
 	}
 
-	// 5. Create a Challenger from the Config and the ChallengerProcessor.
+	// 4. Create a Challenger from the Config and the ChallengerProcessor.
 	challenger, err := challenger.NewChallenger(
 		cfg,
 		indexingChallengerProcessor,
@@ -117,7 +117,7 @@ func main() {
 		return
 	}
 
-	// 6. Start the challenger
+	// 5. Start the challenger
 	err = <-challenger.Start(context.Background())
 	if err != nil {
 		logger.Errorf("Error while running challenger: %v", err)

--- a/examples/incredible-squaring/challenger/main.go
+++ b/examples/incredible-squaring/challenger/main.go
@@ -20,6 +20,14 @@ import (
 	examplecommon "github.com/Layr-Labs/eigensdk-go/examples/incredible-squaring/common"
 )
 
+// This config contains the values needed to create and run the Challenger
+type Config struct {
+	TaskManagerAddress string `toml:"task_manager_address"`
+
+	EthHttpUrl string `toml:"eth_http_url"`
+	EthWsUrl   string `toml:"eth_ws_url"`
+}
+
 func main() {
 	// 0. Create the logger where all the logs will appear
 	logger, err := logging.NewZapLogger(logging.Production) // Change here if want to change logging level
@@ -30,6 +38,12 @@ func main() {
 
 	// 1. Create the config passed to the challenger
 
+	challengerConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/challenger_config.toml", challengerConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	// Get the ABI of the task manager contract's binding
 	taskManagerAbi, err := cstaskmanager.ContractIncredibleSquaringTaskManagerMetaData.GetAbi()
 	if err != nil {
@@ -37,13 +51,13 @@ func main() {
 	}
 
 	// Create the ethereum client that will send the RPC messages to the node
-	ethHttpClient, err := ethclient.Dial("http://localhost:8545")
+	ethHttpClient, err := ethclient.Dial(challengerConfig.EthHttpUrl)
 	if err != nil {
 		return
 	}
 
 	cfg := challenger.Config{
-		EthWsUrl:       "ws://localhost:8545",
+		EthWsUrl:       challengerConfig.EthWsUrl,
 		Logger:         logger,
 		TaskManagerAbi: taskManagerAbi,
 		EthClient:      ethHttpClient,
@@ -76,7 +90,7 @@ func main() {
 	// Note that in this step we define the input and output types that we are using on our AVS. In this case
 	// the input and output are both big int numbers.
 	challengeRaiser, err := taskmanager.NewTaskManagerFromAbi[*big.Int, *big.Int](
-		gethcommon.HexToAddress("0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"),
+		gethcommon.HexToAddress(challengerConfig.TaskManagerAddress),
 		taskManagerAbi,
 		txMgr,
 		ethHttpClient,

--- a/examples/incredible-squaring/common/common.go
+++ b/examples/incredible-squaring/common/common.go
@@ -1,10 +1,27 @@
 package examplecommon
 
-import "math/big"
+import (
+	"math/big"
+	"os"
+
+	"github.com/pelletier/go-toml/v2"
+)
 
 // This function computes the square of a number
 func Square(taskIndex uint32, numberToSquare *big.Int) (*big.Int, error) {
 	numberSquared := big.NewInt(0).Exp(numberToSquare, big.NewInt(2), nil)
 
 	return numberSquared, nil
+}
+
+// This function reads the config from the .toml file at the path received as a parameter
+// and returns a config with those values
+func ReadTomlConfig(path string, config any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	err = toml.Unmarshal(data, config)
+	return err
 }

--- a/examples/incredible-squaring/config/aggregator_config.toml
+++ b/examples/incredible-squaring/config/aggregator_config.toml
@@ -1,10 +1,10 @@
-task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
+task_manager_address = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"
 
 eth_http_url = "http://localhost:8545"
 eth_ws_url = "ws://localhost:8545"
 
 aggregator_server_ip_port = "localhost:8090"
 
-registry_coordinator_address = "0xfd471836031dc5108809d173a067e8486b9047a3"
-operator_state_retriever_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
-service_manager_address = "0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"
+registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
+operator_state_retriever_address = "0x4c5859f0f772848b2d91f1d83e2fe57935348029"
+service_manager_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"

--- a/examples/incredible-squaring/config/aggregator_config.toml
+++ b/examples/incredible-squaring/config/aggregator_config.toml
@@ -1,0 +1,10 @@
+task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
+
+eth_http_url = "http://localhost:8545"
+eth_ws_url = "ws://localhost:8545"
+
+aggregator_server_ip_port = "localhost:8090"
+
+registry_coordinator_address = "0xfd471836031dc5108809d173a067e8486b9047a3"
+operator_state_retriever_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
+service_manager_address = "0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"

--- a/examples/incredible-squaring/config/challenger_config.toml
+++ b/examples/incredible-squaring/config/challenger_config.toml
@@ -1,29 +1,5 @@
-operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-
-# This is the address of the contracts which are deployed in the anvil saved state
-# The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
-# TODO: automate updating these addresses when we deploy new contracts
-
-# Core deployment
-allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
-delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
-rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
-permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
-
-# Avs deployment
-service_manager_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
-registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
-token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
-
-ecdsa_private_key_store_path = "tests/keys/test.ecdsa.key.json"
-bls_private_key_store_path = "tests/keys/test.bls.key.json"
-
 # Node URLs
 eth_http_url = "http://localhost:8545"
 eth_ws_url = "ws://localhost:8545"
 
-aggregator_server_ip_port = "localhost:8090"
-
 task_manager_address = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"
-
-operator_state_retriever_address = "0x4c5859f0f772848b2d91f1d83e2fe57935348029"

--- a/examples/incredible-squaring/config/challenger_config.toml
+++ b/examples/incredible-squaring/config/challenger_config.toml
@@ -1,0 +1,29 @@
+operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+# This is the address of the contracts which are deployed in the anvil saved state
+# The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
+# TODO: automate updating these addresses when we deploy new contracts
+
+# Core deployment
+allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
+delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
+rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
+
+# Avs deployment
+service_manager_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
+registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
+token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
+
+ecdsa_private_key_store_path = "tests/keys/test.ecdsa.key.json"
+bls_private_key_store_path = "tests/keys/test.bls.key.json"
+
+# Node URLs
+eth_http_url = "http://localhost:8545"
+eth_ws_url = "ws://localhost:8545"
+
+aggregator_server_ip_port = "localhost:8090"
+
+task_manager_address = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"
+
+operator_state_retriever_address = "0x4c5859f0f772848b2d91f1d83e2fe57935348029"

--- a/examples/incredible-squaring/config/operator_config.toml
+++ b/examples/incredible-squaring/config/operator_config.toml
@@ -1,0 +1,27 @@
+operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+# This is the address of the contracts which are deployed in the anvil saved state
+# The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
+# TODO: automate updating these addresses when we deploy new contracts
+
+# Core deployment
+allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
+delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
+rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
+
+# Avs deployment
+service_manager_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
+registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
+token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
+
+ecdsa_private_key_store_path = "tests/keys/test.ecdsa.key.json"
+bls_private_key_store_path = "tests/keys/test.bls.key.json"
+
+# Node URLs
+eth_http_url = "http://localhost:8545"
+eth_ws_url = "ws://localhost:8545"
+
+aggregator_server_ip_port = "localhost:8090"
+
+task_manager_address = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"

--- a/examples/incredible-squaring/config/operator_config.toml
+++ b/examples/incredible-squaring/config/operator_config.toml
@@ -15,8 +15,8 @@ service_manager_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
 token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
 
-ecdsa_private_key_store_path = "tests/keys/test.ecdsa.key.json"
-bls_private_key_store_path = "tests/keys/test.bls.key.json"
+ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
+bls_private_key_store_path = "keys/test.bls.key.json"
 
 # Node URLs
 eth_http_url = "http://localhost:8545"

--- a/examples/incredible-squaring/config/task_spammer_config.toml
+++ b/examples/incredible-squaring/config/task_spammer_config.toml
@@ -1,0 +1,4 @@
+# Node URLs
+eth_http_url = "http://localhost:8545"
+
+task_manager_address = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"

--- a/examples/incredible-squaring/operator/main.go
+++ b/examples/incredible-squaring/operator/main.go
@@ -12,6 +12,32 @@ import (
 	examplecommon "github.com/Layr-Labs/eigensdk-go/examples/incredible-squaring/common"
 )
 
+// TODO: add toml flags to the SDK operator config, removing most of this config attributes
+type Config struct {
+	OperatorAddress string `toml:"operator_address"`
+
+	// Core deployment addresses
+	AllocationManagerAddress    string `toml:"allocation_manager_address"`
+	DelegationManagerAddress    string `toml:"delegation_manager_address"`
+	RewardsCoordinatorAddress   string `toml:"rewards_coordinator_address"`
+	PermissionControllerAddress string `toml:"permission_controller_address"`
+
+	// Avs deployment addresses
+	ServiceManagerAddress      string `toml:"service_manager_address"`
+	RegistryCoordinatorAddress string `toml:"registry_coordinator_address"`
+	TokenStrategyAddr          string `toml:"token_strategy_addr"`
+
+	EcdsaPrivateKeyStorePath string `toml:"ecdsa_private_key_store_path"`
+	BlsPrivateKeyStorePath   string `toml:"bls_private_key_store_path"`
+
+	EthRpcUrl string `toml:"eth_http_url"`
+	EthWsUrl  string `toml:"eth_ws_url"`
+
+	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`
+
+	TaskManagerAddress string `toml:"task_manager_address"`
+}
+
 // This is the main function for the operator in the incredible squaring example. The steps followed are
 // also explained in the operator module readme, which can be found at operator/README.md
 func main() {
@@ -31,20 +57,27 @@ func main() {
 
 	// 2. Create the operator config, including the registration config. If you don't want to
 	// register your operator, you can leave the RegistrationCfg field of operator config empty
+
+	opConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/operator_config.toml", opConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	amount := new(big.Int)
 	amount.SetString("1000000000000000000000", 10)
 	registrationConfig := operator.RegistrationConfig{
 		RegisterOnStartup: true,
 
-		AllocationManagerAddr: common.HexToAddress("0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"),
-		AvsAddress:            common.HexToAddress("0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"),
-		StrategyAddrs:         []common.Address{common.HexToAddress("0x2b961e3959b79326a8e7f64ef0d2d825707669b5")},
+		AllocationManagerAddr: common.HexToAddress(opConfig.AllocationManagerAddress),
+		AvsAddress:            common.HexToAddress(opConfig.ServiceManagerAddress),
+		StrategyAddrs:         []common.Address{common.HexToAddress(opConfig.TokenStrategyAddr)},
 
-		DelegationManagerAddress:    common.HexToAddress("0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"),
-		RewardsCoordinatorAddress:   common.HexToAddress("0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"),
-		PermissionControllerAddress: common.HexToAddress("0x59b670e9fa9d0a427751af201d676719a970857b"),
+		DelegationManagerAddress:    common.HexToAddress(opConfig.DelegationManagerAddress),
+		RewardsCoordinatorAddress:   common.HexToAddress(opConfig.RewardsCoordinatorAddress),
+		PermissionControllerAddress: common.HexToAddress(opConfig.PermissionControllerAddress),
 
-		EcdsaKeyStorePath: "keys/test.ecdsa.key.json",
+		EcdsaKeyStorePath: opConfig.EcdsaPrivateKeyStorePath,
 
 		AmountToMint:          amount,
 		AllocatableMagnitudes: []uint64{1000000000000000},
@@ -53,12 +86,12 @@ func main() {
 	}
 
 	operatorConfig := operator.Config{
-		OperatorAddress:               "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-		RegistryCoordinatorAddress:    "0x7bc06c482dead17c0e297afbc32f6e63d3846650",
-		EthRpcUrl:                     "http://localhost:8545",
-		EthWsUrl:                      "ws://localhost:8545",
-		BlsPrivateKeyStorePath:        "keys/test.bls.key.json",
-		AggregatorServerIpPortAddress: "localhost:8090",
+		OperatorAddress:               opConfig.OperatorAddress,
+		RegistryCoordinatorAddress:    opConfig.RegistryCoordinatorAddress,
+		EthRpcUrl:                     opConfig.EthRpcUrl,
+		EthWsUrl:                      opConfig.EthWsUrl,
+		BlsPrivateKeyStorePath:        opConfig.BlsPrivateKeyStorePath,
+		AggregatorServerIpPortAddress: opConfig.AggregatorServerIpPortAddress,
 		Logger:                        logger,
 		TaskManagerAbi:                taskManagerAbi,
 		RegistrationCfg:               registrationConfig,

--- a/examples/incredible-squaring/operator/main.go
+++ b/examples/incredible-squaring/operator/main.go
@@ -97,6 +97,9 @@ func main() {
 		RegistrationCfg:               registrationConfig,
 	}
 
+	// 3. Implement the computation function that processes task inputs and produces outputs
+	// (we do this in examples/incredible-squaring/common/common.go)
+
 	// 4. Create the response calculator with the AVS calculation logic. Note that here we create a
 	// Response calculator with the NewFunctionResponseCalculator from the operator package
 	calculator := operator.NewFunctionResponseCalculator(examplecommon.Square)

--- a/examples/incredible-squaring/task-spammer/main.go
+++ b/examples/incredible-squaring/task-spammer/main.go
@@ -71,6 +71,7 @@ func main() {
 	taskManagerAddress := common.HexToAddress(tsConfig.TaskManagerAddress)
 	taskCreator, err := taskmanager.NewTaskManagerFromAbi[*big.Int, *big.Int](taskManagerAddress, abi, txMgr, ethHttpClient)
 	if err != nil {
+		logger.Errorf("Failed to create Task Creator: %w", err)
 		return
 	}
 

--- a/examples/incredible-squaring/task-spammer/main.go
+++ b/examples/incredible-squaring/task-spammer/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/txmgr"
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/incredible-squaring/bindings/taskManager"
+	examplecommon "github.com/Layr-Labs/eigensdk-go/examples/incredible-squaring/common"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	taskmanager "github.com/Layr-Labs/eigensdk-go/task-manager"
 	taskspammer "github.com/Layr-Labs/eigensdk-go/task-spammer"
@@ -15,6 +16,12 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
+
+type Config struct {
+	TaskManagerAddress string `toml:"task_manager_address"`
+
+	EthHttpUrl string `toml:"eth_http_url"`
+}
 
 func main() {
 	// 0. Create the logger where all the logs will appear
@@ -25,8 +32,14 @@ func main() {
 
 	// 1. Provide a struct that implements the `TaskManager` interface
 
+	tsConfig := &Config{}
+	err = examplecommon.ReadTomlConfig("config/task_spammer_config.toml", tsConfig)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
 	// i. Create the ethereum client that will send the RPC messages to the node
-	ethHttpClient, err := ethclient.Dial("http://localhost:8545")
+	ethHttpClient, err := ethclient.Dial(tsConfig.EthHttpUrl)
 	if err != nil {
 		logger.Errorf("Failed to dial ethclient: %w", err)
 		return
@@ -55,7 +68,7 @@ func main() {
 	// in task-manager/task_manager_wrapper.go
 	// Note that in this step we define the input and output types that we are using on our AVS. In this case
 	// the input and output are both big int numbers.
-	taskManagerAddress := common.HexToAddress("0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3")
+	taskManagerAddress := common.HexToAddress(tsConfig.TaskManagerAddress)
 	taskCreator, err := taskmanager.NewTaskManagerFromAbi[*big.Int, *big.Int](taskManagerAddress, abi, txMgr, ethHttpClient)
 	if err != nil {
 		return


### PR DESCRIPTION
### What Changed?
This PR moves the hardcoded values on the examples entities initialization to TOML config files.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it