### PR TITLE
chore: Rename the operator builder function

### DIFF
--- a/examples/awesome-vault-service/operator/main.go
+++ b/examples/awesome-vault-service/operator/main.go
@@ -60,7 +60,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
+	operator, err := operator.NewOperator(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/examples/incredible-dot-product/operator/main.go
+++ b/examples/incredible-dot-product/operator/main.go
@@ -61,7 +61,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
+	operator, err := operator.NewOperator(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/examples/incredible-squaring/operator/main.go
+++ b/examples/incredible-squaring/operator/main.go
@@ -61,7 +61,7 @@ func main() {
 	// 6. Build the operator, providing operator config, the response calculator and a task response hashing
 	// function, and then start it.
 	// We leave this last parameter as nil because we are using the default hashing function provided by the SDK
-	operator, err := operator.NewOperatorFromConfig(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
+	operator, err := operator.NewOperator(logger, operatorConfig, taskManagerAbi, possibleFailureCalculator, nil)
 	if err != nil {
 		logger.Fatalf("Failed to create operator: %w", err)
 	}

--- a/integration-tests/incredible_squaring_test.go
+++ b/integration-tests/incredible_squaring_test.go
@@ -243,7 +243,7 @@ func createIncredibleSquaringOperator(t *testing.T, ethHttpUrl, ethWsUrl string)
 
 	calculator := operator.NewFunctionResponseCalculator(square)
 
-	operator, err := operator.NewOperatorFromConfig(logger, operatorConfig, taskManagerAbi, calculator, nil)
+	operator, err := operator.NewOperator(logger, operatorConfig, taskManagerAbi, calculator, nil)
 	require.NoError(t, err, "Failed to create operator from config")
 
 	return operator

--- a/operator/README.md
+++ b/operator/README.md
@@ -83,7 +83,7 @@ The Operator functions through the following flow:
 6. **Run the operator**: Initialize the `Operator` with the configuration and the processing logic. Then start the operator.
 
    ```go
-      operator, err := operator.NewOperatorFromConfig(logger, operatorConfig, taskManagerAbi, logic, nil)
+      operator, err := operator.NewOperator(logger, operatorConfig, taskManagerAbi, logic, nil)
       if err != nil {
          logger.Errorf("Failed to create operator from config: %v", err)
          return

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -53,8 +53,8 @@ type Operator[Input any, Output any] struct {
 // The function used to hash the task responses, receiving the generic sdk task response and returning the digest
 type TaskResponseHashFunction[Output any] func(taskResponse taskmanager.TaskResponse[Output]) ([32]byte, error)
 
-// NewOperatorFromConfig creates a new Operator with the provided config and the functions to calculate and hashing the response.
-func NewOperatorFromConfig[Input any, Output any](
+// NewOperator creates a new Operator with the provided config and the functions to calculate and hashing the response.
+func NewOperator[Input any, Output any](
 	logger logging.Logger,
 	c Config,
 	taskManagerAbi *abi.ABI,


### PR DESCRIPTION
### What Changed?
This PR renames the operator builder function from NewOperatorFromConfig to NewOperator, as it is named in other entity modules (NewAggregator or NewChallenger, for example).

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it