### PR TITLE
feat(v2): handle more BLS registration cases

### DIFF
--- a/crypto/bls/attestation.go
+++ b/crypto/bls/attestation.go
@@ -2,12 +2,14 @@ package bls
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 
 	bn254utils "github.com/Layr-Labs/eigensdk-go/crypto/bn254"
 
@@ -157,6 +159,25 @@ func NewPrivateKey(sk string) (*PrivateKey, error) {
 type KeyPair struct {
 	PrivKey *PrivateKey
 	PubKey  *G1Point
+}
+
+func (k *KeyPair) UnmarshalText(text []byte) error {
+	var priv PrivateKey
+
+	privHex := strings.TrimPrefix(string(text), "0x")
+
+	privBytes, err := hex.DecodeString(privHex)
+	if err != nil {
+		return fmt.Errorf("invalid private key hex: %w", err)
+	}
+
+	privateKey := priv.SetBytes(privBytes)
+
+	keyPair := NewKeyPair(privateKey)
+
+	*k = *keyPair
+
+	return nil
 }
 
 func NewKeyPair(sk *PrivateKey) *KeyPair {

--- a/examples/awesome-vault-service/config/config.toml
+++ b/examples/awesome-vault-service/config/config.toml
@@ -27,9 +27,9 @@ quorum_number = [0]
 
 [bls_signer]
 
-bls_private_key_store_path = "keys/test.bls.key.json"
+keystore_path = "keys/test.bls.key.json"
 
-bls_private_key_password = ""
+keystore_password = ""
 
 [registration]
 

--- a/examples/awesome-vault-service/config/config.toml
+++ b/examples/awesome-vault-service/config/config.toml
@@ -31,6 +31,8 @@ keystore_path = "keys/test.bls.key.json"
 
 keystore_password = ""
 
+private_key = "0x2518600ef40ef39cb4ab8b828ce303b3e02ac01ec6ba6bd0d0cf0663e1252ff0"
+
 [registration]
 
 register_on_startup = true

--- a/examples/awesome-vault-service/config/config.toml
+++ b/examples/awesome-vault-service/config/config.toml
@@ -8,8 +8,6 @@ operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 registry_coordinator_address = "0xfd471836031dc5108809d173a067e8486b9047a3"
 token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
 
-bls_private_key_store_path = "keys/test.bls.key.json"
-
 # Node URLs
 eth_http_url = "http://localhost:8545"
 eth_ws_url = "ws://localhost:8545"
@@ -26,6 +24,12 @@ time_between_tasks = 10_000_000_000
 quorum_threshold_percentage = 100
 
 quorum_number = [0]
+
+[bls_signer]
+
+bls_private_key_store_path = "keys/test.bls.key.json"
+
+bls_private_key_password = ""
 
 [registration]
 

--- a/examples/awesome-vault-service/config/config.toml
+++ b/examples/awesome-vault-service/config/config.toml
@@ -31,8 +31,6 @@ keystore_path = "keys/test.bls.key.json"
 
 keystore_password = ""
 
-private_key = "0x2518600ef40ef39cb4ab8b828ce303b3e02ac01ec6ba6bd0d0cf0663e1252ff0"
-
 [registration]
 
 register_on_startup = true

--- a/examples/incredible-dot-product/config/config.toml
+++ b/examples/incredible-dot-product/config/config.toml
@@ -26,9 +26,9 @@ quorum_number = [0]
 
 [bls_signer]
 
-bls_private_key_store_path = "keys/test.bls.key.json"
+keystore_path = "keys/test.bls.key.json"
 
-bls_private_key_password = ""
+keystore_password = ""
 
 [registration]
 

--- a/examples/incredible-dot-product/config/config.toml
+++ b/examples/incredible-dot-product/config/config.toml
@@ -8,8 +8,6 @@ operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 registry_coordinator_address = "0xfd471836031dc5108809d173a067e8486b9047a3"
 token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
 
-bls_private_key_store_path = "keys/test.bls.key.json"
-
 # Node URLs
 eth_http_url = "http://localhost:8545"
 eth_ws_url = "ws://localhost:8545"
@@ -25,6 +23,12 @@ time_between_tasks = 10_000_000_000 # This means 10 seconds
 quorum_threshold_percentage = 100
 
 quorum_number = [0]
+
+[bls_signer]
+
+bls_private_key_store_path = "keys/test.bls.key.json"
+
+bls_private_key_password = ""
 
 [registration]
 

--- a/examples/incredible-dot-product/config/config.toml
+++ b/examples/incredible-dot-product/config/config.toml
@@ -26,10 +26,6 @@ quorum_number = [0]
 
 [bls_signer]
 
-keystore_path = "keys/test.bls.key.json"
-
-keystore_password = ""
-
 private_key = "0x2518600ef40ef39cb4ab8b828ce303b3e02ac01ec6ba6bd0d0cf0663e1252ff0"
 
 [registration]

--- a/examples/incredible-dot-product/config/config.toml
+++ b/examples/incredible-dot-product/config/config.toml
@@ -30,6 +30,8 @@ keystore_path = "keys/test.bls.key.json"
 
 keystore_password = ""
 
+private_key = "0x2518600ef40ef39cb4ab8b828ce303b3e02ac01ec6ba6bd0d0cf0663e1252ff0"
+
 [registration]
 
 register_on_startup = true

--- a/examples/incredible-squaring/config/config.toml
+++ b/examples/incredible-squaring/config/config.toml
@@ -26,9 +26,9 @@ quorum_number = [0]
 
 [bls_signer]
 
-bls_private_key_store_path = "keys/test.bls.key.json"
+keystore_path = "keys/test.bls.key.json"
 
-bls_private_key_password = ""
+keystore_password = ""
 
 [registration]
 

--- a/examples/incredible-squaring/config/config.toml
+++ b/examples/incredible-squaring/config/config.toml
@@ -8,8 +8,6 @@ operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
 token_strategy_addr = "0x2b961e3959b79326a8e7f64ef0d2d825707669b5"
 
-bls_private_key_store_path = "keys/test.bls.key.json"
-
 # Node URLs
 eth_http_url = "http://localhost:8545"
 eth_ws_url = "ws://localhost:8545"
@@ -25,6 +23,12 @@ time_between_tasks = 10_000_000_000 # This means 10 seconds
 quorum_threshold_percentage = 100
 
 quorum_number = [0]
+
+[bls_signer]
+
+bls_private_key_store_path = "keys/test.bls.key.json"
+
+bls_private_key_password = ""
 
 [registration]
 

--- a/examples/incredible-squaring/config/config.toml
+++ b/examples/incredible-squaring/config/config.toml
@@ -30,8 +30,6 @@ keystore_path = "keys/test.bls.key.json"
 
 keystore_password = ""
 
-private_key = "0x2518600ef40ef39cb4ab8b828ce303b3e02ac01ec6ba6bd0d0cf0663e1252ff0"
-
 [registration]
 
 register_on_startup = true

--- a/examples/incredible-squaring/config/config.toml
+++ b/examples/incredible-squaring/config/config.toml
@@ -30,6 +30,8 @@ keystore_path = "keys/test.bls.key.json"
 
 keystore_password = ""
 
+private_key = "0x2518600ef40ef39cb4ab8b828ce303b3e02ac01ec6ba6bd0d0cf0663e1252ff0"
+
 [registration]
 
 register_on_startup = true

--- a/integration-tests/incredible_squaring_test.go
+++ b/integration-tests/incredible_squaring_test.go
@@ -232,13 +232,17 @@ func createIncredibleSquaringOperator(t *testing.T, ethHttpUrl, ethWsUrl string)
 		AllocationDelay: 0,
 	}
 
+	blsSignerConfig := operator.BlsSignerConfig{
+		BlsPrivateKeyStorePath: "../examples/incredible-squaring/keys/test.bls.key.json",
+		BlsPrivateKeyPassword:  "",
+	}
 	operatorConfig := operator.Config{
 		OperatorAddress:            "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
 		RegistryCoordinatorAddress: "0x7bc06c482dead17c0e297afbc32f6e63d3846650",
 		EthRpcUrl:                  ethHttpUrl,
 		EthWsUrl:                   ethWsUrl,
 		// Current dir is integration-tests
-		BlsPrivateKeyStorePath:        "../examples/incredible-squaring/keys/test.bls.key.json",
+		BlsSignerCfg:                  blsSignerConfig,
 		AggregatorServerIpPortAddress: "localhost:8090",
 		Registration:                  registrationConfig,
 	}

--- a/integration-tests/incredible_squaring_test.go
+++ b/integration-tests/incredible_squaring_test.go
@@ -233,8 +233,8 @@ func createIncredibleSquaringOperator(t *testing.T, ethHttpUrl, ethWsUrl string)
 	}
 
 	blsSignerConfig := operator.BlsSignerConfig{
-		BlsPrivateKeyStorePath: "../examples/incredible-squaring/keys/test.bls.key.json",
-		BlsPrivateKeyPassword:  "",
+		KeystorePath:     "../examples/incredible-squaring/keys/test.bls.key.json",
+		KeystorePassword: "",
 	}
 	operatorConfig := operator.Config{
 		OperatorAddress:            "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",

--- a/operator/config.go
+++ b/operator/config.go
@@ -33,10 +33,10 @@ type Config struct {
 
 type BlsSignerConfig struct {
 	// The path to the location of the bls private key on local storage
-	BlsPrivateKeyStorePath string `toml:"bls_private_key_store_path"`
+	KeystorePath string `toml:"bls_private_key_store_path"`
 
 	// The password used to get the private key on local storage
-	BlsPrivateKeyPassword string `toml:"bls_private_key_password"`
+	KeystorePassword string `toml:"bls_private_key_password"`
 
 	// The bls Key Pair, if nil will use the store path and password above
 	BlsKeyPair *bls.KeyPair

--- a/operator/config.go
+++ b/operator/config.go
@@ -34,7 +34,7 @@ type Config struct {
 // We use the go-ethereum keystore package to encrypt/decrypt the private keys, more specifically the V3 encryption,
 // so to see the supported or unsuported keystore formats refer to the geth keystore package documentation.
 type BlsSignerConfig struct {
-	// The path to the location of the bls private key on local storage
+	// Path to the BLS keystore on local storage
 	KeystorePath string `toml:"keystore_path"`
 
 	// The password used to get the private key on local storage

--- a/operator/config.go
+++ b/operator/config.go
@@ -6,14 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type BlsSignerConfig struct {
-	// The path to the location of the bls private key on local storage
-	BlsPrivateKeyStorePath string `toml:"bls_private_key_store_path"`
-
-	// The password used to get the private key on local storage
-	BlsPrivateKeyPassword string `toml:"bls_private_key_password"`
-}
-
 // Operator configuration struct
 type Config struct {
 	// The address for the operator
@@ -36,6 +28,14 @@ type Config struct {
 
 	// The config used to register an operator
 	Registration RegistrationConfig `toml:"registration"`
+}
+
+type BlsSignerConfig struct {
+	// The path to the location of the bls private key on local storage
+	BlsPrivateKeyStorePath string `toml:"bls_private_key_store_path"`
+
+	// The password used to get the private key on local storage
+	BlsPrivateKeyPassword string `toml:"bls_private_key_password"`
 }
 
 // This config is used to register an operator on startup.

--- a/operator/config.go
+++ b/operator/config.go
@@ -44,7 +44,7 @@ type BlsSignerConfig struct {
 	KeystorePassword string `toml:"keystore_password"`
 
 	// The bls Key Pair, if nil will use the store path and password above
-	// Note: the toml tag is private_key because from the private key generates the key pair
+	// Note: the toml tag is private_key because from the private key we generate the key pair
 	BlsKeyPair *bls.KeyPair `toml:"private_key"`
 }
 

--- a/operator/config.go
+++ b/operator/config.go
@@ -44,7 +44,7 @@ type BlsSignerConfig struct {
 	KeystorePassword string `toml:"keystore_password"`
 
 	// The bls Key Pair, if nil will use the store path and password above
-	BlsKeyPair *bls.KeyPair
+	BlsKeyPair *bls.KeyPair `toml:"key_pair"`
 }
 
 // This config is used to register an operator on startup.

--- a/operator/config.go
+++ b/operator/config.go
@@ -37,7 +37,7 @@ type BlsSignerConfig struct {
 	// Path to the BLS keystore on local storage
 	KeystorePath string `toml:"keystore_path"`
 
-	// The password used to get the private key on local storage
+	// Password for the keystore
 	KeystorePassword string `toml:"keystore_password"`
 
 	// The bls Key Pair, if nil will use the store path and password above

--- a/operator/config.go
+++ b/operator/config.go
@@ -44,7 +44,8 @@ type BlsSignerConfig struct {
 	KeystorePassword string `toml:"keystore_password"`
 
 	// The bls Key Pair, if nil will use the store path and password above
-	BlsKeyPair *bls.KeyPair `toml:"key_pair"`
+	// Note: the toml tag is private_key because from the private key generates the key pair
+	BlsKeyPair *bls.KeyPair `toml:"private_key"`
 }
 
 // This config is used to register an operator on startup.

--- a/operator/config.go
+++ b/operator/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	Registration RegistrationConfig `toml:"registration"`
 }
 
+// We use the go-ethereum keystore package to encrypt/decrypt the private keys, more specifically the V3 encryption,
+// so to see the supported or unsuported keystore formats refer to the geth keystore package documentation.
 type BlsSignerConfig struct {
 	// The path to the location of the bls private key on local storage
 	KeystorePath string `toml:"keystore_path"`

--- a/operator/config.go
+++ b/operator/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	Registration RegistrationConfig `toml:"registration"`
 }
 
+// For the BLS signing we accept two different options:
+// - If the key pair is provided, we use that pair
+// - If not, we use the specified keystore path and the password.
 // We use the go-ethereum keystore package to encrypt/decrypt the private keys, more specifically the V3 encryption,
 // so to see the supported or unsuported keystore formats refer to the geth keystore package documentation.
 type BlsSignerConfig struct {

--- a/operator/config.go
+++ b/operator/config.go
@@ -33,10 +33,10 @@ type Config struct {
 
 type BlsSignerConfig struct {
 	// The path to the location of the bls private key on local storage
-	KeystorePath string `toml:"bls_private_key_store_path"`
+	KeystorePath string `toml:"keystore_path"`
 
 	// The password used to get the private key on local storage
-	KeystorePassword string `toml:"bls_private_key_password"`
+	KeystorePassword string `toml:"keystore_password"`
 
 	// The bls Key Pair, if nil will use the store path and password above
 	BlsKeyPair *bls.KeyPair

--- a/operator/config.go
+++ b/operator/config.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"math/big"
 
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -36,6 +37,9 @@ type BlsSignerConfig struct {
 
 	// The password used to get the private key on local storage
 	BlsPrivateKeyPassword string `toml:"bls_private_key_password"`
+
+	// The bls Key Pair, if nil will use the store path and password above
+	BlsKeyPair *bls.KeyPair
 }
 
 // This config is used to register an operator on startup.

--- a/operator/config.go
+++ b/operator/config.go
@@ -6,6 +6,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+type BlsSignerConfig struct {
+	// The path to the location of the bls private key on local storage
+	BlsPrivateKeyStorePath string `toml:"bls_private_key_store_path"`
+
+	// The password used to get the private key on local storage
+	BlsPrivateKeyPassword string `toml:"bls_private_key_password"`
+}
+
 // Operator configuration struct
 type Config struct {
 	// The address for the operator
@@ -20,8 +28,8 @@ type Config struct {
 	// Ethereum WebSocket RPC URL to use for subscribing to on-chain events
 	EthWsUrl string `toml:"eth_ws_url"`
 
-	// The path to the location of the bls private key on local storage
-	BlsPrivateKeyStorePath string `toml:"bls_private_key_store_path"`
+	// The config used to create the BLS signer for the operator
+	BlsSignerCfg BlsSignerConfig `toml:"bls_signer"`
 
 	// IP address and port where the aggregator will listen to operator task responses
 	AggregatorServerIpPortAddress string `toml:"aggregator_server_ip_port"`

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -78,10 +78,14 @@ func NewOperator[Input any, Output any](
 		return nil, err
 	}
 
-	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsSignerCfg.BlsPrivateKeyStorePath, c.BlsSignerCfg.BlsPrivateKeyPassword)
-	if err != nil {
-		logger.Errorf("Cannot parse bls private key", "err", err)
-		return nil, err
+	blsKeyPair := c.BlsSignerCfg.BlsKeyPair
+	if blsKeyPair == nil {
+		logger.Info("Bls Key pair was nil, using the private key store path and password params...")
+		blsKeyPair, err = bls.ReadPrivateKeyFromFile(c.BlsSignerCfg.BlsPrivateKeyStorePath, c.BlsSignerCfg.BlsPrivateKeyPassword)
+		if err != nil {
+			logger.Errorf("Cannot parse bls private key", "err", err)
+			return nil, err
+		}
 	}
 
 	// Check if operator was registered, if its not registered and register on startup flag is not set, then will fail.

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"os"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -79,11 +78,7 @@ func NewOperator[Input any, Output any](
 		return nil, err
 	}
 
-	blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
-	if !ok {
-		logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
-	}
-	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
+	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsSignerCfg.BlsPrivateKeyStorePath, c.BlsSignerCfg.BlsPrivateKeyPassword)
 	if err != nil {
 		logger.Errorf("Cannot parse bls private key", "err", err)
 		return nil, err

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -81,7 +81,7 @@ func NewOperator[Input any, Output any](
 	blsKeyPair := c.BlsSignerCfg.BlsKeyPair
 	if blsKeyPair == nil {
 		logger.Info("Bls Key pair was nil, using the private key store path and password params...")
-		blsKeyPair, err = bls.ReadPrivateKeyFromFile(c.BlsSignerCfg.BlsPrivateKeyStorePath, c.BlsSignerCfg.BlsPrivateKeyPassword)
+		blsKeyPair, err = bls.ReadPrivateKeyFromFile(c.BlsSignerCfg.KeystorePath, c.BlsSignerCfg.KeystorePassword)
 		if err != nil {
 			logger.Errorf("Cannot parse bls private key", "err", err)
 			return nil, err


### PR DESCRIPTION
### What Changed?
This PR adds the BLS signer config field to the operator config, which allows the user to provide a BLS key pair besides the current store path and password. So, if the user does not provide a key pair, the operator will try to obtain the key pair from the store path with the given password.

### Reviewer Checklist
- [ ] Code is well-documented
- [ ] Code adheres to Go [naming conventions](https://go.dev/doc/effective_go#names)
- [ ] Code deprecates any old functionality before removing it