### PR TITLE
fix: remove duplicate config option

### DIFF
--- a/examples/awesome-vault-service/challenger/main.go
+++ b/examples/awesome-vault-service/challenger/main.go
@@ -20,8 +20,6 @@ import (
 type Config struct {
 	TaskManagerAddress string `toml:"task_manager_address"`
 
-	EthHttpUrl string `toml:"eth_http_url"`
-
 	challenger.Config
 }
 

--- a/examples/incredible-dot-product/challenger/main.go
+++ b/examples/incredible-dot-product/challenger/main.go
@@ -23,8 +23,6 @@ import (
 type Config struct {
 	TaskManagerAddress string `toml:"task_manager_address"`
 
-	EthHttpUrl string `toml:"eth_http_url"`
-
 	challenger.Config
 }
 

--- a/examples/incredible-squaring/challenger/main.go
+++ b/examples/incredible-squaring/challenger/main.go
@@ -24,8 +24,6 @@ import (
 type Config struct {
 	TaskManagerAddress string `toml:"task_manager_address"`
 
-	EthHttpUrl string `toml:"eth_http_url"`
-
 	challenger.Config
 }
 
@@ -54,6 +52,7 @@ func main() {
 	// Create the ethereum client that will send the RPC messages to the node
 	ethHttpClient, err := ethclient.Dial(challengerConfig.EthHttpUrl)
 	if err != nil {
+		logger.Errorf("Failed to dial ethclient: %w", err)
 		return
 	}
 


### PR DESCRIPTION
### What Changed?

The Challenger config already had an `EthHttpUrl` field, and declaring a duplicate like we did seems to cause the value for that to be missing.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it