### PR TITLE
feat: create aggregator rpc server

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -46,7 +46,8 @@ type Aggregator[Input any, Output any] struct {
 	taskProcessor taskprocessor.TaskProcessor[Input, Output]
 }
 
-// NewAggregator creates a new Aggregator with the provided config, a logger, a task processor and the task manager contract's ABI.
+// NewAggregator creates a new Aggregator with the provided config, a logger, a task processor and the task
+// manager contract's ABI.
 func NewAggregator[Input any, Output any](
 	logger logging.Logger,
 	c Config,

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -32,9 +32,6 @@ import (
 type Aggregator[Input any, Output any] struct {
 	logger logging.Logger
 
-	// IP address and port where the aggregator will listen to operator task responses
-	serverIpPortAddr string
-
 	// BLS aggregation service
 	blsAggregationService blsagg.BlsAggregationService
 
@@ -118,7 +115,6 @@ func NewAggregator[Input any, Output any](
 
 	return &Aggregator[Input, Output]{
 		logger:                logger,
-		serverIpPortAddr:      c.AggregatorServerIpPortAddr,
 		blsAggregationService: blsAggregationService,
 		newTaskCreatedLogs:    newTaskCreatedLogs,
 		taskManagerAbi:        taskManagerAbi,

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -44,6 +44,8 @@ type Aggregator[Input any, Output any] struct {
 	// ABI of the task manager contract
 	taskManagerAbi *abi.ABI
 
+	aggregatorRpcServer *AggregatorRpcServer[Input, Output]
+
 	taskProcessor taskprocessor.TaskProcessor[Input, Output]
 }
 
@@ -112,6 +114,8 @@ func NewAggregator[Input any, Output any](
 		logger.Fatal("error subscribing to newTaskCreated events", "err", err)
 	}
 
+	rpcServer := NewAggregatorRpcServer[Input, Output](logger, c.AggregatorServerIpPortAddr, blsAggregationService)
+
 	return &Aggregator[Input, Output]{
 		logger:                logger,
 		serverIpPortAddr:      c.AggregatorServerIpPortAddr,
@@ -119,6 +123,7 @@ func NewAggregator[Input any, Output any](
 		newTaskCreatedLogs:    newTaskCreatedLogs,
 		taskManagerAbi:        taskManagerAbi,
 		taskProcessor:         taskProcessor,
+		aggregatorRpcServer:   rpcServer,
 	}, nil
 }
 
@@ -145,7 +150,7 @@ func (agg *Aggregator[Input, Output]) run(ctx context.Context) error {
 
 	serverErrorChannel := make(chan error)
 	go func() {
-		serverErrorChannel <- agg.startServer(ctx)
+		serverErrorChannel <- agg.aggregatorRpcServer.StartServer()
 	}()
 
 	for {

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -40,8 +40,8 @@ func NewAggregatorRpcServer[Input any, Output any](
 	}
 }
 
-// When starting the server, the aggregator RPC server start listening at the address specified by config
-// the calls to the ProcessSignedTaskResponse method
+// When starting the server, the aggregator RPC server starts listening at the address specified by the
+// config for calls to the `ProcessSignedTaskResponse` method
 func (aggServ *AggregatorRpcServer[Input, Output]) StartServer() error {
 	server := rpc.NewServer()
 	err := server.RegisterName("Aggregator", aggServ)

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -7,6 +7,7 @@ import (
 	"net/rpc"
 
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	"github.com/Layr-Labs/eigensdk-go/logging"
 	blsagg "github.com/Layr-Labs/eigensdk-go/services/bls_aggregation"
 	taskmanager "github.com/Layr-Labs/eigensdk-go/task-manager"
 	sdktypes "github.com/Layr-Labs/eigensdk-go/types"
@@ -26,24 +27,26 @@ type AggregatorRpcServer[Input any, Output any] struct {
 func NewAggregatorRpcServer[Input any, Output any](
 	logger logging.Logger,
 	serverIpPortAddr string,
+	blsAggregationService blsagg.BlsAggregationService,
 ) *AggregatorRpcServer[Input, Output] {
 	return &AggregatorRpcServer[Input, Output]{
-		logger:           logger,
-		serverIpPortAddr: serverIpPortAddr,
+		logger:                logger,
+		serverIpPortAddr:      serverIpPortAddr,
+		blsAggregationService: blsAggregationService,
 	}
 }
 
 // When starting the server, the aggregator start listening at the address specified by config the calls to
 // the ProcessSignedTaskResponse method
-func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {
+func (aggServ *AggregatorRpcServer[Input, Output]) StartServer() error {
 	server := rpc.NewServer()
-	err := server.RegisterName("Aggregator", agg)
+	err := server.RegisterName("Aggregator", aggServ)
 	if err != nil {
 		return utils.WrapError("Error registering aggregator service (maybe the format of service task manager isn't correct)", err)
 	}
 
 	// TODO: Replace with http.ListenAndServe()
-	err = agg.listenAndServe(server)
+	err = aggServ.listenAndServe(server)
 	if err != nil {
 		return utils.WrapError("Failed to listen and serve", err)
 	}
@@ -51,8 +54,8 @@ func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {
 	return nil
 }
 
-func (agg *Aggregator[Input, Output]) listenAndServe(server *rpc.Server) error {
-	listener, err := net.Listen("tcp", agg.serverIpPortAddr)
+func (aggServ *AggregatorRpcServer[Input, Output]) listenAndServe(server *rpc.Server) error {
+	listener, err := net.Listen("tcp", aggServ.serverIpPortAddr)
 	if err != nil {
 		return utils.WrapError("Err wile listening", err)
 	}
@@ -74,8 +77,8 @@ type SignedTaskResponse[Output any] struct {
 // rpc endpoint which is called by operator
 // reply doesn't need to be checked. If there are no errors, the task response is accepted
 // rpc framework forces a reply type to exist, so we put bool as a placeholder
-func (agg *Aggregator[Input, Output]) ProcessSignedTaskResponse(signedTaskResponse *SignedTaskResponse[Output], reply *bool) error {
-	agg.logger.Infof("Received signed task response: %#v", signedTaskResponse)
+func (aggServ *AggregatorRpcServer[Input, Output]) ProcessSignedTaskResponse(signedTaskResponse *SignedTaskResponse[Output], reply *bool) error {
+	aggServ.logger.Infof("Received signed task response: %#v", signedTaskResponse)
 	taskIndex := signedTaskResponse.TaskResponse.ReferenceTaskIndex
 
 	taskSignature := blsagg.NewTaskSignature(
@@ -85,7 +88,7 @@ func (agg *Aggregator[Input, Output]) ProcessSignedTaskResponse(signedTaskRespon
 		signedTaskResponse.OperatorId,
 	)
 
-	err := agg.blsAggregationService.ProcessNewSignature(context.Background(), taskSignature)
+	err := aggServ.blsAggregationService.ProcessNewSignature(context.Background(), taskSignature)
 
 	return err
 }

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -14,16 +14,20 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/utils"
 )
 
+// The aggregator RPC server is responsible for receiving signed responses from the operators, and sending
+// those responses to the BLS aggregation service.
 type AggregatorRpcServer[Input any, Output any] struct {
 	logger logging.Logger
 
 	// IP address and port where the aggregator will listen to operator task responses
 	serverIpPortAddr string
 
-	// BLS aggregation service
+	// BLS aggregation service where the operator responses will be sent
 	blsAggregationService blsagg.BlsAggregationService
 }
 
+// NewAggregatorRpcServer creates a new AggregatorRpcServer with a logger, an IP addres and port and
+// the BLS aggregation service.
 func NewAggregatorRpcServer[Input any, Output any](
 	logger logging.Logger,
 	serverIpPortAddr string,
@@ -36,8 +40,8 @@ func NewAggregatorRpcServer[Input any, Output any](
 	}
 }
 
-// When starting the server, the aggregator start listening at the address specified by config the calls to
-// the ProcessSignedTaskResponse method
+// When starting the server, the aggregator RPC server start listening at the address specified by config
+// the calls to the ProcessSignedTaskResponse method
 func (aggServ *AggregatorRpcServer[Input, Output]) StartServer() error {
 	server := rpc.NewServer()
 	err := server.RegisterName("Aggregator", aggServ)
@@ -54,6 +58,8 @@ func (aggServ *AggregatorRpcServer[Input, Output]) StartServer() error {
 	return nil
 }
 
+// This function should be replaced by http.ListenAndServe() in a future. It listens for new connections
+// from operators, and will respond to calls to the ProcessSignedTaskResponse method
 func (aggServ *AggregatorRpcServer[Input, Output]) listenAndServe(server *rpc.Server) error {
 	listener, err := net.Listen("tcp", aggServ.serverIpPortAddr)
 	if err != nil {

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -80,9 +80,9 @@ type SignedTaskResponse[Output any] struct {
 	OperatorId   sdktypes.OperatorId
 }
 
-// rpc endpoint which is called by operator
-// reply doesn't need to be checked. If there are no errors, the task response is accepted
-// rpc framework forces a reply type to exist, so we put bool as a placeholder
+// RPC endpoint which is called by operators.
+// Reply doesn't need to be checked. If there are no errors, the task response is accepted
+// RPC framework forces a reply type to exist, so we put bool as a placeholder.
 func (aggServ *AggregatorRpcServer[Input, Output]) ProcessSignedTaskResponse(signedTaskResponse *SignedTaskResponse[Output], reply *bool) error {
 	aggServ.logger.Infof("Received signed task response: %#v", signedTaskResponse)
 	taskIndex := signedTaskResponse.TaskResponse.ReferenceTaskIndex

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -26,8 +26,8 @@ type AggregatorRpcServer[Input any, Output any] struct {
 	blsAggregationService blsagg.BlsAggregationService
 }
 
-// NewAggregatorRpcServer creates a new AggregatorRpcServer with a logger, an IP addres and port and
-// the BLS aggregation service.
+// NewAggregatorRpcServer creates a new AggregatorRpcServer with a logger, an IP address and port,
+// and the BLS aggregation service.
 func NewAggregatorRpcServer[Input any, Output any](
 	logger logging.Logger,
 	serverIpPortAddr string,

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -16,6 +16,8 @@ import (
 
 // The aggregator RPC server is responsible for receiving signed responses from the operators, and sending
 // those responses to the BLS aggregation service.
+// Warning: Public methods added to this struct may be exposed via RPC and accessible over the network.
+// Ensure that any exported method has proper validation as needed.
 type AggregatorRpcServer[Input any, Output any] struct {
 	logger logging.Logger
 

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -13,6 +13,26 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/utils"
 )
 
+type AggregatorRpcServer[Input any, Output any] struct {
+	logger logging.Logger
+
+	// IP address and port where the aggregator will listen to operator task responses
+	serverIpPortAddr string
+
+	// BLS aggregation service
+	blsAggregationService blsagg.BlsAggregationService
+}
+
+func NewAggregatorRpcServer[Input any, Output any](
+	logger logging.Logger,
+	serverIpPortAddr string,
+) *AggregatorRpcServer[Input, Output] {
+	return &AggregatorRpcServer[Input, Output]{
+		logger:           logger,
+		serverIpPortAddr: serverIpPortAddr,
+	}
+}
+
 // When starting the server, the aggregator start listening at the address specified by config the calls to
 // the ProcessSignedTaskResponse method
 func (agg *Aggregator[Input, Output]) startServer(ctx context.Context) error {


### PR DESCRIPTION
### What Changed?
This PR introduces the aggregator RPC server, which will listen to operator connections and respond to ProcessSignedTaskResponse calls.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it