### PR TITLE
feat: create a new aggregator server for each service

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -143,7 +143,10 @@ func (agg *Aggregator[Input, Output]) run(ctx context.Context) error {
 	agg.logger.Info("Starting aggregator.")
 	agg.logger.Info("Starting aggregator rpc server.")
 
-	serverErrorChannel := agg.startServer(ctx)
+	serverErrorChannel := make(chan error)
+	go func() {
+		serverErrorChannel <- agg.startServer(ctx)
+	}()
 
 	for {
 		select {

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -142,12 +142,15 @@ func (agg *Aggregator[Input, Output]) Start(ctx context.Context) <-chan error {
 func (agg *Aggregator[Input, Output]) run(ctx context.Context) error {
 	agg.logger.Info("Starting aggregator.")
 	agg.logger.Info("Starting aggregator rpc server.")
-	go agg.startServer(ctx)
+
+	serverErrorChannel := agg.startServer(ctx)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
+		case err := <-serverErrorChannel:
+			return err
 		case blsAggServiceResp := <-agg.blsAggregationService.GetResponseChannel():
 			agg.logger.Info("Received response from blsAggregationService", "blsAggServiceResp", blsAggServiceResp)
 			err := agg.processAggregatedResponse(blsAggServiceResp)

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -2,7 +2,6 @@ package aggregator
 
 import (
 	"context"
-	"log"
 	"net"
 	"net/http"
 	"net/rpc"
@@ -20,7 +19,7 @@ func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {
 	server := rpc.NewServer()
 	err := server.RegisterName("Aggregator", agg)
 	if err != nil {
-		agg.logger.Fatal("Format of service TaskManager isn't correct. ", "err", err)
+		return utils.WrapError("Error registering aggregator service (maybe the format of service task manager isn't correct)", err)
 	}
 
 	// TODO: Replace with http.ListenAndServe()

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -2,6 +2,8 @@ package aggregator
 
 import (
 	"context"
+	"log"
+	"net"
 	"net/http"
 	"net/rpc"
 
@@ -14,16 +16,17 @@ import (
 // When starting the server, the aggregator start listening at the address specified by config the calls to
 // the ProcessSignedTaskResponse method
 func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) {
-	err := rpc.RegisterName("Aggregator", agg)
+	server := rpc.NewServer()
+	err := server.RegisterName("Aggregator", agg)
 	if err != nil {
 		agg.logger.Fatal("Format of service TaskManager isn't correct. ", "err", err)
 	}
-	rpc.HandleHTTP()
 
-	err = http.ListenAndServe(agg.serverIpPortAddr, nil)
+	listener, err := net.Listen("tcp", agg.serverIpPortAddr)
 	if err != nil {
-		agg.logger.Fatal("ListenAndServe", "err", err)
+		log.Fatal(err)
 	}
+	go http.Serve(listener, server)
 }
 
 type SignedTaskResponse[Output any] struct {

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -15,7 +15,7 @@ import (
 
 // When starting the server, the aggregator start listening at the address specified by config the calls to
 // the ProcessSignedTaskResponse method
-func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) {
+func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) <-chan error {
 	server := rpc.NewServer()
 	err := server.RegisterName("Aggregator", agg)
 	if err != nil {
@@ -26,7 +26,19 @@ func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	go http.Serve(listener, server)
+
+	errChan := make(chan error)
+
+	go func() {
+		err := http.Serve(listener, server)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		errChan <- nil
+	}()
+
+	return errChan
 }
 
 type SignedTaskResponse[Output any] struct {

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -15,7 +15,7 @@ import (
 
 // When starting the server, the aggregator start listening at the address specified by config the calls to
 // the ProcessSignedTaskResponse method
-func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) <-chan error {
+func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {
 	server := rpc.NewServer()
 	err := server.RegisterName("Aggregator", agg)
 	if err != nil {
@@ -38,7 +38,7 @@ func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) <-chan er
 		errChan <- nil
 	}()
 
-	return errChan
+	return err
 }
 
 type SignedTaskResponse[Output any] struct {

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -11,6 +11,7 @@ import (
 	blsagg "github.com/Layr-Labs/eigensdk-go/services/bls_aggregation"
 	taskmanager "github.com/Layr-Labs/eigensdk-go/task-manager"
 	sdktypes "github.com/Layr-Labs/eigensdk-go/types"
+	"github.com/Layr-Labs/eigensdk-go/utils"
 )
 
 // When starting the server, the aggregator start listening at the address specified by config the calls to
@@ -22,21 +23,22 @@ func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {
 		agg.logger.Fatal("Format of service TaskManager isn't correct. ", "err", err)
 	}
 
+	// TODO: Replace with http.ListenAndServe()
+	err = agg.ListenAndServe(server)
+	if err != nil {
+		return utils.WrapError("Failed to listen and serve", err)
+	}
+
+	return nil
+}
+
+func (agg *Aggregator[Input, Output]) ListenAndServe(server *rpc.Server) error {
 	listener, err := net.Listen("tcp", agg.serverIpPortAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	errChan := make(chan error)
-
-	go func() {
-		err := http.Serve(listener, server)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		errChan <- nil
-	}()
+	err = http.Serve(listener, server)
 
 	return err
 }

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -35,12 +35,15 @@ func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {
 func (agg *Aggregator[Input, Output]) ListenAndServe(server *rpc.Server) error {
 	listener, err := net.Listen("tcp", agg.serverIpPortAddr)
 	if err != nil {
-		log.Fatal(err)
+		return utils.WrapError("Err wile listening", err)
 	}
 
 	err = http.Serve(listener, server)
+	if err != nil {
+		return utils.WrapError("Err while serving", err)
+	}
 
-	return err
+	return nil
 }
 
 type SignedTaskResponse[Output any] struct {

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -23,7 +23,7 @@ func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {
 	}
 
 	// TODO: Replace with http.ListenAndServe()
-	err = agg.ListenAndServe(server)
+	err = agg.listenAndServe(server)
 	if err != nil {
 		return utils.WrapError("Failed to listen and serve", err)
 	}
@@ -31,7 +31,7 @@ func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {
 	return nil
 }
 
-func (agg *Aggregator[Input, Output]) ListenAndServe(server *rpc.Server) error {
+func (agg *Aggregator[Input, Output]) listenAndServe(server *rpc.Server) error {
 	listener, err := net.Listen("tcp", agg.serverIpPortAddr)
 	if err != nil {
 		return utils.WrapError("Err wile listening", err)


### PR DESCRIPTION
### What Changed?
This PR creates a new RPC server for each new Aggregator service instead of using a global RPC server.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it