### PR TITLE
feat(v2): add attributes to the operator registration config

### DIFF
--- a/integration-tests/incredible_squaring_test.go
+++ b/integration-tests/incredible_squaring_test.go
@@ -227,6 +227,10 @@ func createIncredibleSquaringOperator(t *testing.T, ethHttpUrl, ethWsUrl string)
 		AllocatableMagnitudes: []uint64{1000000000000000},
 
 		OperatorSetIds: []uint32{0},
+
+		MetadataUrl:     "",
+		Socket:          "",
+		AllocationDelay: 0,
 	}
 
 	operatorConfig := operator.Config{

--- a/operator/config.go
+++ b/operator/config.go
@@ -61,4 +61,13 @@ type RegistrationConfig struct {
 
 	// The IDs of the operator sets to be registered
 	OperatorSetIds []uint32 `toml:"operator_set_ids"`
+
+	// The operator metadata url to be set in eigenlayer registration
+	MetadataUrl string `toml:"metadata_url"`
+
+	// The socket used in the operator set registration request
+	Socket string `toml:"socket"`
+
+	// The allocation delay set for the operator, set as zero for immediate allocation
+	AllocationDelay uint32 `toml:"allocation_delay"`
 }

--- a/operator/registration.go
+++ b/operator/registration.go
@@ -88,6 +88,7 @@ func registerOperatorOnStartup(
 		ethRpcClient,
 		logger,
 		txMgr,
+		c.MetadataUrl,
 	)
 	if err != nil {
 		logger.Fatalf("Failed to register operator with EigenLayer on startup: %v", err.Error())
@@ -116,7 +117,7 @@ func registerOperatorOnStartup(
 		c.AvsAddress,
 		c.OperatorSetIds,
 		*blsKeyPair,
-		"",
+		c.Socket,
 	)
 	if err != nil {
 		logger.Fatalf("Failed to register operator for operator sets on startup: %v", err.Error())
@@ -128,7 +129,7 @@ func registerOperatorOnStartup(
 		ethRpcClient,
 		c.AllocationManagerAddr,
 		txMgr,
-		0,
+		c.AllocationDelay,
 	)
 	if err != nil {
 		logger.Fatalf("Failed to set allocation delay: %v", err.Error())
@@ -160,10 +161,12 @@ func RegisterOperatorWithEigenlayer(
 	ethClient *ethclient.Client,
 	logger logging.Logger,
 	txMgr txmgr.TxManager,
+	metadataUrl string,
 ) error {
 	op := types.Operator{
 		Address:                   operatorAddr.String(),
 		DelegationApproverAddress: operatorAddr.String(),
+		MetadataUrl:               metadataUrl,
 	}
 
 	elWriter, err := elcontracts.NewWriterFromConfig(elcontractsConfig, ethClient, logger, &metrics.EigenMetrics{}, txMgr)


### PR DESCRIPTION
### What Changed?
This PR adds Metadata Url, Socket and allocation dellay fields to the operator Registration config. In the examples are not needed because the values used are the default ones.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it