### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,4 +1,6 @@
 name: test-coverage
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/eigensdk-go/security/code-scanning/7](https://github.com/Layr-Labs/eigensdk-go/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN to the minimum required. The best way is to add the block at the workflow root level (before `jobs:`), so it applies to all jobs unless overridden. For most test and coverage workflows, `contents: read` is sufficient unless the workflow needs to write to the repository (e.g., updating badges, opening pull requests). If the badge update step requires write access, you may need to add `contents: write` or a more specific permission. However, as a minimal starting point and per CodeQL's suggestion, add `permissions: contents: read` at the top level, just after the workflow name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
