### PR TITLE
feat(v2): add TOML tags to the operator config

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -49,10 +49,10 @@ type Aggregator[Input any, Output any] struct {
 
 // NewAggregator creates a new Aggregator with the provided config, a logger, a task processor and the task manager contract's ABI.
 func NewAggregator[Input any, Output any](
-	c Config,
 	logger logging.Logger,
-	taskProcessor taskprocessor.TaskProcessor[Input, Output],
+	c Config,
 	taskManagerAbi *abi.ABI,
+	taskProcessor taskprocessor.TaskProcessor[Input, Output],
 ) (*Aggregator[Input, Output], error) {
 	avsRegistryConfig := avsregistry.Config{
 		RegistryCoordinatorAddress:    c.RegistryCoordinatorAddress,

--- a/examples/awesome-vault-service/aggregator/main.go
+++ b/examples/awesome-vault-service/aggregator/main.go
@@ -113,7 +113,7 @@ func main() {
 
 	// 3. Build the aggregator, providing aggregator config, logger, task processor and the task manager ABI, and
 	// then start it.
-	aggregator, err := aggregator.NewAggregator(aggConfig, logger, taskProcessor, taskManagerAbi)
+	aggregator, err := aggregator.NewAggregator(logger, aggConfig, taskManagerAbi, taskProcessor)
 	if err != nil {
 		logger.Errorf("Failed to create aggregator: %w", err)
 		return

--- a/examples/awesome-vault-service/config/config.toml
+++ b/examples/awesome-vault-service/config/config.toml
@@ -4,18 +4,10 @@ operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 # The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
 # TODO: automate updating these addresses when we deploy new contracts
 
-# Core deployment
-allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
-delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
-rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
-permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
-
 # Avs deployment
-service_manager_address = "0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"
 registry_coordinator_address = "0xfd471836031dc5108809d173a067e8486b9047a3"
 token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
 
-ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
 bls_private_key_store_path = "keys/test.bls.key.json"
 
 # Node URLs
@@ -27,3 +19,22 @@ aggregator_server_ip_port = "localhost:8090"
 task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
 
 operator_state_retriever_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
+
+[Registration]
+
+register_on_startup = true
+
+allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
+service_manager_address = "0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"
+strategy_addresses = ["0x2b961e3959b79326a8e7f64ef0d2d825707669b5"]
+delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
+rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
+
+ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
+
+amount_to_mint = 1000000000000000000000
+
+allocatable_magnitudes = [1000000000000000]
+
+operator_set_ids = [0]

--- a/examples/awesome-vault-service/config/config.toml
+++ b/examples/awesome-vault-service/config/config.toml
@@ -20,7 +20,7 @@ task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
 
 operator_state_retriever_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
 
-[Registration]
+[registration]
 
 register_on_startup = true
 

--- a/examples/awesome-vault-service/operator/main.go
+++ b/examples/awesome-vault-service/operator/main.go
@@ -10,7 +10,6 @@ import (
 	taskmanager "github.com/Layr-Labs/eigensdk-go/examples/awesome-vault-service/contracts/bindings/AwesomeVaultTaskManager"
 )
 
-// TODO: add toml flags to the SDK operator config, removing most of this config attributes
 type Config struct {
 	operator.Config
 

--- a/examples/awesome-vault-service/operator/main.go
+++ b/examples/awesome-vault-service/operator/main.go
@@ -60,7 +60,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil, logger, taskManagerAbi)
+	operator, err := operator.NewOperatorFromConfig(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/examples/awesome-vault-service/operator/main.go
+++ b/examples/awesome-vault-service/operator/main.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/operator"
-	"github.com/ethereum/go-ethereum/common"
 
 	examplecommon "github.com/Layr-Labs/eigensdk-go/examples/awesome-vault-service/common"
 	taskmanager "github.com/Layr-Labs/eigensdk-go/examples/awesome-vault-service/contracts/bindings/AwesomeVaultTaskManager"
@@ -14,26 +12,7 @@ import (
 
 // TODO: add toml flags to the SDK operator config, removing most of this config attributes
 type Config struct {
-	OperatorAddress string `toml:"operator_address"`
-
-	// Core deployment addresses
-	AllocationManagerAddress    string `toml:"allocation_manager_address"`
-	DelegationManagerAddress    string `toml:"delegation_manager_address"`
-	RewardsCoordinatorAddress   string `toml:"rewards_coordinator_address"`
-	PermissionControllerAddress string `toml:"permission_controller_address"`
-
-	// Avs deployment addresses
-	ServiceManagerAddress      string `toml:"service_manager_address"`
-	RegistryCoordinatorAddress string `toml:"registry_coordinator_address"`
-	TokenStrategyAddr          string `toml:"token_strategy_addr"`
-
-	EcdsaPrivateKeyStorePath string `toml:"ecdsa_private_key_store_path"`
-	BlsPrivateKeyStorePath   string `toml:"bls_private_key_store_path"`
-
-	EthRpcUrl string `toml:"eth_http_url"`
-	EthWsUrl  string `toml:"eth_ws_url"`
-
-	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`
+	operator.Config
 
 	TaskManagerAddress string `toml:"task_manager_address"`
 }
@@ -64,38 +43,7 @@ func main() {
 		logger.Fatalf(err.Error())
 	}
 
-	amount := new(big.Int)
-	amount.SetString("1000000000000000000000", 10)
-	registrationConfig := operator.RegistrationConfig{
-		RegisterOnStartup: true,
-
-		AllocationManagerAddr: common.HexToAddress(opConfig.AllocationManagerAddress),
-		AvsAddress:            common.HexToAddress(opConfig.ServiceManagerAddress),
-		StrategyAddrs:         []common.Address{common.HexToAddress(opConfig.TokenStrategyAddr)},
-
-		DelegationManagerAddress:    common.HexToAddress(opConfig.DelegationManagerAddress),
-		RewardsCoordinatorAddress:   common.HexToAddress(opConfig.RewardsCoordinatorAddress),
-		PermissionControllerAddress: common.HexToAddress(opConfig.PermissionControllerAddress),
-
-		EcdsaKeyStorePath: opConfig.EcdsaPrivateKeyStorePath,
-
-		AmountToMint:          amount,
-		AllocatableMagnitudes: []uint64{1000000000000000},
-
-		OperatorSetIds: []uint32{0},
-	}
-
-	operatorConfig := operator.Config{
-		OperatorAddress:               opConfig.OperatorAddress,
-		RegistryCoordinatorAddress:    opConfig.RegistryCoordinatorAddress,
-		EthRpcUrl:                     opConfig.EthRpcUrl,
-		EthWsUrl:                      opConfig.EthWsUrl,
-		BlsPrivateKeyStorePath:        opConfig.BlsPrivateKeyStorePath,
-		AggregatorServerIpPortAddress: opConfig.AggregatorServerIpPortAddress,
-		Logger:                        logger,
-		TaskManagerAbi:                taskManagerAbi,
-		RegistrationCfg:               registrationConfig,
-	}
+	operatorConfig := opConfig.Config
 
 	// 3. Implement the computation function that processes task inputs and produces outputs
 	// (we do this in examples/incredible-squaring/common/common.go)
@@ -113,7 +61,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil)
+	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil, logger, taskManagerAbi)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/examples/incredible-dot-product/aggregator/main.go
+++ b/examples/incredible-dot-product/aggregator/main.go
@@ -113,7 +113,7 @@ func main() {
 
 	// 3. Build the aggregator, providing aggregator config, logger, task processor and the task manager ABI, and
 	// then start it.
-	aggregator, err := aggregator.NewAggregator(aggConfig, logger, taskProcessor, taskManagerAbi)
+	aggregator, err := aggregator.NewAggregator(logger, aggConfig, taskManagerAbi, taskProcessor)
 	if err != nil {
 		logger.Errorf("Failed to create aggregator: %w", err)
 		return

--- a/examples/incredible-dot-product/config/config.toml
+++ b/examples/incredible-dot-product/config/config.toml
@@ -4,18 +4,10 @@ operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 # The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
 # TODO: automate updating these addresses when we deploy new contracts
 
-# Core deployment
-allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
-delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
-rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
-permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
-
 # Avs deployment
-service_manager_address = "0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"
 registry_coordinator_address = "0xfd471836031dc5108809d173a067e8486b9047a3"
 token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
 
-ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
 bls_private_key_store_path = "keys/test.bls.key.json"
 
 # Node URLs
@@ -27,3 +19,22 @@ aggregator_server_ip_port = "localhost:8090"
 task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
 
 operator_state_retriever_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
+
+[Registration]
+
+register_on_startup = true
+
+allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
+service_manager_address = "0xcd8a1c3ba11cf5ecfa6267617243239504a98d90"
+strategy_addresses = ["0x2b961e3959b79326a8e7f64ef0d2d825707669b5"]
+delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
+rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
+
+ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
+
+amount_to_mint = 1000000000000000000000
+
+allocatable_magnitudes = [1000000000000000]
+
+operator_set_ids = [0]

--- a/examples/incredible-dot-product/config/config.toml
+++ b/examples/incredible-dot-product/config/config.toml
@@ -20,7 +20,7 @@ task_manager_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
 
 operator_state_retriever_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
 
-[Registration]
+[registration]
 
 register_on_startup = true
 

--- a/examples/incredible-dot-product/operator/main.go
+++ b/examples/incredible-dot-product/operator/main.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/operator"
-	"github.com/ethereum/go-ethereum/common"
 
 	examplecommon "github.com/Layr-Labs/eigensdk-go/examples/incredible-dot-product/common"
 	taskmanager "github.com/Layr-Labs/eigensdk-go/examples/incredible-dot-product/contracts/bindings/IncredibleDotProductTaskManager"
@@ -14,26 +13,7 @@ import (
 
 // TODO: add toml flags to the SDK operator config, removing most of this config attributes
 type Config struct {
-	OperatorAddress string `toml:"operator_address"`
-
-	// Core deployment addresses
-	AllocationManagerAddress    string `toml:"allocation_manager_address"`
-	DelegationManagerAddress    string `toml:"delegation_manager_address"`
-	RewardsCoordinatorAddress   string `toml:"rewards_coordinator_address"`
-	PermissionControllerAddress string `toml:"permission_controller_address"`
-
-	// Avs deployment addresses
-	ServiceManagerAddress      string `toml:"service_manager_address"`
-	RegistryCoordinatorAddress string `toml:"registry_coordinator_address"`
-	TokenStrategyAddr          string `toml:"token_strategy_addr"`
-
-	EcdsaPrivateKeyStorePath string `toml:"ecdsa_private_key_store_path"`
-	BlsPrivateKeyStorePath   string `toml:"bls_private_key_store_path"`
-
-	EthRpcUrl string `toml:"eth_http_url"`
-	EthWsUrl  string `toml:"eth_ws_url"`
-
-	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`
+	operator.Config
 
 	TaskManagerAddress string `toml:"task_manager_address"`
 }
@@ -64,38 +44,7 @@ func main() {
 		logger.Fatalf(err.Error())
 	}
 
-	amount := new(big.Int)
-	amount.SetString("1000000000000000000000", 10)
-	registrationConfig := operator.RegistrationConfig{
-		RegisterOnStartup: true,
-
-		AllocationManagerAddr: common.HexToAddress(opConfig.AllocationManagerAddress),
-		AvsAddress:            common.HexToAddress(opConfig.ServiceManagerAddress),
-		StrategyAddrs:         []common.Address{common.HexToAddress(opConfig.TokenStrategyAddr)},
-
-		DelegationManagerAddress:    common.HexToAddress(opConfig.DelegationManagerAddress),
-		RewardsCoordinatorAddress:   common.HexToAddress(opConfig.RewardsCoordinatorAddress),
-		PermissionControllerAddress: common.HexToAddress(opConfig.PermissionControllerAddress),
-
-		EcdsaKeyStorePath: opConfig.EcdsaPrivateKeyStorePath,
-
-		AmountToMint:          amount,
-		AllocatableMagnitudes: []uint64{1000000000000000},
-
-		OperatorSetIds: []uint32{0},
-	}
-
-	operatorConfig := operator.Config{
-		OperatorAddress:               opConfig.OperatorAddress,
-		RegistryCoordinatorAddress:    opConfig.RegistryCoordinatorAddress,
-		EthRpcUrl:                     opConfig.EthRpcUrl,
-		EthWsUrl:                      opConfig.EthWsUrl,
-		BlsPrivateKeyStorePath:        opConfig.BlsPrivateKeyStorePath,
-		AggregatorServerIpPortAddress: opConfig.AggregatorServerIpPortAddress,
-		Logger:                        logger,
-		TaskManagerAbi:                taskManagerAbi,
-		RegistrationCfg:               registrationConfig,
-	}
+	operatorConfig := opConfig.Config
 
 	// 3. Implement the computation function that processes task inputs and produces outputs
 	// (we do this in examples/incredible-dot-product/common/common.go)
@@ -113,7 +62,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil)
+	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil, logger, taskManagerAbi)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/examples/incredible-dot-product/operator/main.go
+++ b/examples/incredible-dot-product/operator/main.go
@@ -61,7 +61,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil, logger, taskManagerAbi)
+	operator, err := operator.NewOperatorFromConfig(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/examples/incredible-dot-product/operator/main.go
+++ b/examples/incredible-dot-product/operator/main.go
@@ -11,7 +11,6 @@ import (
 	taskmanager "github.com/Layr-Labs/eigensdk-go/examples/incredible-dot-product/contracts/bindings/IncredibleDotProductTaskManager"
 )
 
-// TODO: add toml flags to the SDK operator config, removing most of this config attributes
 type Config struct {
 	operator.Config
 

--- a/examples/incredible-squaring/aggregator/main.go
+++ b/examples/incredible-squaring/aggregator/main.go
@@ -103,7 +103,7 @@ func main() {
 
 	// 3. Build the aggregator, providing aggregator config, logger, task processor and the task manager ABI, and
 	// then start it.
-	aggregator, err := aggregator.NewAggregator(aggConfig, logger, taskProcessor, taskManagerAbi)
+	aggregator, err := aggregator.NewAggregator(logger, aggConfig, taskManagerAbi, taskProcessor)
 	if err != nil {
 		logger.Errorf("Failed to create aggregator: %w", err)
 		return

--- a/examples/incredible-squaring/config/config.toml
+++ b/examples/incredible-squaring/config/config.toml
@@ -4,18 +4,10 @@ operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 # The saved eigenlayer state is located in tests/anvil/credible_squaring_avs_deployment_output.json
 # TODO: automate updating these addresses when we deploy new contracts
 
-# Core deployment
-allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
-delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
-rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
-permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
-
 # Avs deployment
-service_manager_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
 token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
 
-ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
 bls_private_key_store_path = "keys/test.bls.key.json"
 
 # Node URLs
@@ -27,3 +19,22 @@ aggregator_server_ip_port = "localhost:8090"
 task_manager_address = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"
 
 operator_state_retriever_address = "0x4c5859f0f772848b2d91f1d83e2fe57935348029"
+
+[Registration]
+
+register_on_startup = true
+
+allocation_manager_address = "0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6"
+service_manager_address = "0x5f3f1dbd7b74c6b46e8c44f98792a1daf8d69154"
+strategy_addresses = ["0x2b961e3959b79326a8e7f64ef0d2d825707669b5"]
+delegation_manager_address = "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0"
+rewards_coordinator_address = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+permission_controller_address = "0x59b670e9fa9d0a427751af201d676719a970857b"
+
+ecdsa_private_key_store_path = "keys/test.ecdsa.key.json"
+
+amount_to_mint = 1000000000000000000000
+
+allocatable_magnitudes = [1000000000000000]
+
+operator_set_ids = [0]

--- a/examples/incredible-squaring/config/config.toml
+++ b/examples/incredible-squaring/config/config.toml
@@ -20,7 +20,7 @@ task_manager_address = "0x2bdcc0de6be1f7d2ee689a0342d76f52e8efaba3"
 
 operator_state_retriever_address = "0x4c5859f0f772848b2d91f1d83e2fe57935348029"
 
-[Registration]
+[registration]
 
 register_on_startup = true
 

--- a/examples/incredible-squaring/operator/main.go
+++ b/examples/incredible-squaring/operator/main.go
@@ -61,7 +61,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil, logger, taskManagerAbi)
+	operator, err := operator.NewOperatorFromConfig(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/examples/incredible-squaring/operator/main.go
+++ b/examples/incredible-squaring/operator/main.go
@@ -92,8 +92,6 @@ func main() {
 		EthWsUrl:                      opConfig.EthWsUrl,
 		BlsPrivateKeyStorePath:        opConfig.BlsPrivateKeyStorePath,
 		AggregatorServerIpPortAddress: opConfig.AggregatorServerIpPortAddress,
-		Logger:                        logger,
-		TaskManagerAbi:                taskManagerAbi,
 		RegistrationCfg:               registrationConfig,
 	}
 
@@ -113,7 +111,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil)
+	operator, err := operator.NewOperatorFromConfig(operatorConfig, possibleFailureCalculator, nil, logger, taskManagerAbi)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/examples/incredible-squaring/operator/main.go
+++ b/examples/incredible-squaring/operator/main.go
@@ -6,34 +6,13 @@ import (
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/operator"
-	"github.com/ethereum/go-ethereum/common"
 
 	examplecommon "github.com/Layr-Labs/eigensdk-go/examples/incredible-squaring/common"
 	cstaskmanager "github.com/Layr-Labs/eigensdk-go/examples/incredible-squaring/contracts/bindings/IncredibleSquaringTaskManager"
 )
 
-// TODO: add toml flags to the SDK operator config, removing most of this config attributes
 type Config struct {
-	OperatorAddress string `toml:"operator_address"`
-
-	// Core deployment addresses
-	AllocationManagerAddress    string `toml:"allocation_manager_address"`
-	DelegationManagerAddress    string `toml:"delegation_manager_address"`
-	RewardsCoordinatorAddress   string `toml:"rewards_coordinator_address"`
-	PermissionControllerAddress string `toml:"permission_controller_address"`
-
-	// Avs deployment addresses
-	ServiceManagerAddress      string `toml:"service_manager_address"`
-	RegistryCoordinatorAddress string `toml:"registry_coordinator_address"`
-	TokenStrategyAddr          string `toml:"token_strategy_addr"`
-
-	EcdsaPrivateKeyStorePath string `toml:"ecdsa_private_key_store_path"`
-	BlsPrivateKeyStorePath   string `toml:"bls_private_key_store_path"`
-
-	EthRpcUrl string `toml:"eth_http_url"`
-	EthWsUrl  string `toml:"eth_ws_url"`
-
-	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`
+	operator.Config
 
 	TaskManagerAddress string `toml:"task_manager_address"`
 }
@@ -64,36 +43,7 @@ func main() {
 		logger.Fatalf(err.Error())
 	}
 
-	amount := new(big.Int)
-	amount.SetString("1000000000000000000000", 10)
-	registrationConfig := operator.RegistrationConfig{
-		RegisterOnStartup: true,
-
-		AllocationManagerAddr: common.HexToAddress(opConfig.AllocationManagerAddress),
-		AvsAddress:            common.HexToAddress(opConfig.ServiceManagerAddress),
-		StrategyAddrs:         []common.Address{common.HexToAddress(opConfig.TokenStrategyAddr)},
-
-		DelegationManagerAddress:    common.HexToAddress(opConfig.DelegationManagerAddress),
-		RewardsCoordinatorAddress:   common.HexToAddress(opConfig.RewardsCoordinatorAddress),
-		PermissionControllerAddress: common.HexToAddress(opConfig.PermissionControllerAddress),
-
-		EcdsaKeyStorePath: opConfig.EcdsaPrivateKeyStorePath,
-
-		AmountToMint:          amount,
-		AllocatableMagnitudes: []uint64{1000000000000000},
-
-		OperatorSetIds: []uint32{0},
-	}
-
-	operatorConfig := operator.Config{
-		OperatorAddress:               opConfig.OperatorAddress,
-		RegistryCoordinatorAddress:    opConfig.RegistryCoordinatorAddress,
-		EthRpcUrl:                     opConfig.EthRpcUrl,
-		EthWsUrl:                      opConfig.EthWsUrl,
-		BlsPrivateKeyStorePath:        opConfig.BlsPrivateKeyStorePath,
-		AggregatorServerIpPortAddress: opConfig.AggregatorServerIpPortAddress,
-		RegistrationCfg:               registrationConfig,
-	}
+	operatorConfig := opConfig.Config
 
 	// 3. Implement the computation function that processes task inputs and produces outputs
 	// (we do this in examples/incredible-squaring/common/common.go)

--- a/operator/config.go
+++ b/operator/config.go
@@ -28,12 +28,6 @@ type Config struct {
 	// IP address and port where the aggregator will listen to operator task responses
 	AggregatorServerIpPortAddress string
 
-	// The logger to use when logging
-	Logger logging.Logger
-
-	// The ABI of the task manager contract
-	TaskManagerAbi *abi.ABI
-
 	// The config used to register an operator
 	RegistrationCfg RegistrationConfig
 }

--- a/operator/config.go
+++ b/operator/config.go
@@ -3,64 +3,62 @@ package operator
 import (
 	"math/big"
 
-	"github.com/Layr-Labs/eigensdk-go/logging"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 // Operator configuration struct
 type Config struct {
 	// The address for the operator
-	OperatorAddress string
+	OperatorAddress string `toml:"operator_address"`
 
 	// The registry coordinator address is used to create the AVS reader
-	RegistryCoordinatorAddress string
+	RegistryCoordinatorAddress string `toml:"registry_coordinator_address"`
 
 	// Ethereum HTTP RPC URL to use for interacting with on-chain contracts
-	EthRpcUrl string
+	EthRpcUrl string `toml:"eth_http_url"`
 
 	// Ethereum WebSocket RPC URL to use for subscribing to on-chain events
-	EthWsUrl string
+	EthWsUrl string `toml:"eth_ws_url"`
 
 	// The path to the location of the bls private key on local storage
-	BlsPrivateKeyStorePath string
+	BlsPrivateKeyStorePath string `toml:"bls_private_key_store_path"`
 
 	// IP address and port where the aggregator will listen to operator task responses
-	AggregatorServerIpPortAddress string
+	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`
 
 	// The config used to register an operator
-	RegistrationCfg RegistrationConfig
+	Registration RegistrationConfig `toml:"Registration"`
 }
 
 // This config is used to register an operator on startup.
 // A TODO of this config is to make some values optional to perform some registration operations instead of all
 type RegistrationConfig struct {
 	// If set true, should register the operator on startup
-	RegisterOnStartup bool
+	RegisterOnStartup bool `toml:"register_on_startup"`
 
 	// Used for setting the allogation delay to zero and initialize allocations
-	AllocationManagerAddr common.Address
+	AllocationManagerAddr common.Address `toml:"allocation_manager_address"`
 
 	// Used to register operator in operator sets and initialize allocations
-	AvsAddress common.Address
+	AvsAddress common.Address `toml:"service_manager_address"`
 
 	// Used to deposit into these strategies for operator and initialize allocations on these strategies
-	StrategyAddrs []common.Address
+	StrategyAddrs []common.Address `toml:"strategy_addresses"`
 
 	// Used to create eigenlayer chain reader and writer
-	DelegationManagerAddress    common.Address
-	RewardsCoordinatorAddress   common.Address
-	PermissionControllerAddress common.Address
+	DelegationManagerAddress    common.Address `toml:"delegation_manager_address"`
+	RewardsCoordinatorAddress   common.Address `toml:"rewards_coordinator_address"`
+	PermissionControllerAddress common.Address `toml:"permission_controller_address"`
 
 	// The path to the location of the ecdsa private key on local storage
-	EcdsaKeyStorePath string
+	EcdsaKeyStorePath string `toml:"ecdsa_private_key_store_path"`
 
 	// The ammount to mint to the operator
-	AmountToMint *big.Int
+	AmountToMint *big.Int `toml:"amount_to_mint"`
 
 	// The magnitudes to be allocatable (slashable) in the strategies for the operator
-	AllocatableMagnitudes []uint64
+	AllocatableMagnitudes []uint64 `toml:"allocatable_magnitudes"`
 
 	// The IDs of the operator sets to be registered
-	OperatorSetIds []uint32
+	OperatorSetIds []uint32 `toml:"operator_set_ids"`
 }

--- a/operator/config.go
+++ b/operator/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`
 
 	// The config used to register an operator
-	Registration RegistrationConfig `toml:"Registration"`
+	Registration RegistrationConfig `toml:"registration"`
 }
 
 // This config is used to register an operator on startup.

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -58,6 +58,8 @@ func NewOperatorFromConfig[Input any, Output any](
 	c Config,
 	responseCalculator ResponseCalculator[Input, Output],
 	taskResponseHashFn TaskResponseHashFunction[Output],
+	logger logging.Logger,
+	taskManagerAbi *abi.ABI,
 ) (*Operator[Input, Output], error) {
 	// Note: here we only assign the registry coordinator address because is the only address we use
 	// when we use the AVS registry reader. If you want to do more things with avs registry reader,
@@ -71,19 +73,19 @@ func NewOperatorFromConfig[Input any, Output any](
 		return nil, utils.WrapError("Failed to create Eth Http client", err)
 	}
 
-	avsReader, err := avsregistry.NewReaderFromConfig(avsConfig, ethHttpClient, c.Logger)
+	avsReader, err := avsregistry.NewReaderFromConfig(avsConfig, ethHttpClient, logger)
 	if err != nil {
-		c.Logger.Error("Cannot create AvsReader", "err", err)
+		logger.Error("Cannot create AvsReader", "err", err)
 		return nil, err
 	}
 
 	blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
 	if !ok {
-		c.Logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
+		logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
 	}
 	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
 	if err != nil {
-		c.Logger.Errorf("Cannot parse bls private key", "err", err)
+		logger.Errorf("Cannot parse bls private key", "err", err)
 		return nil, err
 	}
 
@@ -91,21 +93,21 @@ func NewOperatorFromConfig[Input any, Output any](
 	// If its not registered and should be registered on startup, make the registration.
 	operatorIsRegistered, err := avsReader.IsOperatorRegistered(&bind.CallOpts{}, common.HexToAddress(c.OperatorAddress))
 	if err != nil {
-		c.Logger.Error("Error checking if operator is registered", "err", err)
+		logger.Error("Error checking if operator is registered", "err", err)
 		return nil, err
 	}
 	if !operatorIsRegistered {
-		if c.RegistrationCfg.RegisterOnStartup {
+		if c.Registration.RegisterOnStartup {
 			err = registerOperatorOnStartup(
-				c.RegistrationCfg,
-				c.Logger,
+				c.Registration,
+				logger,
 				avsConfig.RegistryCoordinatorAddress,
 				common.HexToAddress(c.OperatorAddress),
 				ethHttpClient,
 				blsKeyPair,
 			)
 			if err != nil {
-				c.Logger.Errorf("Failure while registering operator on startup: %w", err)
+				logger.Errorf("Failure while registering operator on startup: %w", err)
 				return nil, err
 			}
 		} else {
@@ -120,22 +122,22 @@ func NewOperatorFromConfig[Input any, Output any](
 
 	operatorId, err := avsReader.GetOperatorId(&bind.CallOpts{}, common.HexToAddress(c.OperatorAddress))
 	if err != nil {
-		c.Logger.Error("Cannot get operator id", "err", err)
+		logger.Error("Cannot get operator id", "err", err)
 		return nil, err
 	}
 
-	aggregatorRpcClient, err := NewAggregatorRpcClient[Output](c.AggregatorServerIpPortAddress, c.Logger)
+	aggregatorRpcClient, err := NewAggregatorRpcClient[Output](c.AggregatorServerIpPortAddress, logger)
 	if err != nil {
-		c.Logger.Error("Cannot create AggregatorRpcClient. Is aggregator running?", "err", err)
+		logger.Error("Cannot create AggregatorRpcClient. Is aggregator running?", "err", err)
 		return nil, err
 	}
 
 	wsClient, err := ethclient.Dial(c.EthWsUrl)
 	if err != nil {
-		c.Logger.Fatal("error connecting to web socket", "err", err)
+		logger.Fatal("error connecting to web socket", "err", err)
 	}
 
-	eventHash := c.TaskManagerAbi.Events["NewTaskCreated"].ID
+	eventHash := taskManagerAbi.Events["NewTaskCreated"].ID
 	query := ethereum.FilterQuery{
 		Addresses: []common.Address{},
 		Topics:    [][]common.Hash{{eventHash}},
@@ -144,13 +146,13 @@ func NewOperatorFromConfig[Input any, Output any](
 	newTaskCreatedLogs := make(chan types.Log)
 	_, err = wsClient.SubscribeFilterLogs(context.Background(), query, newTaskCreatedLogs)
 	if err != nil {
-		c.Logger.Fatal("error subscribing to newTaskCreated events", "err", err)
+		logger.Fatal("error subscribing to newTaskCreated events", "err", err)
 	}
 
 	if taskResponseHashFn == nil {
-		taskResponseType, err := extractTypeFromAbi(c.TaskManagerAbi)
+		taskResponseType, err := extractTypeFromAbi(taskManagerAbi)
 		if err != nil {
-			c.Logger.Error("Failed to get task response type in default abi.", "err", err)
+			logger.Error("Failed to get task response type in default abi.", "err", err)
 			return nil, err
 		}
 
@@ -158,17 +160,17 @@ func NewOperatorFromConfig[Input any, Output any](
 	}
 
 	operator := &Operator[Input, Output]{
-		logger:              c.Logger,
+		logger:              logger,
 		blsKeypair:          blsKeyPair,
 		aggregatorRpcClient: *aggregatorRpcClient,
 		operatorId:          operatorId,
 		newTaskCreatedLogs:  newTaskCreatedLogs,
-		taskManagerAbi:      c.TaskManagerAbi,
+		taskManagerAbi:      taskManagerAbi,
 		responseCalculator:  responseCalculator,
 		taskResponseHashFn:  taskResponseHashFn,
 	}
 
-	c.Logger.Info("Operator info",
+	logger.Info("Operator info",
 		"operatorId", operatorId,
 		"operatorAddr", c.OperatorAddress,
 		"operatorG1Pubkey", operator.blsKeypair.GetPubKeyG1(),

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -55,11 +55,11 @@ type TaskResponseHashFunction[Output any] func(taskResponse taskmanager.TaskResp
 
 // NewOperatorFromConfig creates a new Operator with the provided config and the functions to calculate and hashing the response.
 func NewOperatorFromConfig[Input any, Output any](
+	logger logging.Logger,
 	c Config,
+	taskManagerAbi *abi.ABI,
 	responseCalculator ResponseCalculator[Input, Output],
 	taskResponseHashFn TaskResponseHashFunction[Output],
-	logger logging.Logger,
-	taskManagerAbi *abi.ABI,
 ) (*Operator[Input, Output], error) {
 	// Note: here we only assign the registry coordinator address because is the only address we use
 	// when we use the AVS registry reader. If you want to do more things with avs registry reader,


### PR DESCRIPTION
### What Changed?
This PR adds TOML serialization tags to the operator SDK config, removing the need for the AVSs to create an intermediate config for reading from TOML files.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it